### PR TITLE
Fix bender target for Questasim

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -293,7 +293,7 @@ sources:
       # Level 1
       - hw/snax_hwpe_mac/src/snax_mac_wrapper.sv
   # SNAX ALU
-  - target: snax-alu
+  - target: snax_alu
     files:
       # Level 0
       - hw/snax_alu/src/snax_alu_csr.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -307,7 +307,7 @@ sources:
       # Level 2
       - target/snitch_cluster/generated/snax_alu/snax_alu_wrapper.sv
 
-  - target: snax-streamer-gemm
+  - target: snax_streamer_gemm
     files:
       # Level 0
       - target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_csrman_CsrManager.sv
@@ -318,7 +318,7 @@ sources:
       # Level 2
       - target/snitch_cluster/generated/snax_streamer_gemm/snax_streamer_gemm_wrapper.sv
 
-  - target: snax-streamer-simd
+  - target: snax_streamer_simd
     files:
       # Level 0
       - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_csrman_CsrManager.sv
@@ -329,7 +329,7 @@ sources:
       # Level 2
       - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_wrapper.sv
 
-  - target: snax-data-reshuffler
+  - target: snax_data_reshuffler
     files:
       # Level 0
       - hw/snax_data_reshuffler/src/data_reshuffler.sv

--- a/hw/snax_util/src/snax_intf_translator.sv
+++ b/hw/snax_util/src/snax_intf_translator.sv
@@ -9,6 +9,11 @@
 // Snitch accelerator ports to
 // CSR ports
 //-------------------------------
+`ifdef TARGET_QUESTA_SIM
+import riscv_instr::*;
+import reqrsp_pkg::*;
+`endif
+
 module snax_intf_translator #(
   parameter type                        acc_req_t = logic,
   parameter type                        acc_rsp_t = logic,

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -267,6 +267,16 @@ module snitch_cluster
   input  wide_in_req_t                  wide_in_req_i,
   output wide_in_resp_t                 wide_in_resp_o
 );
+
+  // 
+  tcdm_rsp_t [SnaxAccNarrowTcdmPorts - 1:0] snax_tcdm_rsp_o_narrow;
+  tcdm_rsp_t [SnaxAccWideTcdmPorts - 1:0] snax_tcdm_rsp_o_wide;
+
+  assign snax_tcdm_rsp_o[SnaxAccWideTcdmPorts - 1:0] = snax_tcdm_rsp_o_wide;
+  assign snax_tcdm_rsp_o[TotalSnaxTcdmPorts - 1 : TotalSnaxTcdmPorts - SnaxAccNarrowTcdmPorts] = snax_tcdm_rsp_o_narrow;
+
+  //
+
   // ---------
   // Constants
   // ---------
@@ -719,33 +729,33 @@ module snitch_cluster
 
         // Response ports
         {
-          snax_tcdm_rsp_o[i*8+7].p.data,
-          snax_tcdm_rsp_o[i*8+6].p.data,
-          snax_tcdm_rsp_o[i*8+5].p.data,
-          snax_tcdm_rsp_o[i*8+4].p.data,
-          snax_tcdm_rsp_o[i*8+3].p.data,
-          snax_tcdm_rsp_o[i*8+2].p.data,
-          snax_tcdm_rsp_o[i*8+1].p.data,
-          snax_tcdm_rsp_o[i*8].p.data
+          snax_tcdm_rsp_o_wide[i*8+7].p.data,
+          snax_tcdm_rsp_o_wide[i*8+6].p.data,
+          snax_tcdm_rsp_o_wide[i*8+5].p.data,
+          snax_tcdm_rsp_o_wide[i*8+4].p.data,
+          snax_tcdm_rsp_o_wide[i*8+3].p.data,
+          snax_tcdm_rsp_o_wide[i*8+2].p.data,
+          snax_tcdm_rsp_o_wide[i*8+1].p.data,
+          snax_tcdm_rsp_o_wide[i*8].p.data
         } = snax_wide_rsp[i].p.data;
 
-        snax_tcdm_rsp_o[i*8+7].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8+6].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8+5].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8+4].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8+3].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8+2].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8+1].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o[i*8].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+7].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+6].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+5].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+4].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+3].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+2].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8+1].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o_wide[i*8].p_valid = snax_wide_rsp[i].p_valid;
 
