### PR TITLE
build: Fix make dependencies for multiple concurrent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           make -C target/snitch_cluster sw
       - name: Build Hardware
         run: |
-          make -C target/snitch_cluster bin/snitch_cluster.vlt
+          make -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |
@@ -76,7 +76,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -101,7 +101,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-gemm.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -126,7 +126,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-streamer-gemm.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -151,7 +151,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-data-reshuffler.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -177,7 +177,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac-mult.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -203,7 +203,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-alu.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -229,7 +229,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-streamer-simd.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -35,17 +35,34 @@ CHISEL_PATH := $(ROOT)/hw/chisel/
 
 include $(ROOT)/target/common/common.mk
 
+############
+# Programs #
+############
+
+REGGEN          ?= $(shell $(BENDER) path register_interface)/vendor/lowrisc_opentitan/util/regtool.py
+CLUSTER_GEN     ?= $(ROOT)/util/clustergen.py
+CLUSTER_GEN_SRC ?= $(wildcard $(ROOT)/util/clustergen/*.py)
+WRAPPER_GEN     ?= $(ROOT)/util/wrappergen/wrappergen.py
+
+#########################
+# Files and directories #
+#########################
+
+SW_DIR             = sw
+TARGET_C_HDRS_DIR ?= $(SW_DIR)/runtime/common
+GENERATED_DIR     ?= $(MKFILE_DIR)generated
+
 ####################
 # SNAX Generations #
 ####################
 
 define generate_snax_gen
 SNAX_GEN := \
-	/repo/target/snitch_cluster/generated/$(1)/$(1)_csrman_CsrManager.sv \
-	/repo/target/snitch_cluster/generated/$(1)/$(1)_streamer_StreamerTop.sv \
-	/repo/target/snitch_cluster/generated/$(1)/$(1)_csrman_wrapper.sv \
-	/repo/target/snitch_cluster/generated/$(1)/$(1)_streamer_wrapper.sv \
-	/repo/target/snitch_cluster/generated/$(1)/$(1)_wrapper.sv
+	$(GENERATED_DIR)/$(1)/$(1)_csrman_CsrManager.sv \
+	$(GENERATED_DIR)/$(1)/$(1)_streamer_StreamerTop.sv \
+	$(GENERATED_DIR)/$(1)/$(1)_csrman_wrapper.sv \
+	$(GENERATED_DIR)/$(1)/$(1)_streamer_wrapper.sv \
+	$(GENERATED_DIR)/$(1)/$(1)_wrapper.sv
 endef
 
 # Usage example
@@ -105,22 +122,6 @@ $(eval $(call generate_snax_gen,snax_data_reshuffler))
 
 endif
 
-############
-# Programs #
-############
-
-REGGEN          ?= $(shell $(BENDER) path register_interface)/vendor/lowrisc_opentitan/util/regtool.py
-CLUSTER_GEN     ?= $(ROOT)/util/clustergen.py
-CLUSTER_GEN_SRC ?= $(wildcard $(ROOT)/util/clustergen/*.py)
-WRAPPER_GEN     ?= $(ROOT)/util/wrappergen/wrappergen.py
-
-#########################
-# Files and directories #
-#########################
-
-SW_DIR             = sw
-TARGET_C_HDRS_DIR ?= $(SW_DIR)/runtime/common
-GENERATED_DIR     ?= $(MKFILE_DIR)generated
 
 # Verilated and compiled snitch cluster
 VLT_AR = ${VLT_BUILDDIR}/Vtestharness__ALL.a
@@ -254,7 +255,6 @@ $(FIRST_SNAX_GEN) : $(SNAX_TEMPLATE_SOURCES) $(CFG_FILE) $(SNAX_SCALA_SOURCES)
 
 # This is a fake job that forces parallel make to wait for the first thing to be generated
 $(OTHER_SNAX_GEN): $(FIRST_SNAX_GEN)
-
 
 ############
 # Software #

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -217,18 +217,22 @@ test/bootrom.elf test/bootrom.dump test/bootrom.bin: test/bootrom.S test/bootrom
 	riscv64-unknown-elf-objdump -d test/bootrom.elf > test/bootrom.dump
 	riscv64-unknown-elf-objcopy -j .text -O binary test/bootrom.elf test/bootrom.bin
 
-/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_CsrManager.sv: $(SNAX_GEN)
+SNAX_GEN := \
+	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_CsrManager.sv \
+	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_StreamerTop.sv \
+	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_wrapper.sv \
+	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_wrapper.sv \
+	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_wrapper.sv
 
-/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_StreamerTop.sv: $(SNAX_GEN)
 
-/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_wrapper.sv: $(SNAX_GEN)
+SNAX_TEMPLATE_SOURCES = $(wildcard $(SNAX_TPL_PATH)*.tpl)
+CFG_FILE = $(ROOT)/target/snitch_cluster/$(CFG_OVERRIDE)
+SNAX_SCALA_SOURCES = \
+	$(wildcard ${CHISEL_PATH}/src/main/scala/snax/streamer/*.scala) \
+	$(wildcard ${CHISEL_PATH}/src/main/scala/snax/csr_manager/*.scala)
 
-/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_wrapper.sv: $(SNAX_GEN)
-
-/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_wrapper.sv: $(SNAX_GEN)
-
-$(SNAX_GEN):
-	${WRAPPER_GEN} --cfg_path="$(ROOT)/target/snitch_cluster/$(CFG_OVERRIDE)" \
+$(SNAX_GEN): $(SNAX_TEMPLATE_SOURCES) $(CFG_FILE) $(SNAX_SCALA_SOURCES)
+	${WRAPPER_GEN} --cfg_path="$(CFG_FILE)" \
 	--tpl_path="${SNAX_TPL_PATH}" \
 	--chisel_path="${CHISEL_PATH}" \
 	--gen_path="${GENERATED_DIR}/"

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -217,6 +217,15 @@ test/bootrom.elf test/bootrom.dump test/bootrom.bin: test/bootrom.S test/bootrom
 	riscv64-unknown-elf-objdump -d test/bootrom.elf > test/bootrom.dump
 	riscv64-unknown-elf-objcopy -j .text -O binary test/bootrom.elf test/bootrom.bin
 
+/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_CsrManager.sv: $(SNAX_GEN)
+
+/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_StreamerTop.sv: $(SNAX_GEN)
+
+/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_wrapper.sv: $(SNAX_GEN)
+
+/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_wrapper.sv: $(SNAX_GEN)
+
+/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_wrapper.sv: $(SNAX_GEN)
 
 $(SNAX_GEN):
 	${WRAPPER_GEN} --cfg_path="$(ROOT)/target/snitch_cluster/$(CFG_OVERRIDE)" \
@@ -285,7 +294,7 @@ clean-vlt: clean-work
 	rm -rf bin/snitch_cluster.vlt $(VLT_BUILDDIR)
 
 $(VLT_AR): ${VLT_SOURCES} ${TB_SRCS}
-	$(call VERILATE,testharness)
+	+$(call VERILATE,testharness)
 verilate: $(VLT_AR)
 
 # Build targets for verilator TB

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -59,6 +59,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-gemm.hjson)
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
+
+$(eval $(call generate_snax_gen,snax_streamer_gemm))
+
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
@@ -66,12 +69,12 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
 	VLT_BENDER  += -t snax-streamer-gemm
 	VCS_BENDER  += -t snax-streamer-gemm
 
-$(eval $(call generate_snax_gen,snax_streamer_gemm))
-
-
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-simd.hjson)
+
+$(eval $(call generate_snax_gen,snax_streamer_simd))
+
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-postprocessing-simd)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
@@ -79,13 +82,12 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-simd.hjson)
 	VLT_BENDER  += -t snax-streamer-simd
 	VCS_BENDER  += -t snax-streamer-simd
 
-	SNAX_GEN += ${GENERATED_DIR}/snax-streamer-simd
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-alu.hjson)
 
-	SNAX_GEN += ${GENERATED_DIR}/snax-alu
+$(eval $(call generate_snax_gen,snax_alu))
 
 	VSIM_BENDER += -t snax-alu
 	VLT_BENDER  += -t snax-alu
@@ -95,7 +97,7 @@ endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-data-reshuffler.hjson)
 
-	SNAX_GEN += ${GENERATED_DIR}/snax-data-reshuffler
+$(eval $(call generate_snax_gen,snax_data_reshuffler))
 
 	VSIM_BENDER += -t snax-data-reshuffler
 	VLT_BENDER  += -t snax-data-reshuffler

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -39,6 +39,16 @@ include $(ROOT)/target/common/common.mk
 # SNAX Generations #
 ####################
 
+define generate_snax_gen
+SNAX_GEN := \
+	/repo/target/snitch_cluster/generated/$(1)/$(1)_csrman_CsrManager.sv \
+	/repo/target/snitch_cluster/generated/$(1)/$(1)_streamer_StreamerTop.sv \
+	/repo/target/snitch_cluster/generated/$(1)/$(1)_csrman_wrapper.sv \
+	/repo/target/snitch_cluster/generated/$(1)/$(1)_streamer_wrapper.sv \
+	/repo/target/snitch_cluster/generated/$(1)/$(1)_wrapper.sv
+endef
+
+# Usage example
 ifeq (${CFG_OVERRIDE}, cfg/snax-gemm.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile	
@@ -56,7 +66,8 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
 	VLT_BENDER  += -t snax-streamer-gemm
 	VCS_BENDER  += -t snax-streamer-gemm
 
-	SNAX_GEN += ${GENERATED_DIR}/snax-streamer-gemm
+$(eval $(call generate_snax_gen,snax_streamer_gemm))
+
 
 endif
 
@@ -217,13 +228,6 @@ test/bootrom.elf test/bootrom.dump test/bootrom.bin: test/bootrom.S test/bootrom
 	riscv64-unknown-elf-objdump -d test/bootrom.elf > test/bootrom.dump
 	riscv64-unknown-elf-objcopy -j .text -O binary test/bootrom.elf test/bootrom.bin
 
-SNAX_GEN := \
-	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_CsrManager.sv \
-	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_StreamerTop.sv \
-	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_wrapper.sv \
-	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_streamer_wrapper.sv \
-	/repo/target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_wrapper.sv
-
 
 SNAX_TEMPLATE_SOURCES = $(wildcard $(SNAX_TPL_PATH)*.tpl)
 CFG_FILE = $(ROOT)/target/snitch_cluster/$(CFG_OVERRIDE)
@@ -231,11 +235,24 @@ SNAX_SCALA_SOURCES = \
 	$(wildcard ${CHISEL_PATH}/src/main/scala/snax/streamer/*.scala) \
 	$(wildcard ${CHISEL_PATH}/src/main/scala/snax/csr_manager/*.scala)
 
-$(SNAX_GEN): $(SNAX_TEMPLATE_SOURCES) $(CFG_FILE) $(SNAX_SCALA_SOURCES)
+# Pick the first file
+FIRST_SNAX_GEN := $(firstword $(SNAX_GEN))
+# Pick all the files but the first file, if there are more than one
+OTHER_SNAX_GEN := $(filter-out $(FIRST_SNAX),$(SNAX_GEN))
+
+# Force a serialized build in parallel make through a circular dependency
+# Implemented as documented in:
+# https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
+# Please note the limitations of this method over there
+$(FIRST_SNAX_GEN) : $(SNAX_TEMPLATE_SOURCES) $(CFG_FILE) $(SNAX_SCALA_SOURCES)
 	${WRAPPER_GEN} --cfg_path="$(CFG_FILE)" \
 	--tpl_path="${SNAX_TPL_PATH}" \
 	--chisel_path="${CHISEL_PATH}" \
 	--gen_path="${GENERATED_DIR}/"
+
+# This is a fake job that forces parallel make to wait for the first thing to be generated
+$(OTHER_SNAX_GEN): $(FIRST_SNAX_GEN)
+
 
 ############
 # Software #
@@ -314,7 +331,7 @@ $(VLT_BUILDDIR)/generated/%.o: $(GENERATED_DIR)/%.cc ${VLT_BUILDDIR}/lib/libfesv
 
 # Build compilation script and compile all sources for Verilator simulation
 # Link verilated archive with $(VLT_COBJ)
-bin/snitch_cluster.vlt: $(SNAX_GEN) $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
+bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
 	$(CXX) $(LDFLAGS) -std=c++14 -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lfesvr -lpthread
 


### PR DESCRIPTION
This PR does multiple things, but all are related to fix parallel builds:
* adds a `+` sign here: `+$(call VERILATE,testharness)`, otherwise make will spawn an error from verilator that it disables the job server and will not run in parallel.
* adds dependencies to the jobs that create streamers and csr managers. All jobs that require `wrappergen` to be called. Note that make really was not built for commands outputting multiple files, so I'm using the idiom described here (https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html) to force a serialized build in parallel make, otherwise make will spawn multiple concurrent instances of `wrappergen`, which is not wrong per se, but a bit unnecessary. The method used has several downsides, and will most likely require to run `make clean-generated` periodically. This also creates explicit recipes for all the generated files. Not having such a recipe caused previous parallel builds to generate a race condition and fail.
* Adds a macro to get all the files generated by wrappergen in one go for multiple configurations of SNAX.
* Fixes a wrong dependency. `$(SNAX_GEN)` is not a dependency of `bin/snitch_cluster` but already needs to be generated at `VERILATE`, specifiying the files here is not necessary, since `VLT_SOURCES` already fetches those file lists from `Bender.yml`