### PR TITLE
Add criss-cross TCDM connections

### DIFF
--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -433,6 +433,18 @@
                                             "description": "Number of ports dedicated for an accelerator",
                                             "default": 0
                                         },
+                                        "snax_narrow_tcdm_ports": {
+                                            "type": "number",
+                                            "title": "Number of SNAX narrow TCDM ports",
+                                            "description": "Number of dedicated narrow TCDM ports",
+                                            "default": 0
+                                        },
+                                        "snax_wide_tcdm_ports": {
+                                            "type": "number",
+                                            "title": "Number of SNAX wide TCDM ports",
+                                            "description": "Number of dedicated wide TCDM ports",
+                                            "default": 0
+                                        },
                                         "snax_num_rw_csr": {
                                             "type": "number",
                                             "title": "Number of CSR Read-Write Registers",

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -689,7 +689,9 @@ module snitch_cluster
   localparam int unsigned NumSnaxWideTcdmPorts = TotalSnaxWideTcdmPorts / 8;
 
   if ((NumSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
-    assign snax_tcdm_req_narrow = snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts];
+    assign snax_tcdm_req_wide = snax_tcdm_req_i[TotalSnaxWideTcdmPorts-1:0];
+    assign snax_tcdm_req_narrow = 
+      snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts];
 
     assign snax_tcdm_rsp_o[TotalSnaxWideTcdmPorts-1:0] = snax_tcdm_rsp_wide;
     assign snax_tcdm_rsp_o[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]
@@ -714,39 +716,39 @@ module snitch_cluster
     always_comb begin
       for (int i = 0; i < NumSnaxWideTcdmPorts; i++) begin
         // Request ports
-        snax_wide_req[i].q.addr  = snax_tcdm_req_i[i*8].q.addr ;
-        snax_wide_req[i].q.write = snax_tcdm_req_i[i*8].q.write;
+        snax_wide_req[i].q.addr  = snax_tcdm_req_wide[i*8].q.addr ;
+        snax_wide_req[i].q.write = snax_tcdm_req_wide[i*8].q.write;
         snax_wide_req[i].q.amo   = reqrsp_pkg::AMONone;
         snax_wide_req[i].q.data  = {
-                                      snax_tcdm_req_i[i*8+7].q.data,
-                                      snax_tcdm_req_i[i*8+6].q.data,
-                                      snax_tcdm_req_i[i*8+5].q.data,
-                                      snax_tcdm_req_i[i*8+4].q.data,
-                                      snax_tcdm_req_i[i*8+3].q.data,
-                                      snax_tcdm_req_i[i*8+2].q.data,
-                                      snax_tcdm_req_i[i*8+1].q.data,
-                                      snax_tcdm_req_i[i*8].q.data
+                                      snax_tcdm_req_wide[i*8+7].q.data,
+                                      snax_tcdm_req_wide[i*8+6].q.data,
+                                      snax_tcdm_req_wide[i*8+5].q.data,
+                                      snax_tcdm_req_wide[i*8+4].q.data,
+                                      snax_tcdm_req_wide[i*8+3].q.data,
+                                      snax_tcdm_req_wide[i*8+2].q.data,
+                                      snax_tcdm_req_wide[i*8+1].q.data,
+                                      snax_tcdm_req_wide[i*8].q.data
                                     };
         snax_wide_req[i].q.strb  = {
-                                      snax_tcdm_req_i[i*8+7].q.strb,
-                                      snax_tcdm_req_i[i*8+6].q.strb,
-                                      snax_tcdm_req_i[i*8+5].q.strb,
-                                      snax_tcdm_req_i[i*8+4].q.strb,
-                                      snax_tcdm_req_i[i*8+3].q.strb,
-                                      snax_tcdm_req_i[i*8+2].q.strb,
-                                      snax_tcdm_req_i[i*8+1].q.strb,
-                                      snax_tcdm_req_i[i*8].q.strb
+                                      snax_tcdm_req_wide[i*8+7].q.strb,
+                                      snax_tcdm_req_wide[i*8+6].q.strb,
+                                      snax_tcdm_req_wide[i*8+5].q.strb,
+                                      snax_tcdm_req_wide[i*8+4].q.strb,
+                                      snax_tcdm_req_wide[i*8+3].q.strb,
+                                      snax_tcdm_req_wide[i*8+2].q.strb,
+                                      snax_tcdm_req_wide[i*8+1].q.strb,
+                                      snax_tcdm_req_wide[i*8].q.strb
                                     };
         snax_wide_req[i].q.user  = '0;
         snax_wide_req[i].q_valid = &{
-                                      snax_tcdm_req_i[i*8+7].q_valid,
-                                      snax_tcdm_req_i[i*8+6].q_valid,
-                                      snax_tcdm_req_i[i*8+5].q_valid,
-                                      snax_tcdm_req_i[i*8+4].q_valid,
-                                      snax_tcdm_req_i[i*8+3].q_valid,
-                                      snax_tcdm_req_i[i*8+2].q_valid,
-                                      snax_tcdm_req_i[i*8+1].q_valid,
-                                      snax_tcdm_req_i[i*8].q_valid
+                                      snax_tcdm_req_wide[i*8+7].q_valid,
+                                      snax_tcdm_req_wide[i*8+6].q_valid,
+                                      snax_tcdm_req_wide[i*8+5].q_valid,
+                                      snax_tcdm_req_wide[i*8+4].q_valid,
+                                      snax_tcdm_req_wide[i*8+3].q_valid,
+                                      snax_tcdm_req_wide[i*8+2].q_valid,
+                                      snax_tcdm_req_wide[i*8+1].q_valid,
+                                      snax_tcdm_req_wide[i*8].q_valid
                                     };
 
         // Response ports

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -678,22 +678,29 @@ module snitch_cluster
   // Therefore we allocate 8 TCDM ports for each bandwidth
 
   // Split narrow and wide TCDM ports to solve the multi-driver issue
-  tcdm_rsp_t [TotalSnaxNarrowTcdmPorts-1:0] snax_tcdm_rsp_o_narrow;
-  tcdm_rsp_t [TotalSnaxWideTcdmPorts-1:0] snax_tcdm_rsp_o_wide;
+  tcdm_req_t [TotalSnaxNarrowTcdmPorts-1:0] snax_tcdm_req_narrow;
+  tcdm_req_t [TotalSnaxWideTcdmPorts-1:0] snax_tcdm_req_wide;
 
-  if ((NumSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
-    assign snax_tcdm_rsp_o[TotalSnaxWideTcdmPorts-1:0] = snax_tcdm_rsp_o_wide;
-    assign snax_tcdm_rsp_o[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]
-        = snax_tcdm_rsp_o_narrow;
-  end else if (NumSnaxWideTcdmPorts > 0) begin: gen_wide_only_map
-    assign snax_tcdm_rsp_o = snax_tcdm_rsp_o_wide;
-  end else begin: gen_narrow_only_map
-    assign snax_tcdm_rsp_o = snax_tcdm_rsp_o_narrow;
-  end
+  tcdm_rsp_t [TotalSnaxNarrowTcdmPorts-1:0] snax_tcdm_rsp_narrow;
+  tcdm_rsp_t [TotalSnaxWideTcdmPorts-1:0] snax_tcdm_rsp_wide;
 
   // Use this ports for the total number and needs to be cute into multiple versions
   // It needs to be divided by 8 because each narrow TCDM port is 64 bits wide
   localparam int unsigned NumSnaxWideTcdmPorts = TotalSnaxWideTcdmPorts / 8;
+
+  if ((NumSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
+    assign snax_tcdm_req_narrow = snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts];
+
+    assign snax_tcdm_rsp_o[TotalSnaxWideTcdmPorts-1:0] = snax_tcdm_rsp_wide;
+    assign snax_tcdm_rsp_o[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]
+        = snax_tcdm_rsp_narrow;
+  end else if (NumSnaxWideTcdmPorts > 0) begin: gen_wide_only_map
+    assign snax_tcdm_rsp_o = snax_tcdm_rsp_wide;
+  end else if (TotalSnaxNarrowTcdmPorts > 0) begin: gen_narrow_only_map
+    assign snax_tcdm_rsp_o = snax_tcdm_rsp_narrow;
+  end else begin: gen_no_snax_map
+    assign snax_tcdm_rsp_o = '0;
+  end
 
   if (NumSnaxWideTcdmPorts > 0) begin: gen_yes_wide_acc_connect
 
@@ -744,33 +751,33 @@ module snitch_cluster
 
         // Response ports
         {
-          snax_tcdm_rsp_o_wide[i*8+7].p.data,
-          snax_tcdm_rsp_o_wide[i*8+6].p.data,
-          snax_tcdm_rsp_o_wide[i*8+5].p.data,
-          snax_tcdm_rsp_o_wide[i*8+4].p.data,
-          snax_tcdm_rsp_o_wide[i*8+3].p.data,
-          snax_tcdm_rsp_o_wide[i*8+2].p.data,
-          snax_tcdm_rsp_o_wide[i*8+1].p.data,
-          snax_tcdm_rsp_o_wide[i*8].p.data
+          snax_tcdm_rsp_wide[i*8+7].p.data,
+          snax_tcdm_rsp_wide[i*8+6].p.data,
+          snax_tcdm_rsp_wide[i*8+5].p.data,
+          snax_tcdm_rsp_wide[i*8+4].p.data,
+          snax_tcdm_rsp_wide[i*8+3].p.data,
+          snax_tcdm_rsp_wide[i*8+2].p.data,
+          snax_tcdm_rsp_wide[i*8+1].p.data,
+          snax_tcdm_rsp_wide[i*8].p.data
         } = snax_wide_rsp[i].p.data;
 
-        snax_tcdm_rsp_o_wide[i*8+7].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+6].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+5].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+4].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+3].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+2].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8+1].p_valid = snax_wide_rsp[i].p_valid;
-        snax_tcdm_rsp_o_wide[i*8].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+7].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+6].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+5].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+4].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+3].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+2].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8+1].p_valid = snax_wide_rsp[i].p_valid;
+        snax_tcdm_rsp_wide[i*8].p_valid = snax_wide_rsp[i].p_valid;
 