-        snax_tcdm_rsp_o[i*8+7].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8+6].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8+5].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8+4].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8+3].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8+2].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8+1].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o[i*8].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+7].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+6].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+5].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+4].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+3].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+2].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8+1].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o_wide[i*8].q_ready = snax_wide_rsp[i].q_ready;
       end
     end
 
@@ -908,8 +918,8 @@ module snitch_cluster
     ) i_tcdm_interconnect (
       .clk_i,
       .rst_ni,
-      .req_i ({axi_soc_req, tcdm_req, snax_tcdm_req_i}),
-      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_o}),
+      .req_i ({axi_soc_req, tcdm_req, snax_tcdm_req_i[TotalSnaxTcdmPorts - 1 : TotalSnaxTcdmPorts - SnaxAccNarrowTcdmPorts]}),
+      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_o_narrow}),
       .mem_req_o (ic_req),
       .mem_rsp_i (ic_rsp)
     );

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -267,16 +267,6 @@ module snitch_cluster
   input  wide_in_req_t                  wide_in_req_i,
   output wide_in_resp_t                 wide_in_resp_o
 );
-
-  // 
-  tcdm_rsp_t [SnaxAccNarrowTcdmPorts - 1:0] snax_tcdm_rsp_o_narrow;
-  tcdm_rsp_t [SnaxAccWideTcdmPorts - 1:0] snax_tcdm_rsp_o_wide;
-
-  assign snax_tcdm_rsp_o[SnaxAccWideTcdmPorts - 1:0] = snax_tcdm_rsp_o_wide;
-  assign snax_tcdm_rsp_o[TotalSnaxTcdmPorts - 1 : TotalSnaxTcdmPorts - SnaxAccNarrowTcdmPorts] = snax_tcdm_rsp_o_narrow;
-
-  //
-
   // ---------
   // Constants
   // ---------
@@ -729,33 +719,33 @@ module snitch_cluster
 
         // Response ports
         {
-          snax_tcdm_rsp_o_wide[i*8+7].p.data,
-          snax_tcdm_rsp_o_wide[i*8+6].p.data,
-          snax_tcdm_rsp_o_wide[i*8+5].p.data,
-          snax_tcdm_rsp_o_wide[i*8+4].p.data,
-          snax_tcdm_rsp_o_wide[i*8+3].p.data,
-          snax_tcdm_rsp_o_wide[i*8+2].p.data,
-          snax_tcdm_rsp_o_wide[i*8+1].p.data,
-          snax_tcdm_rsp_o_wide[i*8].p.data
+          snax_tcdm_rsp_o[i*8+7].p.data,
+          snax_tcdm_rsp_o[i*8+6].p.data,
+          snax_tcdm_rsp_o[i*8+5].p.data,
+          snax_tcdm_rsp_o[i*8+4].p.data,
+          snax_tcdm_rsp_o[i*8+3].p.data,
+          snax_tcdm_rsp_o[i*8+2].p.data,
+          snax_tcdm_rsp_o[i*8+1].p.data,
+          snax_tcdm_rsp_o[i*8].p.data
         } = snax_wide_rsp[i].p.data;
 
-        snax_tcdm_rsp_o_wide[i*8+7].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+6].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+5].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+4].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+3].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+2].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+1].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+7].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+6].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+5].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+4].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+3].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+2].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8+1].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_o[i*8].p_valid = snax_wide_rsp[i].p_valid;
 
-        snax_tcdm_rsp_o_wide[i*8+7].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+6].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+5].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+4].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+3].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+2].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+1].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+7].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+6].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+5].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+4].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+3].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+2].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8+1].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_o[i*8].q_ready = snax_wide_rsp[i].q_ready;
       end
     end
 
@@ -918,8 +908,8 @@ module snitch_cluster
     ) i_tcdm_interconnect (
       .clk_i,
       .rst_ni,
-      .req_i ({axi_soc_req, tcdm_req, snax_tcdm_req_i[TotalSnaxTcdmPorts - 1 : TotalSnaxTcdmPorts - SnaxAccNarrowTcdmPorts]}),
-      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_o_narrow}),
+      .req_i ({axi_soc_req, tcdm_req, snax_tcdm_req_i}),
+      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_o}),
       .mem_req_o (ic_req),
       .mem_rsp_i (ic_rsp)
     );

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -122,25 +122,6 @@ $(eval $(call generate_snax_gen,snax_data_reshuffler))
 
 endif
 
