### PR TITLE
build docker on release

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - 'util/container/Dockerfile'
   workflow_dispatch:
+  release:
+    types: [published]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kuleuven-micas/snax


### PR DESCRIPTION
This (hopefully) makes sure a new docker is built on a new release with the correct version tag