### PR TITLE
Fix SNAX ALU output data width to 64bits

### DIFF
--- a/hw/snax_alu/src/snax_alu_pe.sv
+++ b/hw/snax_alu/src/snax_alu_pe.sv
@@ -10,21 +10,21 @@
 module snax_alu_pe #(
   parameter int unsigned DataWidth = 64
 )(
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
-  input  logic [  DataWidth-1:0] a_i,
-  input  logic                   a_valid_i,
-  output logic                   a_ready_o,
-  input  logic [  DataWidth-1:0] b_i,
-  input  logic                   b_valid_i,
-  output logic                   b_ready_o,
-  output logic [2*DataWidth-1:0] c_o,
-  output logic                   c_valid_o,
-  input  logic                   c_ready_i,
+  input  logic                 clk_i,
+  input  logic                 rst_ni,
+  input  logic [DataWidth-1:0] a_i,
+  input  logic                 a_valid_i,
+  output logic                 a_ready_o,
+  input  logic [DataWidth-1:0] b_i,
+  input  logic                 b_valid_i,
+  output logic                 b_ready_o,
+  output logic [DataWidth-1:0] c_o,
+  output logic                 c_valid_o,
+  input  logic                 c_ready_i,
   // Fix this to 2 bits only
   // Let's do 4 ALU operations for simplicity
-  input  logic                   acc_ready_i,
-  input  logic [            1:0] alu_config_i
+  input  logic                 acc_ready_i,
+  input  logic [          1:0] alu_config_i
 );
 
   //-------------------------------
@@ -38,7 +38,7 @@ module snax_alu_pe #(
   //-------------------------------
   // Wires and combinational logic
   //-------------------------------
-  logic [2*DataWidth-1:0] result_wide;
+  logic [DataWidth-1:0] result_wide;
 
   logic input_success;
 

--- a/hw/snax_alu/src/snax_alu_shell_wrapper.sv
+++ b/hw/snax_alu/src/snax_alu_shell_wrapper.sv
@@ -14,7 +14,6 @@ module snax_alu_shell_wrapper #(
   parameter int unsigned RegROCount   = 2,
   parameter int unsigned NumPE        = 4,
   parameter int unsigned DataWidth    = 64,
-  parameter int unsigned OutDataWidth = DataWidth*2,
   parameter int unsigned RegDataWidth = 32,
   parameter int unsigned RegAddrWidth = 32
 )(
@@ -31,7 +30,7 @@ module snax_alu_shell_wrapper #(
   // just to comply with the top-level wrapper
 
   // Ports from accelerator to streamer
-  output logic [(NumPE*OutDataWidth)-1:0] acc2stream_0_data_o,
+  output logic [(NumPE*DataWidth)-1:0] acc2stream_0_data_o,
   output logic acc2stream_0_valid_o,
   input  logic acc2stream_0_ready_i,
 
@@ -58,9 +57,9 @@ module snax_alu_shell_wrapper #(
   //-------------------------------
 
   // Wiring for accelerator ports
-  logic [NumPE-1:0][DataWidth-1   :0] a_split;
-  logic [NumPE-1:0][DataWidth-1   :0] b_split;
-  logic [NumPE-1:0][OutDataWidth-1:0] c_split;
+  logic [NumPE-1:0][DataWidth-1:0] a_split;
+  logic [NumPE-1:0][DataWidth-1:0] b_split;
+  logic [NumPE-1:0][DataWidth-1:0] c_split;
 
   logic [NumPE-1:0] a_ready;
   logic [NumPE-1:0] b_ready;
@@ -87,7 +86,7 @@ module snax_alu_shell_wrapper #(
       b_split[i] = stream2acc_1_data_i[i*DataWidth+:DataWidth];
 
       // Concatenating the output signals
-      acc2stream_0_data_o[i*OutDataWidth+:OutDataWidth] = c_split[i];
+      acc2stream_0_data_o[i*DataWidth+:DataWidth] = c_split[i];
     end
 
     // Inputs are read when all ready signals are ready

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -88,7 +88,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_alu"
-            snax_narrow_tcdm_ports: 16,
+            snax_narrow_tcdm_ports: 12,
             snax_num_rw_csr: 3,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_alu_streamer_template" }
@@ -139,7 +139,7 @@
         }
 
         fifo_writer_params: {
-            fifo_width: [512],
+            fifo_width: [256],
             fifo_depth: [8],
         }
 
@@ -151,8 +151,8 @@
         }
 
         data_writer_params:{
-            tcdm_ports_num: [8],
-            spatial_bounds: [[8]],
+            tcdm_ports_num: [4],
+            spatial_bounds: [[4]],
             spatial_dim: [1],
             element_width: [64],
         }

--- a/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
+++ b/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
@@ -65,7 +65,7 @@ int main() {
         write_csr(0x3c0, LOOP_ITER);
         write_csr(0x3c1, 32);
         write_csr(0x3c2, 32);
-        write_csr(0x3c3, 64);
+        write_csr(0x3c3, 32);
         write_csr(0x3c4, 8);
         write_csr(0x3c5, 8);
         write_csr(0x3c6, 8);
@@ -99,13 +99,10 @@ int main() {
         // Compare results and check if the
         // accelerator returns correct answers
         // For every incorrect answer, increment err
-        uint64_t check_val;
-
         for (uint32_t i = 0; i < DATA_LEN; i++) {
             // Need to combine upper 64bit bank
             // with the lower 64 bit bank
-            check_val = *(local_o + i * 2) + *(local_o + i * 2 + 1);
-            if (check_val != OUT[i]) {
+            if (OUT[i] != *(local_o + i)) {
                 err++;
             }
         }

--- a/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
+++ b/target/snitch_cluster/sw/apps/snax-alu/src/snax-alu.c
@@ -100,8 +100,6 @@ int main() {
         // accelerator returns correct answers
         // For every incorrect answer, increment err
         for (uint32_t i = 0; i < DATA_LEN; i++) {
-            // Need to combine upper 64bit bank
-            // with the lower 64 bit bank
             if (OUT[i] != *(local_o + i)) {
                 err++;
             }


### PR DESCRIPTION
This PR simply modifies the output data width to 64 bits to simplify the "accelerator".

TODOs:
- [x] Modify main PE ALU
- [x] Modify shell wrapper to accommodate 64b change
- [x] Modify the config file for the streamer part to be 64b wide only
- [x] Modify the test to read 64b directly