-ifeq (${CFG_OVERRIDE}, cfg/snax-wide-gemm-data-reshuffler.hjson)
-
-$(eval $(call generate_snax_gen,snax_streamer_gemm))
-
-	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
-	include $(SNAX_GEMM_ROOT)/Makefile
-
-	VSIM_BENDER += -t snax_streamer_gemm
-	VLT_BENDER  += -t snax_streamer_gemm
-	VCS_BENDER  += -t snax_streamer_gemm
-
-$(eval $(call generate_snax_gen,snax_data_reshuffler))
-
-	VSIM_BENDER += -t snax_data_reshuffler
-	VLT_BENDER  += -t snax_data_reshuffler
-	VCS_BENDER  += -t snax_data_reshuffler
-
-endif
-
 VSIM_BENDER += -t QUESTA_SIM
 
 # Verilated and compiled snitch cluster

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -82,9 +82,9 @@ $(eval $(call generate_snax_gen,snax_streamer_gemm))
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
-	VSIM_BENDER += -t snax-streamer-gemm
-	VLT_BENDER  += -t snax-streamer-gemm
-	VCS_BENDER  += -t snax-streamer-gemm
+	VSIM_BENDER += -t snax_streamer_gemm
+	VLT_BENDER  += -t snax_streamer_gemm
+	VCS_BENDER  += -t snax_streamer_gemm
 
 endif
 
@@ -95,9 +95,9 @@ $(eval $(call generate_snax_gen,snax_streamer_simd))
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-postprocessing-simd)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
-	VSIM_BENDER += -t snax-streamer-simd
-	VLT_BENDER  += -t snax-streamer-simd
-	VCS_BENDER  += -t snax-streamer-simd
+	VSIM_BENDER += -t snax_streamer_simd
+	VLT_BENDER  += -t snax_streamer_simd
+	VCS_BENDER  += -t snax_streamer_simd
 
 
 endif
@@ -116,12 +116,32 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-data-reshuffler.hjson)
 
 $(eval $(call generate_snax_gen,snax_data_reshuffler))
 
-	VSIM_BENDER += -t snax-data-reshuffler
-	VLT_BENDER  += -t snax-data-reshuffler
-	VCS_BENDER  += -t snax-data-reshuffler
+	VSIM_BENDER += -t snax_data_reshuffler
+	VLT_BENDER  += -t snax_data_reshuffler
+	VCS_BENDER  += -t snax_data_reshuffler
 
 endif
 
+ifeq (${CFG_OVERRIDE}, cfg/snax-wide-gemm-data-reshuffler.hjson)
+
+$(eval $(call generate_snax_gen,snax_streamer_gemm))
+
+	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
+	include $(SNAX_GEMM_ROOT)/Makefile
+
+	VSIM_BENDER += -t snax_streamer_gemm
+	VLT_BENDER  += -t snax_streamer_gemm
+	VCS_BENDER  += -t snax_streamer_gemm
+
+$(eval $(call generate_snax_gen,snax_data_reshuffler))
+
+	VSIM_BENDER += -t snax_data_reshuffler
+	VLT_BENDER  += -t snax_data_reshuffler
+	VCS_BENDER  += -t snax_data_reshuffler
+
+endif
+
+VSIM_BENDER += -t QUESTA_SIM
 
 # Verilated and compiled snitch cluster
 VLT_AR = ${VLT_BUILDDIR}/Vtestharness__ALL.a

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -106,9 +106,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-alu.hjson)
 
 $(eval $(call generate_snax_gen,snax_alu))
 
-	VSIM_BENDER += -t snax-alu
-	VLT_BENDER  += -t snax-alu
-	VCS_BENDER  += -t snax-alu
+	VSIM_BENDER += -t snax_alu
+	VLT_BENDER  += -t snax_alu
+	VCS_BENDER  += -t snax_alu
 
 endif
 


### PR DESCRIPTION
This PR renames the target tags for the accelerators.

The `-` character gives an error for Questasim. To make it work we need to use `_` instead so that the MACRO definitions in questa does not complain.