### PR TITLE
Porting out some base addresses for CONVOLVE tapeout

### DIFF
--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -64,7 +64,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   input  logic [31:0]   hart_id_i,
   /// Interrupts
   input  interrupts_t   irq_i,
-  /// Boot address port 
+  /// Boot address port
   input  logic [31:0]   boot_addr_i,
   /// Instruction cache flush request
   output logic          flush_i_valid_o,

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -11,8 +11,6 @@
 // `SNITCH_ENABLE_PERF Enables mcycle, minstret performance counters (read only)
 
 module snitch import snitch_pkg::*; import riscv_instr::*; #(
-  /// Boot address of core.
-  parameter logic [31:0] BootAddr  = 32'h0000_1000,
   /// Physical Address width of the core.
   parameter int unsigned AddrWidth = 48,
   /// Data width of memory interface.
@@ -66,6 +64,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   input  logic [31:0]   hart_id_i,
   /// Interrupts
   input  interrupts_t   irq_i,
+  /// Boot address port 
+  input  logic [31:0]   boot_addr_i,
   /// Instruction cache flush request
   output logic          flush_i_valid_o,
   /// Flush has completed when the signal goes to `1`.
@@ -329,7 +329,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   assign fpu_fmt_mode_o = fcsr_q.fmode;
 
   // Registers
