### PR TITLE
Fix ALU valid-ready signal

### DIFF
--- a/hw/snax_alu/src/snax_alu_pe.sv
+++ b/hw/snax_alu/src/snax_alu_pe.sv
@@ -63,8 +63,8 @@ module snax_alu_pe #(
   //-------------------------------
   // Input ports are ready when the output ready
   // is also ready and when busy state is high
-  assign a_ready_o = acc_ready_i && c_ready_i;
-  assign b_ready_o = acc_ready_i && c_ready_i;
+  assign a_ready_o = acc_ready_i && c_ready_i && (a_valid_i && b_valid_i);
+  assign b_ready_o = acc_ready_i && c_ready_i && (a_valid_i && b_valid_i);
   assign c_valid_o = input_success;
   assign c_o       = result_wide;
 

--- a/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
+++ b/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
@@ -86,7 +86,7 @@ int main() {
         write_csr(0x3cd, LOOP_ITER);
 
         // Start streamer then start ALU
-        write_csr(0x3ca, 1); 
+        write_csr(0x3ca, 1);
         write_csr(0x3ce, 1);
 
         // Mark the end of the CSR setup cycles

--- a/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
+++ b/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
@@ -72,7 +72,6 @@ int main() {
         write_csr(0x3c7, (uint64_t)local_a);
         write_csr(0x3c8, (uint64_t)local_b);
         write_csr(0x3c9, (uint64_t)local_o);
-        write_csr(0x3ca, 1);
 
         //------------------------------
         // 2nd set the CSRs of the accelerator
@@ -85,6 +84,9 @@ int main() {
         //------------------------------
         write_csr(0x3cc, MODE);
         write_csr(0x3cd, LOOP_ITER);
+
+        // Start streamer then start ALU
+        write_csr(0x3ca, 1); 
         write_csr(0x3ce, 1);
 
         // Mark the end of the CSR setup cycles


### PR DESCRIPTION
This PR fixes the valid-ready signal of the ALU example.

The ready signals of inputs A and B must only be ready when:
1. The accelerator is ready (activated)
2. The output-ready signal is also ready (means the output is ready to write data)
3. When both A and B valid signals are asserted, only when A and B are ready.

To make this sort of forced to paper in the software, the `snax-alu.c` was also updated such that the streamer start and ALU start is close together.