-        snax_tcdm_rsp_o_wide[i*8+7].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+6].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+5].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+4].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+3].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+2].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8+1].q_ready = snax_wide_rsp[i].q_ready;
-        snax_tcdm_rsp_o_wide[i*8].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+7].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+6].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+5].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+4].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+3].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+2].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8+1].q_ready = snax_wide_rsp[i].q_ready;
+        snax_tcdm_rsp_wide[i*8].q_ready = snax_wide_rsp[i].q_ready;
       end
     end
 
@@ -935,8 +942,9 @@ module snitch_cluster
       .rst_ni,
       .req_i ({axi_soc_req,
                tcdm_req,
-               snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]}),
-      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_o_narrow}),
+               snax_tcdm_req_narrow}),
+               //snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]}),
+      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_narrow}),
       .mem_req_o (ic_req),
       .mem_rsp_i (ic_rsp)
     );

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -736,44 +736,6 @@ module snitch_cluster
     end
   end
 
-
-  // if ((TotalSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
-
-  //   int total_offset = 0;
-  //   int wide_offset = 0;
-  //   int narrow_offset = 0;
-  //   int curr_wide = 0;
-  //   int curr_narrow = 0;
-
-  //   always_comb begin
-  //     // Note: Wide first then narrow
-  //     for(int i = 0; i < NrCores; i++) begin
-
-  //       curr_wide = SnaxWideTcdmPorts[i];
-  //       curr_narrow = SnaxNarrowTcdmPorts[i];
-
-  //       // Requests
-  //       snax_tcdm_req_wide[(curr_wide+wide_offset)-1:wide_offset] =
-  //         snax_tcdm_req_i[(curr_wide+total_offset)-1:(total_offset)];
-
-  //       snax_tcdm_req_narrow[(curr_narrow+narrow_offset)-1:narrow_offset] =
-  //         snax_tcdm_req_i[(curr_wide+curr_narrow+total_offset)-1:(curr_wide+total_offset)];
-
-  //       // Responses
-  //       snax_tcdm_rsp_o[(curr_wide+total_offset)-1:(total_offset)] =
-  //         snax_tcdm_rsp_wide[(curr_wide+wide_offset)-1:wide_offset];
-
-  //       snax_tcdm_rsp_o[(curr_wide+curr_narrow+total_offset)-1:(curr_wide+total_offset)] =
-  //         snax_tcdm_rsp_narrow[(curr_narrow+narrow_offset)-1:narrow_offset];
-
-  //       wide_offset += curr_wide;
-  //       narrow_offset += curr_narrow;
-  //       total_offset += (curr_wide + curr_narrow);
-  //     end
-  //   end
-  // end
-  
-
   if (NumSnaxWideTcdmPorts > 0) begin: gen_yes_wide_acc_connect
 
     // First declare the wide SNAX tcdm ports

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -689,20 +689,68 @@ module snitch_cluster
   localparam int unsigned NumSnaxWideTcdmPorts = TotalSnaxWideTcdmPorts / 8;
 
   if ((NumSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
-    assign snax_tcdm_req_wide = snax_tcdm_req_i[TotalSnaxWideTcdmPorts-1:0];
-    assign snax_tcdm_req_narrow = 
-      snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts];
+    always_comb begin
+      snax_tcdm_req_wide = snax_tcdm_req_i[TotalSnaxWideTcdmPorts-1:0];
+      snax_tcdm_req_narrow = 
+        snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts];
 
