### PR TITLE
Add temporal loop bound zero check

### DIFF
--- a/hw/chisel/src/main/scala/snax/streamer/DataMover.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DataMover.scala
@@ -34,6 +34,7 @@ class DataMoverIO(params: DataMoverParams) extends Bundle {
   // all the temporal addresses have been produced
   val addr_gen_done = Input(Bool())
 
+  // signal to indicate the case when any of the loop bounds are zero
   val zeroLoopBoundCase = Input(Bool())
 
   // output signal to indicate the data movement process is done

--- a/hw/chisel/src/main/scala/snax/streamer/DataMover.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DataMover.scala
@@ -34,6 +34,8 @@ class DataMoverIO(params: DataMoverParams) extends Bundle {
   // all the temporal addresses have been produced
   val addr_gen_done = Input(Bool())
 
+  val zeroLoopBoundCase = Input(Bool())
+
   // output signal to indicate the data movement process is done
   val data_movement_done = Output(Bool())
 }
@@ -98,6 +100,8 @@ class DataMover(
   // State changes
   cstate := nstate
 
+  val data_movement_done = WireInit(0.B)
+
   chisel3.dontTouch(cstate)
   switch(cstate) {
     is(sIDLE) {
@@ -109,7 +113,7 @@ class DataMover(
 
     }
     is(sBUSY) {
-      when(io.addr_gen_done) {
+      when(data_movement_done) {
         nstate := sIDLE
       }.otherwise {
         nstate := sBUSY
@@ -211,8 +215,7 @@ class DataMover(
 
   // finally, we can signal the data movement process is finished when all requests
   // have been acknowledged and all temporal addresses have been processed
-  val data_movement_done = WireInit(0.B)
-  data_movement_done := io.addr_gen_done && tcdm_req_ready
+  data_movement_done := (io.addr_gen_done && tcdm_req_ready) || io.zeroLoopBoundCase
   io.data_movement_done := data_movement_done
 
 }

--- a/hw/chisel/src/main/scala/snax/streamer/DataReaderWriter.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DataReaderWriter.scala
@@ -34,6 +34,8 @@ class DataReaderWriterIO(
   // all the temporal addresses have been produced
   val addr_gen_done = Vec(2, Input(Bool()))
 
+  val zeroLoopBoundCase = Vec(2, Input(Bool()))
+
   // output signal to indicate the data movement process is done
   val data_movement_done = Vec(2, Output(Bool()))
 
@@ -113,6 +115,7 @@ class DataReaderWriter(
   data_reader.io.ptr_agu_i <> io.ptr_agu_i(0)
   data_reader.io.spatialStrides_csr_i <> io.spatialStrides_csr_i(0)
   data_reader.io.addr_gen_done <> io.addr_gen_done(0)
+  data_reader.io.zeroLoopBoundCase <> io.zeroLoopBoundCase(0)
   data_reader.io.data_movement_done <> io.data_movement_done(0)
 
   data_reader.io.data_fifo_o <> io.data_fifo_o
@@ -122,6 +125,7 @@ class DataReaderWriter(
   data_writer.io.ptr_agu_i <> io.ptr_agu_i(1)
   data_writer.io.spatialStrides_csr_i <> io.spatialStrides_csr_i(1)
   data_writer.io.addr_gen_done <> io.addr_gen_done(1)
+  data_writer.io.zeroLoopBoundCase <> io.zeroLoopBoundCase(1)
   data_writer.io.data_movement_done <> io.data_movement_done(1)
 
   data_writer.io.data_fifo_i <> io.data_fifo_i

--- a/hw/chisel/src/main/scala/snax/streamer/DataReaderWriter.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DataReaderWriter.scala
@@ -34,6 +34,7 @@ class DataReaderWriterIO(
   // all the temporal addresses have been produced
   val addr_gen_done = Vec(2, Input(Bool()))
 
+  // signal to indicate the case when any of the loop bounds are zero
   val zeroLoopBoundCase = Vec(2, Input(Bool()))
 
   // output signal to indicate the data movement process is done

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -295,7 +295,11 @@ class Streamer(
       if (params.stationarity(i) == 1) {
         for (j <- 0 until params.temporalDimInt) {
           if (j == 0) {
-            address_gen_unit(i).io.loopBounds_i.bits(j) := 1.U
+            when(io.csr.bits.loopBounds_i(0)(j) === 0.U){
+              address_gen_unit(i).io.loopBounds_i.bits(j) := 0.U
+            }.otherwise{
+              address_gen_unit(i).io.loopBounds_i.bits(j) := 1.U
+            }
           } else {
             address_gen_unit(i).io.loopBounds_i
               .bits(j) := io.csr.bits.loopBounds_i(0)(j)
@@ -325,7 +329,11 @@ class Streamer(
       if (params.stationarity(i) == 1) {
         for (j <- 0 until params.temporalDimSeq(i)) {
           if (j == 0) {
-            address_gen_unit(i).io.loopBounds_i.bits(j) := 1.U
+            when(io.csr.bits.loopBounds_i(i)(j) === 0.U){
+              address_gen_unit(i).io.loopBounds_i.bits(j) := 0.U
+            }.otherwise{
+              address_gen_unit(i).io.loopBounds_i.bits(j) := 1.U
+            }
           } else {
             address_gen_unit(i).io.loopBounds_i
               .bits(j) := io.csr.bits.loopBounds_i(i)(j)
@@ -390,6 +398,7 @@ class Streamer(
     if (i < params.dataReaderNum) {
       address_gen_unit(i).io.ptr_o <> data_reader(i).io.ptr_agu_i
       data_reader(i).io.addr_gen_done := address_gen_unit(i).io.done
+      data_reader(i).io.zeroLoopBoundCase := address_gen_unit(i).io.zeroLoopBoundCase
     } else {
       if (i < params.dataReaderNum + params.dataWriterNum) {
         address_gen_unit(i).io.ptr_o <> data_writer(
@@ -398,6 +407,9 @@ class Streamer(
         data_writer(
           i - params.dataReaderNum
         ).io.addr_gen_done := address_gen_unit(i).io.done
+        data_writer(
+          i - params.dataReaderNum
+        ).io.zeroLoopBoundCase := address_gen_unit(i).io.zeroLoopBoundCase
       } else {
         reader_writer_idx =
           (i - params.dataReaderNum - params.dataWriterNum) / 2
@@ -409,6 +421,9 @@ class Streamer(
         data_reader_writer(
           reader_writer_idx
         ).io.addr_gen_done(reader_writer_idx_rw) := address_gen_unit(i).io.done
+        data_reader_writer(
+          reader_writer_idx
+        ).io.zeroLoopBoundCase(reader_writer_idx_rw) := address_gen_unit(i).io.zeroLoopBoundCase
       }
     }
   }

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -295,9 +295,9 @@ class Streamer(
       if (params.stationarity(i) == 1) {
         for (j <- 0 until params.temporalDimInt) {
           if (j == 0) {
-            when(io.csr.bits.loopBounds_i(0)(j) === 0.U){
+            when(io.csr.bits.loopBounds_i(0)(j) === 0.U) {
               address_gen_unit(i).io.loopBounds_i.bits(j) := 0.U
-            }.otherwise{
+            }.otherwise {
               address_gen_unit(i).io.loopBounds_i.bits(j) := 1.U
             }
           } else {
@@ -329,9 +329,9 @@ class Streamer(
       if (params.stationarity(i) == 1) {
         for (j <- 0 until params.temporalDimSeq(i)) {
           if (j == 0) {
-            when(io.csr.bits.loopBounds_i(i)(j) === 0.U){
+            when(io.csr.bits.loopBounds_i(i)(j) === 0.U) {
               address_gen_unit(i).io.loopBounds_i.bits(j) := 0.U
-            }.otherwise{
+            }.otherwise {
               address_gen_unit(i).io.loopBounds_i.bits(j) := 1.U
             }
           } else {
@@ -398,7 +398,9 @@ class Streamer(
     if (i < params.dataReaderNum) {
       address_gen_unit(i).io.ptr_o <> data_reader(i).io.ptr_agu_i
       data_reader(i).io.addr_gen_done := address_gen_unit(i).io.done
-      data_reader(i).io.zeroLoopBoundCase := address_gen_unit(i).io.zeroLoopBoundCase
+      data_reader(i).io.zeroLoopBoundCase := address_gen_unit(
+        i
+      ).io.zeroLoopBoundCase
     } else {
       if (i < params.dataReaderNum + params.dataWriterNum) {
         address_gen_unit(i).io.ptr_o <> data_writer(
@@ -423,7 +425,9 @@ class Streamer(
         ).io.addr_gen_done(reader_writer_idx_rw) := address_gen_unit(i).io.done
         data_reader_writer(
           reader_writer_idx
-        ).io.zeroLoopBoundCase(reader_writer_idx_rw) := address_gen_unit(i).io.zeroLoopBoundCase
+        ).io.zeroLoopBoundCase(reader_writer_idx_rw) := address_gen_unit(
+          i
+        ).io.zeroLoopBoundCase
       }
     }
   }

--- a/hw/chisel/src/main/scala/snax/streamer/TemporalAddrGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/TemporalAddrGenUnit.scala
@@ -53,6 +53,7 @@ class TemporalAddrGenUnitIO(
   // done signal indicating current transaction is done, ready for next config and transaction
   val done = Output(Bool())
 
+  // signal to indicate the case when any of the loop bounds are zero
   val zeroLoopBoundCase = Output(Bool())
 }
 
@@ -98,6 +99,7 @@ class TemporalAddrGenUnit(
   )
   val ptr = RegInit(0.U((params.addrWidth).W))
 
+  // signal to indicate the case when any of the loop bounds are zero
   val zeroLoopBoundCase = WireInit(0.B)
 
   /** The following code is the FSM for the TemporalAddrGenUnit module.

--- a/hw/chisel/src/main/scala/snax/streamer/TemporalAddrGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/TemporalAddrGenUnit.scala
@@ -204,7 +204,9 @@ class TemporalAddrGenUnit(
     .map { case (a, b) => a * b })
     .reduce(_ +& _) +& ptr
 
-  addr_gen_finish := (loop_counters_last.reduce(_ & _) && io.ptr_o.fire) || zeroLoopBoundCase
+  addr_gen_finish := (loop_counters_last.reduce(
+    _ & _
+  ) && io.ptr_o.fire) || zeroLoopBoundCase
 
   // the decoupled interface is driven by the module state
   io.ptr_o.valid := cstate === sBUSY && !zeroLoopBoundCase

--- a/hw/chisel/src/main/scala/snax/streamer/TemporalAddrGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/TemporalAddrGenUnit.scala
@@ -52,6 +52,8 @@ class TemporalAddrGenUnitIO(
 
   // done signal indicating current transaction is done, ready for next config and transaction
   val done = Output(Bool())
+
+  val zeroLoopBoundCase = Output(Bool())
 }
 
 /** TemporalAddrGenUnit is a module that generates addresses based on a nested
@@ -95,6 +97,8 @@ class TemporalAddrGenUnit(
     VecInit(Seq.fill(params.loopDim)(0.U(params.addrWidth.W)))
   )
   val ptr = RegInit(0.U((params.addrWidth).W))
+
+  val zeroLoopBoundCase = WireInit(0.B)
 
   /** The following code is the FSM for the TemporalAddrGenUnit module.
     *
@@ -142,6 +146,10 @@ class TemporalAddrGenUnit(
     strides := io.strides_i.bits
     ptr := io.ptr_i.bits
   }
+
+  // special case test for when any loop bound is zero
+  zeroLoopBoundCase := cstate === sBUSY && loopBounds.exists(_ === 0.U)
+  io.zeroLoopBoundCase := zeroLoopBoundCase
 
   /** Generates a nested loop counter based on the provided parameters.
     */
@@ -196,10 +204,10 @@ class TemporalAddrGenUnit(
     .map { case (a, b) => a * b })
     .reduce(_ +& _) +& ptr
 
-  addr_gen_finish := loop_counters_last.reduce(_ & _) && io.ptr_o.fire
+  addr_gen_finish := (loop_counters_last.reduce(_ & _) && io.ptr_o.fire) || zeroLoopBoundCase
 
   // the decoupled interface is driven by the module state
-  io.ptr_o.valid := cstate === sBUSY
+  io.ptr_o.valid := cstate === sBUSY && !zeroLoopBoundCase
 
   io.loopBounds_i.ready := cstate === sIDLE
   io.strides_i.ready := cstate === sIDLE

--- a/hw/templates/snax_acc_wrapper.sv.tpl
+++ b/hw/templates/snax_acc_wrapper.sv.tpl
@@ -16,7 +16,7 @@
 
   if("data_writer_params" in cfg["snax_streamer_cfg"]):
       num_tcdm_writer = sum(cfg["snax_streamer_cfg"]["data_writer_params"]["tcdm_ports_num"])
-      num_writer_offset = len(cfg["snax_streamer_cfg"]["data_reader_params"]["tcdm_ports_num"])
+      num_writer_offset = len(cfg["snax_streamer_cfg"]["data_writer_params"]["tcdm_ports_num"])
 
   if("data_reader_writer_params" in cfg["snax_streamer_cfg"]):
       num_tcdm_reader_writer = sum(cfg["snax_streamer_cfg"]["data_reader_writer_params"]["tcdm_ports_num"])

--- a/hw/templates/snax_streamer_wrapper.sv.tpl
+++ b/hw/templates/snax_streamer_wrapper.sv.tpl
@@ -16,7 +16,7 @@
 
   if("data_writer_params" in cfg["snax_streamer_cfg"]):
       num_tcdm_writer = sum(cfg["snax_streamer_cfg"]["data_writer_params"]["tcdm_ports_num"])
-      num_writer_offset = len(cfg["snax_streamer_cfg"]["data_reader_params"]["tcdm_ports_num"])
+      num_writer_offset = len(cfg["snax_streamer_cfg"]["data_writer_params"]["tcdm_ports_num"])
 
   if("data_reader_writer_params" in cfg["snax_streamer_cfg"]):
       num_tcdm_reader_writer = sum(cfg["snax_streamer_cfg"]["data_reader_writer_params"]["tcdm_ports_num"])


### PR DESCRIPTION
This PR adds the 0 loop bound case because previously it was a bug when 0 loops were set, the busy signal goes high indefinitely.

So, when 0 loops are set, it should terminate or not cause any busy to stay.

Finally, includes minor typo fixes found by this.