### PR TITLE
Decouple the combinational control of Chisel FIFO

### DIFF
--- a/hw/chisel/src/main/scala/snax/streamer/FIFO.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/FIFO.scala
@@ -22,7 +22,7 @@ class FIFO(
   val io = IO(new FIFOIO(width))
 
   if (depth > 0) {
-    val fifo = Module(new Queue(UInt(width.W), depth, pipe = true))
+    val fifo = Module(new Queue(UInt(width.W), depth, flow = true))
     fifo.io.enq <> io.in
     fifo.io.deq <> io.out
     io.almost_full := fifo.io.count === (depth - 1).U


### PR DESCRIPTION
This PR decouples the combinational control of the chisel FIFOs.

This resolves several convergence errors that are difficult to debug due to the combinational loops.
These cannot be seen from simulations but the waveform clues lead to the combinational loop at these parts.