-    assign snax_tcdm_rsp_o[TotalSnaxWideTcdmPorts-1:0] = snax_tcdm_rsp_wide;
-    assign snax_tcdm_rsp_o[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]
-        = snax_tcdm_rsp_narrow;
+      snax_tcdm_rsp_o[TotalSnaxWideTcdmPorts-1:0] = snax_tcdm_rsp_wide;
+      snax_tcdm_rsp_o[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]
+          = snax_tcdm_rsp_narrow;
+    end
   end else if (NumSnaxWideTcdmPorts > 0) begin: gen_wide_only_map
-    assign snax_tcdm_rsp_o = snax_tcdm_rsp_wide;
+    always_comb begin
+      snax_tcdm_req_wide = snax_tcdm_req_i;
+      snax_tcdm_rsp_o    = snax_tcdm_rsp_wide;
+    end
   end else if (TotalSnaxNarrowTcdmPorts > 0) begin: gen_narrow_only_map
-    assign snax_tcdm_rsp_o = snax_tcdm_rsp_narrow;
+    always_comb begin
+      snax_tcdm_req_narrow = snax_tcdm_req_i;
+      snax_tcdm_rsp_o      = snax_tcdm_rsp_narrow;
+    end
   end else begin: gen_no_snax_map
-    assign snax_tcdm_rsp_o = '0;
+    always_comb begin
+      snax_tcdm_rsp_o = '0;
+    end
   end