-  `FFAR(pc_q, pc_d, BootAddr, clk_i, rst_i)
+  `FFAR(pc_q, pc_d, boot_addr_i, clk_i, rst_i)
   `FFAR(wfi_q, wfi_d, '0, clk_i, rst_i)
   `FFAR(sb_q, sb_d, '0, clk_i, rst_i)
   `FFAR(fcsr_q, fcsr_d, '0, clk_i, rst_i)

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -41,8 +41,6 @@ module snitch_cc #(
   parameter type         acc_resp_t         = logic,
   parameter type         dma_events_t       = logic,
   parameter fpnew_pkg::fpu_implementation_t FPUImplementation = '0,
-  /// Boot address of core.
-  parameter logic [31:0] BootAddr           = 32'h0000_1000,
   /// Reduced-register extension
   parameter bit          RVE                = 0,
   /// Enable F and D Extension
@@ -113,6 +111,8 @@ module snitch_cc #(
   input  snitch_pkg::interrupts_t    irq_i,
   output hive_req_t                  hive_req_o,
   input  hive_rsp_t                  hive_rsp_i,
+  // Boot address port
+  input  logic [31:0]                boot_addr_i,
   // Core data ports
   output dreq_t                      data_req_o,
   input  drsp_t                      data_rsp_i,
@@ -217,7 +217,6 @@ module snitch_cc #(
     .drsp_t (drsp_t),
     .pa_t (pa_t),
     .l0_pte_t (l0_pte_t),
-    .BootAddr (BootAddr),
     .SnitchPMACfg (SnitchPMACfg),
     .NumIntOutstandingLoads (NumIntOutstandingLoads),
     .NumIntOutstandingMem (NumIntOutstandingMem),
@@ -245,6 +244,7 @@ module snitch_cc #(
     .rst_i ( ~rst_ni ),
     .hart_id_i,
     .irq_i,
+    .boot_addr_i(boot_addr_i),
     .flush_i_valid_o (hive_req_o.flush_i_valid),
     .flush_i_ready_i (hive_rsp_i.flush_i_ready),
     .inst_addr_o (hive_req_o.inst_addr),
@@ -957,6 +957,6 @@ module snitch_cc #(
   // verilog_lint: waive-stop always-ff-non-blocking
   // pragma translate_on
 
-  `ASSERT_INIT(BootAddrAligned, BootAddr[1:0] == 2'b00)
+  `ASSERT_INIT(BootAddrAligned, boot_addr_i[1:0] == 2'b00)
 
 endmodule

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -38,7 +38,6 @@ module snitch_cluster
   /// AXI: dma user width.
   parameter int unsigned WideUserWidth      = 1,
   /// Address from which to fetch the first instructions.
-  parameter logic [31:0] BootAddr           = 32'h0,
   /// Number of Hives. Each Hive can hold 1-many cores.
   parameter int unsigned NrHives            = 1,
   /// The total (not per Hive) amount of cores.
@@ -229,6 +228,8 @@ module snitch_cluster
   /// Base address of cluster. TCDM and cluster peripheral location are derived from
   /// it. This signal is pseudo-static.
   input  logic [PhysicalAddrWidth-1:0]  cluster_base_addr_i,
+  /// Boot address
+  input  logic [31:0]                   boot_addr_i,
   /// Configuration inputs for the memory cuts used in implementation.
   /// These signals are pseudo-static.
   input  sram_cfgs_t                    sram_cfgs_i,
@@ -1202,7 +1203,6 @@ module snitch_cluster
         .acc_req_t (acc_req_t),
         .acc_resp_t (acc_resp_t),
         .dma_events_t (dma_events_t),
-        .BootAddr (BootAddr),
         .RVE (RVE[i]),
         .RVF (RVF[i]),
         .RVD (RVD[i]),
@@ -1250,6 +1250,7 @@ module snitch_cluster
         .hart_id_i (hart_base_id_i + i),
         .hive_req_o (hive_req[i]),
         .hive_rsp_i (hive_rsp[i]),
+        .boot_addr_i  (boot_addr_i),
         .irq_i (irq),
         .data_req_o (core_req[i]),
         .data_rsp_i (core_rsp[i]),

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -55,6 +55,11 @@ ${',' if not loop.last else ''}
 // verilog_lint: waive-start package-filename
 package ${cfg['pkg_name']};
 
+  // Addressing Parameters
+  localparam int unsigned HartBaseID = ${to_sv_hex(cfg['cluster_base_hartid'], 10)};
+  localparam int unsigned ClusterBaseAddr = ${to_sv_hex(cfg['cluster_base_addr'], cfg['addr_width'])};
+  localparam int unsigned BootAddr = ${to_sv_hex(cfg['boot_addr'], 32)};
+
   // Base and pre-calculated parameters
   localparam int unsigned NrCores = ${cfg['nr_cores']};
   localparam int unsigned NrHives = ${cfg['nr_hives']};
@@ -281,13 +286,12 @@ module ${cfg['name']}_wrapper (
   input  logic [${cfg['pkg_name']}::NrCores-1:0] meip_i,
   input  logic [${cfg['pkg_name']}::NrCores-1:0] mtip_i,
   input  logic [${cfg['pkg_name']}::NrCores-1:0] msip_i,
-% if not cfg['tie_ports']:
   //-----------------------------
   // Cluster base addressing
   //-----------------------------
   input  logic [9:0]                             hart_base_id_i,
   input  logic [${cfg['addr_width']-1}:0]        cluster_base_addr_i,
-% endif
+  input  logic [31:0]                            boot_addr_i,
 % if cfg['timing']['iso_crossings']:
   //-----------------------------
   // ISO crossings
@@ -572,14 +576,9 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     //-----------------------------
     // Cluster base and boot addressing
     //-----------------------------
-% if cfg['tie_ports']:
-    .hart_base_id_i ( ${to_sv_hex(cfg['cluster_base_hartid'], 10)} ),
-    .cluster_base_addr_i ( ${to_sv_hex(cfg['cluster_base_addr'], cfg['addr_width'])} ),
-% else:
     .hart_base_id_i ( hart_base_id_i ),
     .cluster_base_addr_i ( cluster_base_addr_i ),
-% endif
-    .boot_addr_i  (${to_sv_hex(cfg['boot_addr'], 32)}),
+    .boot_addr_i  (boot_addr_i),
     //-----------------------------
     // ISO crossings
     //-----------------------------

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -470,7 +470,6 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .WideIdWidthIn (${cfg['pkg_name']}::WideIdWidthIn),
     .NarrowUserWidth (${cfg['pkg_name']}::NarrowUserWidth),
     .WideUserWidth (${cfg['pkg_name']}::WideUserWidth),
-    .BootAddr (${to_sv_hex(cfg['boot_addr'], 32)}),
     .narrow_in_req_t (${cfg['pkg_name']}::narrow_in_req_t),
     .narrow_in_resp_t (${cfg['pkg_name']}::narrow_in_resp_t),
     .narrow_out_req_t (${cfg['pkg_name']}::narrow_out_req_t),
@@ -571,7 +570,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .mtip_i ( mtip_i ),
     .msip_i ( msip_i ),
     //-----------------------------
-    // Cluster base addressing
+    // Cluster base and boot addressing
     //-----------------------------
 % if cfg['tie_ports']:
     .hart_base_id_i ( ${to_sv_hex(cfg['cluster_base_hartid'], 10)} ),
@@ -580,6 +579,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .hart_base_id_i ( hart_base_id_i ),
     .cluster_base_addr_i ( cluster_base_addr_i ),
 % endif
+    .boot_addr_i  (${to_sv_hex(cfg['boot_addr'], 32)}),
     //-----------------------------
     // ISO crossings
     //-----------------------------

--- a/target/snitch_cluster/test/testharness.sv
+++ b/target/snitch_cluster/test/testharness.sv
@@ -25,6 +25,9 @@ module testharness import snitch_cluster_pkg::*; (
   snitch_cluster_wrapper i_snitch_cluster (
     .clk_i,
     .rst_ni,
+    .hart_base_id_i ( HartBaseID ),
+    .cluster_base_addr_i ( ClusterBaseAddr ),
+    .boot_addr_i  (BootAddr),
     .debug_req_i ('0),
     .meip_i ('0),
     .mtip_i ('0),


### PR DESCRIPTION
This PR needs to port out the base addresses needed for the multi-cluster integration.

Major TODOs:

- [x] Port out BootAddr
- [x] Port out hart_base_id_i
- [x] Port out cluster_base_addr_i