+
+
+  // if ((TotalSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
+
+  //   int total_offset = 0;
+  //   int wide_offset = 0;
+  //   int narrow_offset = 0;
+  //   int curr_wide = 0;
+  //   int curr_narrow = 0;
+
+  //   always_comb begin
+  //     // Note: Wide first then narrow
+  //     for(int i = 0; i < NrCores; i++) begin
+
+  //       curr_wide = SnaxWideTcdmPorts[i];
+  //       curr_narrow = SnaxNarrowTcdmPorts[i];
+
+  //       // Requests
+  //       snax_tcdm_req_wide[(curr_wide+wide_offset)-1:wide_offset] =
+  //         snax_tcdm_req_i[(curr_wide+total_offset)-1:(total_offset)];
+
+  //       snax_tcdm_req_narrow[(curr_narrow+narrow_offset)-1:narrow_offset] =
+  //         snax_tcdm_req_i[(curr_wide+curr_narrow+total_offset)-1:(curr_wide+total_offset)];
+
+  //       // Responses
+  //       snax_tcdm_rsp_o[(curr_wide+total_offset)-1:(total_offset)] =
+  //         snax_tcdm_rsp_wide[(curr_wide+wide_offset)-1:wide_offset];
+
+  //       snax_tcdm_rsp_o[(curr_wide+curr_narrow+total_offset)-1:(curr_wide+total_offset)] =
+  //         snax_tcdm_rsp_narrow[(curr_narrow+narrow_offset)-1:narrow_offset];
+
+  //       wide_offset += curr_wide;
+  //       narrow_offset += curr_narrow;
+  //       total_offset += (curr_wide + curr_narrow);
+  //     end
+  //   end
+  // end
+  
 
   if (NumSnaxWideTcdmPorts > 0) begin: gen_yes_wide_acc_connect
 

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -88,7 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_alu"
-            snax_tcdm_ports: 16,
+            snax_narrow_tcdm_ports: 16,
             snax_num_rw_csr: 3,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_alu_streamer_template" }

--- a/target/snitch_cluster/cfg/snax-data-reshuffler.hjson
+++ b/target/snitch_cluster/cfg/snax-data-reshuffler.hjson
@@ -88,8 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_data_reshuffler",
-            snax_module: "snax_data_reshuffler_wrapper",
-            snax_tcdm_ports: 16,
+            snax_narrow_tcdm_ports: 16,
             snax_num_rw_csr: 2,
             snax_num_ro_csr: 0,
             snax_streamer_cfg: {$ref: "#/snax_data_reshuffler_streamer_template" }

--- a/target/snitch_cluster/cfg/snax-gemm.hjson
+++ b/target/snitch_cluster/cfg/snax-gemm.hjson
@@ -88,8 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_gemm",
-            snax_module: "snax_gemm_wrapper",
-            snax_tcdm_ports: 24,
+            snax_narrow_tcdm_ports: 24,
         },
         snax_use_custom_ports: true,
         snax_acc_wide: true,

--- a/target/snitch_cluster/cfg/snax-mac-mult.hjson
+++ b/target/snitch_cluster/cfg/snax-mac-mult.hjson
@@ -88,10 +88,9 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_mac",
-            snax_module: "snax_mac_wrapper",
+            snax_narrow_tcdm_ports: 4,
             snax_num_rw_csr: 24,
             snax_num_acc: 4,
-            snax_tcdm_ports: 4,
         },
         snax_use_custom_ports: true,
         num_int_outstanding_loads: 1,

--- a/target/snitch_cluster/cfg/snax-mac.hjson
+++ b/target/snitch_cluster/cfg/snax-mac.hjson
@@ -88,8 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_mac"
-            snax_module: "snax_mac_wrapper",
-            snax_tcdm_ports: 4,
+            snax_narrow_tcdm_ports: 4,
         },
         snax_use_custom_ports: true,
         num_int_outstanding_loads: 1,

--- a/target/snitch_cluster/cfg/snax-streamer-gemm-conv.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm-conv.hjson
@@ -87,8 +87,7 @@
         xfvec: true,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemm",
-            snax_module: "snax_streamer_gemm_wrapper",
-            snax_tcdm_ports: 48,
+            snax_narrow_tcdm_ports: 48,
             snax_num_rw_csr: 5,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemm_streamer_template" }

--- a/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
@@ -88,8 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemm",
-            snax_module: "snax_streamer_gemm_wrapper",
-            snax_tcdm_ports: 48,
+            snax_narrow_tcdm_ports: 48,
             snax_num_rw_csr: 5,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemm_streamer_template" }

--- a/target/snitch_cluster/cfg/snax-streamer-simd.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-simd.hjson
@@ -88,8 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_simd",
-            snax_module: "snax_streamer_simd_wrapper",
-            snax_tcdm_ports: 40,
+            snax_narrow_tcdm_ports: 40,
             snax_num_rw_csr: 5,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_streamer_simd_streamer_template" }

--- a/target/snitch_cluster/cfg/snax-wide-gemm-data-reshuffler.hjson
+++ b/target/snitch_cluster/cfg/snax-wide-gemm-data-reshuffler.hjson
@@ -91,8 +91,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_data_reshuffler",
-            snax_module: "snax_data_reshuffler_wrapper",
-            snax_tcdm_ports: 16,
+            snax_narrow_tcdm_ports: 16,
             snax_num_rw_csr: 2,
             snax_num_ro_csr: 0,
             snax_streamer_cfg: {$ref: "#/snax_data_reshuffler_streamer_template" }
@@ -121,8 +120,7 @@
         xfvec: true,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemm",
-            snax_module: "snax_streamer_gemm_wrapper",
-            snax_tcdm_ports: 48,
+            snax_narrow_tcdm_ports: 48,
             snax_num_rw_csr: 5,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemm_streamer_template" }


### PR DESCRIPTION
This PR adds the criss-cross connection where an accelerator can specify which ports go to the narrow and which go to the wide TCDM ports.

Major TODOs:
- [x] Update snitch_cluster.sv
- [x] Update snitch_cluster.sv.tpl
- [x] Update configurations
- [x] Add configuration build for testing