### PR TITLE
Add reshuffle and max pool sw test

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -332,14 +332,14 @@ sources:
   - target: snax_data_reshuffler
     files:
       # Level 0
-      - hw/snax_data_reshuffler/src/data_reshuffler.sv
+      - hw/chisel_acc/generated/reshuffle/Reshuffler.sv
       - target/snitch_cluster/generated/snax_data_reshuffler/snax_data_reshuffler_csrman_CsrManager.sv
       - target/snitch_cluster/generated/snax_data_reshuffler/snax_data_reshuffler_streamer_StreamerTop.sv
       # Level 1
       - target/snitch_cluster/generated/snax_data_reshuffler/snax_data_reshuffler_csrman_wrapper.sv
       - target/snitch_cluster/generated/snax_data_reshuffler/snax_data_reshuffler_streamer_wrapper.sv
       # Level 2
-      - hw/snax_data_reshuffler/src/snax_data_reshuffler_shell_wrapper.sv
+      - hw/chisel_acc/src/snax_data_reshuffler_shell_wrapper.sv
       - target/snitch_cluster/generated/snax_data_reshuffler/snax_data_reshuffler_wrapper.sv
 
   - target: snax_streamer_gemmX

--- a/hw/chisel_acc/Makefile
+++ b/hw/chisel_acc/Makefile
@@ -33,6 +33,6 @@ $(DR_GENERATED_FILES): $(DR_SCALA_SOURCES)
 .PHONY: clean-data clean
 
 clean-chisel-generated-sv:
-	rm -f -r $(CHISEL_GENERATED_FILES) $(CHISEL_GENERATED_FILES_OLD) $(CHISEL_GENERATED_DIR)
+	rm -f -r $(CHISEL_GENERATED_FILES) $(DR_GENERATED_FILES) $(CHISEL_GENERATED_DIR)
 
 clean: clean-chisel-generated-sv	

--- a/hw/chisel_acc/Makefile
+++ b/hw/chisel_acc/Makefile
@@ -15,7 +15,7 @@ endef
 GEMMX = BlockGemmRescaleSIMD
 GEMMX_PKG_NAME = gemmx
 
-GEMMX_GENERATED_FILES = $(MK_DIR)generated/$(GEMMX_PKG_NAME)/$(GEMMX).sv
+GEMMX_GENERATED_FILES = $(MK_DIR)generated/$(GEMMX_PKG_NAME)/$(CHISEL_MODULE).sv
 GEMMX_SCALA_SOURCES := $(wildcard src/main/scala/snax_acc/$(GEMMX_PKG_NAME)/*.scala)
 
 $(GEMMX_GENERATED_FILES): $(GEMMX_SCALA_SOURCES)

--- a/hw/chisel_acc/Makefile
+++ b/hw/chisel_acc/Makefile
@@ -4,31 +4,31 @@
 #
 # Xiaoling Yi <xiaoling.yi@esat.kuleuven.be>
 
-MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+MK_CUR_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-CHISEL_GENERATED_DIR = $(MK_DIR)generated
+CHISEL_GENERATED_DIR = $(MK_CUR_DIR)generated
 
-define gen_sv_file
-	mkdir -p $(MK_DIR)generated/$(1) && cd $(MK_DIR) && sbt "runMain snax_acc.$(1).$(2)"
+define gen_snax_acc_sv_file
+	mkdir -p $(MK_CUR_DIR)generated/$(1) && cd $(MK_CUR_DIR) && sbt "runMain snax_acc.$(1).$(2)"
 endef
 
 GEMMX = BlockGemmRescaleSIMD
 GEMMX_PKG_NAME = gemmx
 
-GEMMX_GENERATED_FILES = $(MK_DIR)generated/$(GEMMX_PKG_NAME)/$(GEMMX).sv
+GEMMX_GENERATED_FILES = $(MK_CUR_DIR)generated/$(GEMMX_PKG_NAME)/$(GEMMX).sv
 GEMMX_SCALA_SOURCES := $(wildcard src/main/scala/snax_acc/$(GEMMX_PKG_NAME)/*.scala)
 
 $(GEMMX_GENERATED_FILES): $(GEMMX_SCALA_SOURCES)
-	$(call gen_sv_file,$(GEMMX_PKG_NAME),$(GEMMX))
+	$(call gen_snax_acc_sv_file,$(GEMMX_PKG_NAME),$(GEMMX))
 
 DR = Reshuffler
 DR_PKG_NAME = reshuffle
 
-DR_GENERATED_FILES = $(MK_DIR)generated/$(DR_PKG_NAME)/$(DR).sv
+DR_GENERATED_FILES = $(MK_CUR_DIR)generated/$(DR_PKG_NAME)/$(DR).sv
 DR_SCALA_SOURCES := $(wildcard src/main/scala/snax_acc/$(DR_PKG_NAME)/*.scala)
 
 $(DR_GENERATED_FILES): $(DR_SCALA_SOURCES)
-	$(call gen_sv_file,$(DR_PKG_NAME),$(DR))
+	$(call gen_snax_acc_sv_file,$(DR_PKG_NAME),$(DR))
 
 .PHONY: clean-data clean
 

--- a/hw/chisel_acc/Makefile
+++ b/hw/chisel_acc/Makefile
@@ -32,7 +32,5 @@ $(DR_GENERATED_FILES): $(DR_SCALA_SOURCES)
 
 .PHONY: clean-data clean
 
-clean-chisel-generated-sv:
-	rm -f -r $(CHISEL_GENERATED_FILES) $(DR_GENERATED_FILES) $(CHISEL_GENERATED_DIR)
-
-clean: clean-chisel-generated-sv	
+clean:
+	rm -f -r $(GEMMX_GENERATED_FILES) $(DR_GENERATED_FILES) $(CHISEL_GENERATED_DIR)

--- a/hw/chisel_acc/Makefile
+++ b/hw/chisel_acc/Makefile
@@ -15,7 +15,7 @@ endef
 GEMMX = BlockGemmRescaleSIMD
 GEMMX_PKG_NAME = gemmx
 
-GEMMX_GENERATED_FILES = $(MK_DIR)generated/$(GEMMX_PKG_NAME)/$(CHISEL_MODULE).sv
+GEMMX_GENERATED_FILES = $(MK_DIR)generated/$(GEMMX_PKG_NAME)/$(GEMMX).sv
 GEMMX_SCALA_SOURCES := $(wildcard src/main/scala/snax_acc/$(GEMMX_PKG_NAME)/*.scala)
 
 $(GEMMX_GENERATED_FILES): $(GEMMX_SCALA_SOURCES)

--- a/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/Reshuffle.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/Reshuffle.scala
@@ -247,7 +247,7 @@ class Reshuffler(params: ReshufflerParams)
 }
 
 // Scala main function for generating system verilog file for the Reshuffler module
-object ReshufflerGen extends App {
+object Reshuffler extends App {
   emitVerilog(
     new Reshuffler(DefaultConfig.ReshufflerConfig),
     Array("--target-dir", "generated/reshuffle")

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -116,6 +116,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-data-reshuffler.hjson)
 
 $(eval $(call generate_snax_gen,snax_data_reshuffler))
 
+	SNAX_DR_ROOT ?= $(ROOT)/hw/chisel_acc
+	include $(SNAX_DR_ROOT)/Makefile
+
 	VSIM_BENDER += -t snax_data_reshuffler
 	VLT_BENDER  += -t snax_data_reshuffler
 	VCS_BENDER  += -t snax_data_reshuffler
@@ -160,6 +163,9 @@ $(eval $(call generate_snax_gen,snax_streamer_gemm))
     VCS_BENDER  += -t snax_streamer_gemm
 
 $(eval $(call generate_snax_gen,snax_data_reshuffler))
+
+	SNAX_DR_ROOT ?= $(ROOT)/hw/chisel_acc
+	include $(SNAX_DR_ROOT)/Makefile
 
 	VSIM_BENDER += -t snax_data_reshuffler
 	VLT_BENDER  += -t snax_data_reshuffler

--- a/target/snitch_cluster/cfg/snax-data-reshuffler.hjson
+++ b/target/snitch_cluster/cfg/snax-data-reshuffler.hjson
@@ -90,7 +90,7 @@
             snax_acc_name: "snax_data_reshuffler",
             snax_narrow_tcdm_ports: 16,
             snax_num_rw_csr: 2,
-            snax_num_ro_csr: 0,
+            snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_data_reshuffler_streamer_template" }
         },
         snax_use_custom_ports: false,

--- a/target/snitch_cluster/cfg/snax-data-reshuffler.hjson
+++ b/target/snitch_cluster/cfg/snax-data-reshuffler.hjson
@@ -129,8 +129,8 @@
     snax_data_reshuffler_streamer_template :{
 
         temporal_addrgen_unit_params: {
-            loop_dim: [2],
-            share_temp_addr_gen_loop_bounds: true,
+            loop_dim: [5, 3],
+            share_temp_addr_gen_loop_bounds: false,
         }
 
         fifo_reader_params: {

--- a/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
@@ -18,10 +18,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../../../util/
 from data_utils import format_scalar_definition, format_vector_definition  # noqa E402
 
 # Add golden model path
-from snax_utils import (
-    data_reshuffler_golden_model,
-    max_pooling
-)  # noqa E402
+from snax_utils import data_reshuffler_golden_model, max_pooling  # noqa E402
 
 np.random.seed(42)
 
@@ -41,7 +38,7 @@ MAX = 127
 def emit_gemm_data(**kwargs):
     data_str = []
 
-    if kwargs["ifMaxPool"] == False:
+    if kwargs["ifMaxPool"] is False:
         # Generating loop bounds settings
         data_str += [
             format_scalar_definition("int8_t", "tempLoop0_in", kwargs["tempLoop0"]),
@@ -179,7 +176,11 @@ def emit_gemm_data(**kwargs):
             print("Invalid operation")
 
         # set transpose or not
-        data_str += [format_scalar_definition("int", "TloopLen",  kwargs["tempLoop0"] * kwargs["tempLoop1"])]
+        data_str += [
+            format_scalar_definition(
+                "int", "TloopLen", kwargs["tempLoop0"] * kwargs["tempLoop1"]
+            )
+        ]
         data_str += [format_scalar_definition("int", "reduceLen", 1)]
         data_str += [format_scalar_definition("int", "opcode", transpose)]
 
@@ -189,7 +190,7 @@ def emit_gemm_data(**kwargs):
 
         data_str = "\n\n".join(data_str)
 
-    elif kwargs['ifC8HW8datalayout'] == True:
+    elif kwargs["ifC8HW8datalayout"] is True:
         # data layout, C8HW8
         # Generating loop bounds settings
         padded_input_tensor_w = kwargs["W"] + kwargs["pad_w"] * 2
@@ -301,7 +302,7 @@ def emit_gemm_data(**kwargs):
             kwargs["stride_h"],
             kwargs["pad_w"],
             kwargs["pad_h"],
-            "C8HW8"
+            "C8HW8",
         )
 
         padded_data_in = np.pad(
@@ -357,7 +358,9 @@ def emit_gemm_data(**kwargs):
         ) // kwargs["stride_h"] + 1
 
         input_data_len = padded_input_tensor_w * padded_input_tensor_h * kwargs["Cin"]
-        output_data_len = padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
+        output_data_len = (
+            padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
+        )
 
         assert padded_output_tensor_w == kwargs["W"]
         assert padded_output_tensor_h == kwargs["H"]
@@ -366,22 +369,32 @@ def emit_gemm_data(**kwargs):
             # input data reshuffler loop bounds settings
             format_scalar_definition("int8_t", "tempLoop0_in", kwargs["Kw"]),
             format_scalar_definition("int8_t", "tempLoop1_in", kwargs["Kh"]),
+            format_scalar_definition("int8_t", "tempLoop2_in", kwargs["Cin"] // 8),
             format_scalar_definition(
-                "int8_t", "tempLoop2_in", kwargs["Cin"] // 8
+                "int8_t", "tempLoop3_in", padded_output_tensor_w // 8
             ),
-            format_scalar_definition("int8_t", "tempLoop3_in", padded_output_tensor_w // 8),
             format_scalar_definition("int8_t", "tempLoop4_in", padded_output_tensor_h),
             # output data reshuffler loop bounds settings
+            format_scalar_definition("int8_t", "tempLoop0_out", kwargs["Cin"] // 8),
             format_scalar_definition(
-                "int8_t", "tempLoop0_out", kwargs["Cin"] // 8
+                "int8_t", "tempLoop1_out", padded_output_tensor_w // 8
             ),
-            format_scalar_definition("int8_t", "tempLoop1_out", padded_output_tensor_w // 8),
             format_scalar_definition("int8_t", "tempLoop2_out", padded_output_tensor_h),
             # data length setting
             format_scalar_definition("int32_t", "input_data_len", input_data_len),
             format_scalar_definition("int32_t", "output_data_len", output_data_len),
-            format_scalar_definition("int32_t", "TloopLen", padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"] // 8 // 8),
-            format_scalar_definition("int32_t", "reduceLen", kwargs["Kw"] * kwargs["Kh"]),
+            format_scalar_definition(
+                "int32_t",
+                "TloopLen",
+                padded_output_tensor_w
+                * padded_output_tensor_h
+                * kwargs["Cin"]
+                // 8
+                // 8,
+            ),
+            format_scalar_definition(
+                "int32_t", "reduceLen", kwargs["Kw"] * kwargs["Kh"]
+            ),
         ]
 
         data_str += [
@@ -395,23 +408,29 @@ def emit_gemm_data(**kwargs):
             ),
             format_scalar_definition("int32_t", "tempStride2_in", 8),
             format_scalar_definition("int32_t", "tempStride3_in", 8 * kwargs["Cin"]),
-            format_scalar_definition("int32_t", "tempStride4_in", padded_input_tensor_w * kwargs["Cin"]),
+            format_scalar_definition(
+                "int32_t", "tempStride4_in", padded_input_tensor_w * kwargs["Cin"]
+            ),
             # data reshuffler output strides
             format_scalar_definition("int32_t", "spatialStride1_out", kwargs["Cin"]),
             format_scalar_definition("int32_t", "tempStride0_out", 8),
             format_scalar_definition("int32_t", "tempStride1_out", 8 * kwargs["Cin"]),
-            format_scalar_definition("int32_t", "tempStride2_out", padded_output_tensor_w * kwargs["Cin"]),
-            # Generating base address pointers
             format_scalar_definition(
-                "int32_t", "delta_local_in", 0
+                "int32_t", "tempStride2_out", padded_output_tensor_w * kwargs["Cin"]
             ),
+            # Generating base address pointers
+            format_scalar_definition("int32_t", "delta_local_in", 0),
             format_scalar_definition(
-                "int32_t", "delta_local_out", padded_input_tensor_h * padded_input_tensor_w * kwargs["Cin"]
+                "int32_t",
+                "delta_local_out",
+                padded_input_tensor_h * padded_input_tensor_w * kwargs["Cin"],
             ),
         ]
 
         # Generating random input data vector
-        data_in = np.random.randint(MIN, MAX, (1, kwargs["H"], kwargs["W"], kwargs["Cin"]))
+        data_in = np.random.randint(
+            MIN, MAX, (1, kwargs["H"], kwargs["W"], kwargs["Cin"])
+        )
 
         # Generating golden data
         c_golden = max_pooling(
@@ -422,12 +441,17 @@ def emit_gemm_data(**kwargs):
             kwargs["stride_h"],
             kwargs["pad_w"],
             kwargs["pad_h"],
-            "HWC"
+            "HWC",
         )
 
         padded_data_in = np.pad(
             data_in,
-            ((0, 0), (kwargs["pad_h"], kwargs["pad_h"]), (kwargs["pad_w"], kwargs["pad_w"]), (0, 0)),
+            (
+                (0, 0),
+                (kwargs["pad_h"], kwargs["pad_h"]),
+                (kwargs["pad_w"], kwargs["pad_w"]),
+                (0, 0),
+            ),
             "constant",
         )
 
@@ -435,14 +459,28 @@ def emit_gemm_data(**kwargs):
         data_str += [format_scalar_definition("int", "opcode", 2)]
 
         # Writing testing data and golden data into data.h
-        assert padded_data_in.shape == (1, padded_input_tensor_h, padded_input_tensor_w, kwargs["Cin"])
+        assert padded_data_in.shape == (
+            1,
+            padded_input_tensor_h,
+            padded_input_tensor_w,
+            kwargs["Cin"],
+        )
         assert padded_data_in.reshape(-1).shape[0] == input_data_len
-        data_str += [format_vector_definition("int8_t", "DataIn", padded_data_in.reshape(-1))]
+        data_str += [
+            format_vector_definition("int8_t", "DataIn", padded_data_in.reshape(-1))
+        ]
 
-        assert c_golden.shape == (1, padded_output_tensor_h, padded_output_tensor_w, kwargs["Cin"])
+        assert c_golden.shape == (
+            1,
+            padded_output_tensor_h,
+            padded_output_tensor_w,
+            kwargs["Cin"],
+        )
         assert c_golden.reshape(-1).shape[0] == output_data_len
 
-        data_str += [format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))]
+        data_str += [
+            format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))
+        ]
 
         data_str = "\n\n".join(data_str)
 

--- a/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
@@ -14,12 +14,15 @@ import sys
 import os
 
 # Add data utility path
-sys.path.append(
-    os.path.join(os.path.dirname(__file__), "../../../../../../util/sim/"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../../../util/sim/"))
 from data_utils import format_scalar_definition, format_vector_definition  # noqa E402
 
 # Add golden model path
-from snax_utils import data_reshuffler_golden_model  # noqa E402
+from snax_utils import (
+    data_reshuffler_golden_model,
+    max_pooling_3d,
+    max_pooling_4d,
+)  # noqa E402
 
 np.random.seed(42)
 
@@ -39,126 +42,406 @@ MAX = 127
 def emit_gemm_data(**kwargs):
     data_str = []
 
-    # Generating loop bounds settings
-    data_str += [
-        format_scalar_definition("int8_t", "tempLoop0", kwargs["tempLoop0"]),
-        format_scalar_definition("int8_t", "tempLoop1", kwargs["tempLoop1"]),
-    ]
+    if kwargs["ifMaxPool"] == False:
+        # Generating loop bounds settings
+        data_str += [
+            format_scalar_definition("int8_t", "tempLoop0_in", kwargs["tempLoop0"]),
+            format_scalar_definition("int8_t", "tempLoop1_in", kwargs["tempLoop1"]),
+            format_scalar_definition("int8_t", "tempLoop2_in", 1),
+            format_scalar_definition("int8_t", "tempLoop3_in", 1),
+            format_scalar_definition("int8_t", "tempLoop4_in", 1),
+            format_scalar_definition("int8_t", "tempLoop0_out", kwargs["tempLoop0"]),
+            format_scalar_definition("int8_t", "tempLoop1_out", kwargs["tempLoop1"]),
+            format_scalar_definition("int8_t", "tempLoop2_out", 1),
+            format_scalar_definition(
+                "int32_t",
+                "input_data_len",
+                kwargs["tempLoop0"] * kwargs["tempLoop1"] * 8 * 8,
+            ),
+            format_scalar_definition(
+                "int32_t",
+                "output_data_len",
+                kwargs["tempLoop0"] * kwargs["tempLoop1"] * 8 * 8,
+            ),
+        ]
 
-    # Generating temporal strides settings
-    # DMA strides (from L3 to L1)
-    data_str += [
-        format_scalar_definition(
-            "int32_t", "DMAtempStride0_in", kwargs["DMAtempStride0_in"]
-        ),
-        format_scalar_definition(
-            "int32_t", "DMAtempStride1_in", kwargs["DMAtempStride1_in"]
-        ),
-        format_scalar_definition(
-            "int32_t", "DMAspatialStride1_in", kwargs["DMAspatialStride1_in"]
-        ),
-        # data reshuffler input strides
-        format_scalar_definition("int32_t", "tempStride0_in",
-                                 kwargs["tempStride0_in"]),
-        format_scalar_definition("int32_t", "tempStride1_in",
-                                 kwargs["tempStride1_in"]),
-        format_scalar_definition(
-            "int32_t", "spatialStride1_in", kwargs["spatialStride1_in"]
-        ),
-        # data reshuffler output strides
-        format_scalar_definition(
-            "int32_t",
-            "tempStride0_out",
-            kwargs["tempStride0_out"],
-        ),
-        format_scalar_definition(
-            "int32_t", "tempStride1_out", kwargs["tempStride1_out"]
-        ),
-        format_scalar_definition(
-            "int32_t", "spatialStride1_out", kwargs["spatialStride1_out"]
-        ),
-        # Generating base address pointers
-        format_scalar_definition("int32_t", "delta_local_in",
-                                 kwargs["delta_local_in"]),
-        format_scalar_definition("int32_t", "delta_local_out",
-                                 kwargs["delta_local_out"]),
-    ]
+        # Generating temporal strides settings
+        # DMA strides (from L3 to L1)
+        data_str += [
+            format_scalar_definition(
+                "int32_t", "DMAtempStride0_in", kwargs["DMAtempStride0_in"]
+            ),
+            format_scalar_definition(
+                "int32_t", "DMAtempStride1_in", kwargs["DMAtempStride1_in"]
+            ),
+            format_scalar_definition(
+                "int32_t", "DMAspatialStride1_in", kwargs["DMAspatialStride1_in"]
+            ),
+            # data reshuffler input strides
+            format_scalar_definition(
+                "int32_t", "tempStride0_in", kwargs["tempStride0_in"]
+            ),
+            format_scalar_definition(
+                "int32_t", "tempStride1_in", kwargs["tempStride1_in"]
+            ),
+            format_scalar_definition("int32_t", "tempStride2_in", 0),
+            format_scalar_definition("int32_t", "tempStride3_in", 0),
+            format_scalar_definition("int32_t", "tempStride4_in", 0),
+            format_scalar_definition(
+                "int32_t", "spatialStride1_in", kwargs["spatialStride1_in"]
+            ),
+            # data reshuffler output strides
+            format_scalar_definition(
+                "int32_t",
+                "tempStride0_out",
+                kwargs["tempStride0_out"],
+            ),
+            format_scalar_definition(
+                "int32_t", "tempStride1_out", kwargs["tempStride1_out"]
+            ),
+            format_scalar_definition("int32_t", "tempStride2_out", 0),
+            format_scalar_definition(
+                "int32_t", "spatialStride1_out", kwargs["spatialStride1_out"]
+            ),
+            # Generating base address pointers
+            format_scalar_definition(
+                "int32_t", "delta_local_in", kwargs["delta_local_in"]
+            ),
+            format_scalar_definition(
+                "int32_t", "delta_local_out", kwargs["delta_local_out"]
+            ),
+        ]
 
-    # Generating random input data vector
-    length_in = (
-        kwargs["tempLoop0"]
-        * kwargs["tempLoop1"]
-        * kwargs["spatial_len_0"]
-        * kwargs["spatial_len_1"]
-    )
-
-    data_in = np.random.randint(MIN, MAX, length_in)
-
-    op = kwargs["op"]
-
-    # Generating golden data
-    # NOTE: using 4 loops to iterate through the
-    # input data and reshuffle the data.
-    # different from the hardware data reshuffler,
-    # the golden model uses the pure strided layout mapping equation,
-    # no 64 data granularity constraint, no need to transpose explicitly.
-    if op == "rowmajor2tiledrowmajor":
-        c_golden = data_reshuffler_golden_model(
-            kwargs["tempLoop0"],
-            kwargs["tempLoop1"],
-            kwargs["spatial_len_0"],
-            kwargs["spatial_len_1"],
-            kwargs["tempStride0_in"],
-            kwargs["tempStride1_in"],
-            1,
-            kwargs["spatialStride1_in"],
-            data_in,
+        # Generating random input data vector
+        length_in = (
+            kwargs["tempLoop0"]
+            * kwargs["tempLoop1"]
+            * kwargs["spatial_len_0"]
+            * kwargs["spatial_len_1"]
         )
 
-    if op == "rowmajor2tiledcolmajor":
-        c_golden = data_reshuffler_golden_model(
-            kwargs["tempLoop0"],
-            kwargs["tempLoop1"],
-            kwargs["spatial_len_0"],
-            kwargs["spatial_len_1"],
-            kwargs["tempStride0_in"],
-            kwargs["tempStride1_in"],
-            kwargs["tempLoop0"] * 8,
-            1,
-            data_in,
-        )
+        data_in = np.random.randint(MIN, MAX, length_in)
 
-    if op == "tiledrowmajor2tiledcolmajor":
-        c_golden = data_reshuffler_golden_model(
-            kwargs["tempLoop0"],
-            kwargs["tempLoop1"],
-            kwargs["spatial_len_0"],
-            kwargs["spatial_len_1"],
-            kwargs["tempStride0_in"],
-            kwargs["tempStride1_in"],
-            8,
-            1,
-            data_in,
-        )
+        op = kwargs["op"]
 
-    # Generating transpose flag for the data reshuffler hardware
-    if op == "rowmajor2tiledrowmajor":
-        transpose = 0
-    elif op == "rowmajor2tiledcolmajor":
-        transpose = 1
-    elif op == "tiledrowmajor2tiledcolmajor":
-        transpose = 1
+        # Generating golden data
+        # NOTE: using 4 loops to iterate through the
+        # input data and reshuffle the data.
+        # different from the hardware data reshuffler,
+        # the golden model uses the pure strided layout mapping equation,
+        # no 64 data granularity constraint, no need to transpose explicitly.
+        if op == "rowmajor2tiledrowmajor":
+            c_golden = data_reshuffler_golden_model(
+                kwargs["tempLoop0"],
+                kwargs["tempLoop1"],
+                kwargs["spatial_len_0"],
+                kwargs["spatial_len_1"],
+                kwargs["tempStride0_in"],
+                kwargs["tempStride1_in"],
+                1,
+                kwargs["spatialStride1_in"],
+                data_in,
+            )
+
+        if op == "rowmajor2tiledcolmajor":
+            c_golden = data_reshuffler_golden_model(
+                kwargs["tempLoop0"],
+                kwargs["tempLoop1"],
+                kwargs["spatial_len_0"],
+                kwargs["spatial_len_1"],
+                kwargs["tempStride0_in"],
+                kwargs["tempStride1_in"],
+                kwargs["tempLoop0"] * 8,
+                1,
+                data_in,
+            )
+
+        if op == "tiledrowmajor2tiledcolmajor":
+            c_golden = data_reshuffler_golden_model(
+                kwargs["tempLoop0"],
+                kwargs["tempLoop1"],
+                kwargs["spatial_len_0"],
+                kwargs["spatial_len_1"],
+                kwargs["tempStride0_in"],
+                kwargs["tempStride1_in"],
+                8,
+                1,
+                data_in,
+            )
+
+        # Generating transpose flag for the data reshuffler hardware
+        if op == "rowmajor2tiledrowmajor":
+            transpose = 0
+        elif op == "rowmajor2tiledcolmajor":
+            transpose = 1
+        elif op == "tiledrowmajor2tiledcolmajor":
+            transpose = 1
+        else:
+            print("Invalid operation")
+
+        # set transpose or not
+        data_str += [format_scalar_definition("int", "opcode", transpose)]
+
+        # Writing testing data and golden data into data.h
+        data_str += [format_vector_definition("int8_t", "DataIn", data_in)]
+        data_str += [format_vector_definition("int8_t", "C_golden", c_golden)]
+
+        data_str = "\n\n".join(data_str)
+
     else:
-        print("Invalid operation")
+        # # data layout HWCin
+        # # Generating loop bounds settings
+        # padded_input_tensor_w = kwargs["W"] + kwargs["pad_w"] * 2
+        # padded_input_tensor_h = kwargs["H"] + kwargs["pad_h"] * 2
 
-    # set transpose or not
-    data_str += [format_scalar_definition("bool", "transpose", transpose)]
+        # padded_output_tensor_w = (
+        #     kwargs["W"] + kwargs["pad_w"] * 2 - kwargs["Kw"]
+        # ) // kwargs["stride_w"] + 1
+        # padded_output_tensor_h = (
+        #     kwargs["H"] + kwargs["pad_h"] * 2 - kwargs["Kh"]
+        # ) // kwargs["stride_h"] + 1
 
-    # Writing testing data and golden data into data.h
-    data_str += [format_vector_definition("int8_t", "DataIn", data_in)]
-    data_str += [format_vector_definition("int8_t", "C_golden", c_golden)]
+        # input_data_len = padded_input_tensor_w * padded_input_tensor_h * kwargs["Cin"]
+        # output_data_len = padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
 
-    data_str = "\n\n".join(data_str)
+        # assert padded_output_tensor_w == kwargs["W"]
+        # assert padded_output_tensor_h == kwargs["H"]
+
+        # data_str += [
+        #     # input data reshuffler loop bounds settings
+        #     format_scalar_definition("int8_t", "tempLoop0_in", kwargs["Kw"]),
+        #     format_scalar_definition("int8_t", "tempLoop1_in", kwargs["Kh"]),
+        #     format_scalar_definition(
+        #         "int8_t", "tempLoop2_in", kwargs["Cin"] // 8
+        #     ),
+        #     format_scalar_definition("int8_t", "tempLoop3_in", padded_output_tensor_w // 8),
+        #     format_scalar_definition("int8_t", "tempLoop4_in", padded_output_tensor_h),
+        #     # output data reshuffler loop bounds settings
+        #     format_scalar_definition(
+        #         "int8_t", "tempLoop0_out", kwargs["Cin"] // 8
+        #     ),
+        #     format_scalar_definition("int8_t", "tempLoop1_out", padded_output_tensor_w // 8),
+        #     format_scalar_definition("int8_t", "tempLoop2_out", padded_output_tensor_h),
+        #     # data length setting
+        #     format_scalar_definition("int32_t", "input_data_len", input_data_len),
+        #     format_scalar_definition("int32_t", "output_data_len", output_data_len),
+        #     format_scalar_definition("int32_t", "TloopLen", padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"] // 8 // 8),
+        #     format_scalar_definition("int32_t", "reduceLen", kwargs["Kw"] * kwargs["Kh"]),
+        # ]
+
+        # data_str += [
+        #     # data reshuffler input strides
+        #     format_scalar_definition("int32_t", "spatialStride1_in", kwargs["Cin"]),
+        #     format_scalar_definition(
+        #         "int32_t", "tempStride0_in", kwargs["stride_w"] * kwargs["Cin"]
+        #     ),
+        #     format_scalar_definition(
+        #         "int32_t", "tempStride1_in", padded_input_tensor_w * kwargs["Cin"]
+        #     ),
+        #     format_scalar_definition("int32_t", "tempStride2_in", 8),
+        #     format_scalar_definition("int32_t", "tempStride3_in", 8 * kwargs["Cin"]),
+        #     format_scalar_definition("int32_t", "tempStride4_in", padded_input_tensor_w * kwargs["Cin"]),
+        #     # data reshuffler output strides
+        #     format_scalar_definition("int32_t", "spatialStride1_out", kwargs["Cin"]),
+        #     format_scalar_definition("int32_t", "tempStride0_out", 8),
+        #     format_scalar_definition("int32_t", "tempStride1_out", 8 * kwargs["Cin"]),
+        #     format_scalar_definition("int32_t", "tempStride2_out", padded_output_tensor_w * kwargs["Cin"]),
+        #     # Generating base address pointers
+        #     format_scalar_definition(
+        #         "int32_t", "delta_local_in", 0
+        #     ),
+        #     format_scalar_definition(
+        #         "int32_t", "delta_local_out", padded_input_tensor_h * padded_input_tensor_w * kwargs["Cin"]
+        #     ),
+        # ]
+
+        # # Generating random input data vector
+        # data_in = np.random.randint(MIN, MAX, (kwargs["H"], kwargs["W"], kwargs["Cin"]))
+
+        # # Generating golden data
+        # c_golden = max_pooling_3d(
+        #     data_in,
+        #     kwargs["Kw"],
+        #     kwargs["Kh"],
+        #     kwargs["stride_w"],
+        #     kwargs["stride_h"],
+        #     kwargs["pad_w"],
+        #     kwargs["pad_h"],
+        # )
+
+        # padded_data_in = np.pad(
+        #     data_in,
+        #     ((kwargs["pad_h"], kwargs["pad_h"]), (kwargs["pad_w"], kwargs["pad_w"]), (0, 0)),
+        #     "constant",
+        # )
+
+        # # set opcode
+        # data_str += [format_scalar_definition("int", "opcode", 2)]
+
+        # # Writing testing data and golden data into data.h
+        # assert padded_data_in.shape == (padded_input_tensor_h, padded_input_tensor_w, kwargs["Cin"])
+        # assert padded_data_in.reshape(-1).shape[0] == input_data_len
+        # data_str += [format_vector_definition("int8_t", "DataIn", padded_data_in.reshape(-1))]
+
+        # assert c_golden.shape == (padded_output_tensor_h, padded_output_tensor_w, kwargs["Cin"])
+        # assert c_golden.reshape(-1).shape[0] == output_data_len
+
+        # data_str += [format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))]
+
+        # data_str = "\n\n".join(data_str)
+
+        # data layout, C8HW8
+        # Generating loop bounds settings
+        padded_input_tensor_w = kwargs["W"] + kwargs["pad_w"] * 2
+        padded_input_tensor_h = kwargs["H"] + kwargs["pad_h"] * 2
+
+        padded_output_tensor_w = (
+            kwargs["W"] + kwargs["pad_w"] * 2 - kwargs["Kw"]
+        ) // kwargs["stride_w"] + 1
+        padded_output_tensor_h = (
+            kwargs["H"] + kwargs["pad_h"] * 2 - kwargs["Kh"]
+        ) // kwargs["stride_h"] + 1
+
+        input_data_len = padded_input_tensor_w * padded_input_tensor_h * kwargs["Cin"]
+        output_data_len = (
+            padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
+        )
+
+        assert padded_output_tensor_w == kwargs["W"]
+        assert padded_output_tensor_h == kwargs["H"]
+
+        data_str += [
+            # input data reshuffler loop bounds settings
+            format_scalar_definition("int8_t", "tempLoop0_in", kwargs["Kw"]),
+            format_scalar_definition("int8_t", "tempLoop1_in", kwargs["Kh"]),
+            format_scalar_definition(
+                "int8_t", "tempLoop2_in", padded_output_tensor_w // 8
+            ),
+            format_scalar_definition("int8_t", "tempLoop3_in", padded_output_tensor_h),
+            format_scalar_definition("int8_t", "tempLoop4_in", kwargs["Cin"] // 8),
+            # output data reshuffler loop bounds settings
+            format_scalar_definition(
+                "int8_t", "tempLoop0_out", padded_output_tensor_w // 8
+            ),
+            format_scalar_definition("int8_t", "tempLoop1_out", padded_output_tensor_h),
+            format_scalar_definition("int8_t", "tempLoop2_out", kwargs["Cin"] // 8),
+            # data length setting
+            format_scalar_definition("int32_t", "input_data_len", input_data_len),
+            format_scalar_definition("int32_t", "output_data_len", output_data_len),
+            format_scalar_definition(
+                "int32_t",
+                "TloopLen",
+                padded_output_tensor_w
+                * padded_output_tensor_h
+                * kwargs["Cin"]
+                // 8
+                // 8,
+            ),
+            format_scalar_definition(
+                "int32_t", "reduceLen", kwargs["Kw"] * kwargs["Kh"]
+            ),
+        ]
+
+        assert padded_output_tensor_w * 8 == 8 * 8 * (padded_output_tensor_w // 8)
+        data_str += [
+            # data reshuffler input strides
+            format_scalar_definition("int32_t", "spatialStride1_in", 8),
+            format_scalar_definition(
+                "int32_t", "tempStride0_in", kwargs["stride_w"] * 8
+            ),
+            format_scalar_definition(
+                "int32_t", "tempStride1_in", padded_input_tensor_w * 8
+            ),
+            format_scalar_definition("int32_t", "tempStride2_in", 8 * 8),
+            format_scalar_definition(
+                "int32_t",
+                "tempStride3_in",
+                padded_input_tensor_w * 8 * kwargs["stride_h"],
+            ),
+            format_scalar_definition(
+                "int32_t",
+                "tempStride4_in",
+                padded_input_tensor_w * padded_input_tensor_h * 8,
+            ),
+            # data reshuffler output strides
+            format_scalar_definition("int32_t", "spatialStride1_out", 8),
+            format_scalar_definition(
+                "int32_t",
+                "tempStride0_out",
+                8 * 8,
+            ),
+            format_scalar_definition(
+                "int32_t", "tempStride1_out", padded_output_tensor_w * 8
+            ),
+            format_scalar_definition(
+                "int32_t",
+                "tempStride2_out",
+                padded_output_tensor_w * padded_output_tensor_h * 8,
+            ),
+            # Generating base address pointers
+            format_scalar_definition("int32_t", "delta_local_in", 0),
+            format_scalar_definition(
+                "int32_t",
+                "delta_local_out",
+                padded_input_tensor_h * padded_input_tensor_w * kwargs["Cin"],
+            ),
+        ]
+
+        # Generating random input data vector
+        data_in = np.random.randint(
+            MIN, MAX, (kwargs["Cin"] // 8, kwargs["H"], kwargs["W"], 8)
+        )
+
+        # Generating golden data
+        c_golden = max_pooling_4d(
+            data_in,
+            kwargs["Kw"],
+            kwargs["Kh"],
+            kwargs["stride_w"],
+            kwargs["stride_h"],
+            kwargs["pad_w"],
+            kwargs["pad_h"],
+        )
+
+        padded_data_in = np.pad(
+            data_in,
+            (
+                (0, 0),
+                (kwargs["pad_h"], kwargs["pad_h"]),
+                (kwargs["pad_w"], kwargs["pad_w"]),
+                (0, 0),
+            ),
+            "constant",
+        )
+
+        # set opcode
+        data_str += [format_scalar_definition("int", "opcode", 2)]
+
+        # Writing testing data and golden data into data.h
+        assert padded_data_in.shape == (
+            kwargs["Cin"] // 8,
+            padded_input_tensor_h,
+            padded_input_tensor_w,
+            8,
+        )
+        assert padded_data_in.reshape(-1).shape[0] == input_data_len
+        data_str += [
+            format_vector_definition("int8_t", "DataIn", padded_data_in.reshape(-1))
+        ]
+
+        assert c_golden.shape == (
+            kwargs["Cin"] // 8,
+            padded_output_tensor_h,
+            padded_output_tensor_w,
+            8,
+        )
+        assert c_golden.reshape(-1).shape[0] == output_data_len
+
+        data_str += [
+            format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))
+        ]
+
+        data_str = "\n\n".join(data_str)
 
     return data_str
 

--- a/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
@@ -20,8 +20,7 @@ from data_utils import format_scalar_definition, format_vector_definition  # noq
 # Add golden model path
 from snax_utils import (
     data_reshuffler_golden_model,
-    max_pooling_3d,
-    max_pooling_4d,
+    max_pooling
 )  # noqa E402
 
 np.random.seed(42)
@@ -180,6 +179,8 @@ def emit_gemm_data(**kwargs):
             print("Invalid operation")
 
         # set transpose or not
+        data_str += [format_scalar_definition("int", "TloopLen",  kwargs["tempLoop0"] * kwargs["tempLoop1"])]
+        data_str += [format_scalar_definition("int", "reduceLen", 1)]
         data_str += [format_scalar_definition("int", "opcode", transpose)]
 
         # Writing testing data and golden data into data.h
@@ -188,108 +189,7 @@ def emit_gemm_data(**kwargs):
 
         data_str = "\n\n".join(data_str)
 
-    else:
-        # # data layout HWCin
-        # # Generating loop bounds settings
-        # padded_input_tensor_w = kwargs["W"] + kwargs["pad_w"] * 2
-        # padded_input_tensor_h = kwargs["H"] + kwargs["pad_h"] * 2
-
-        # padded_output_tensor_w = (
-        #     kwargs["W"] + kwargs["pad_w"] * 2 - kwargs["Kw"]
-        # ) // kwargs["stride_w"] + 1
-        # padded_output_tensor_h = (
-        #     kwargs["H"] + kwargs["pad_h"] * 2 - kwargs["Kh"]
-        # ) // kwargs["stride_h"] + 1
-
-        # input_data_len = padded_input_tensor_w * padded_input_tensor_h * kwargs["Cin"]
-        # output_data_len = padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
-
-        # assert padded_output_tensor_w == kwargs["W"]
-        # assert padded_output_tensor_h == kwargs["H"]
-
-        # data_str += [
-        #     # input data reshuffler loop bounds settings
-        #     format_scalar_definition("int8_t", "tempLoop0_in", kwargs["Kw"]),
-        #     format_scalar_definition("int8_t", "tempLoop1_in", kwargs["Kh"]),
-        #     format_scalar_definition(
-        #         "int8_t", "tempLoop2_in", kwargs["Cin"] // 8
-        #     ),
-        #     format_scalar_definition("int8_t", "tempLoop3_in", padded_output_tensor_w // 8),
-        #     format_scalar_definition("int8_t", "tempLoop4_in", padded_output_tensor_h),
-        #     # output data reshuffler loop bounds settings
-        #     format_scalar_definition(
-        #         "int8_t", "tempLoop0_out", kwargs["Cin"] // 8
-        #     ),
-        #     format_scalar_definition("int8_t", "tempLoop1_out", padded_output_tensor_w // 8),
-        #     format_scalar_definition("int8_t", "tempLoop2_out", padded_output_tensor_h),
-        #     # data length setting
-        #     format_scalar_definition("int32_t", "input_data_len", input_data_len),
-        #     format_scalar_definition("int32_t", "output_data_len", output_data_len),
-        #     format_scalar_definition("int32_t", "TloopLen", padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"] // 8 // 8),
-        #     format_scalar_definition("int32_t", "reduceLen", kwargs["Kw"] * kwargs["Kh"]),
-        # ]
-
-        # data_str += [
-        #     # data reshuffler input strides
-        #     format_scalar_definition("int32_t", "spatialStride1_in", kwargs["Cin"]),
-        #     format_scalar_definition(
-        #         "int32_t", "tempStride0_in", kwargs["stride_w"] * kwargs["Cin"]
-        #     ),
-        #     format_scalar_definition(
-        #         "int32_t", "tempStride1_in", padded_input_tensor_w * kwargs["Cin"]
-        #     ),
-        #     format_scalar_definition("int32_t", "tempStride2_in", 8),
-        #     format_scalar_definition("int32_t", "tempStride3_in", 8 * kwargs["Cin"]),
-        #     format_scalar_definition("int32_t", "tempStride4_in", padded_input_tensor_w * kwargs["Cin"]),
-        #     # data reshuffler output strides
-        #     format_scalar_definition("int32_t", "spatialStride1_out", kwargs["Cin"]),
-        #     format_scalar_definition("int32_t", "tempStride0_out", 8),
-        #     format_scalar_definition("int32_t", "tempStride1_out", 8 * kwargs["Cin"]),
-        #     format_scalar_definition("int32_t", "tempStride2_out", padded_output_tensor_w * kwargs["Cin"]),
-        #     # Generating base address pointers
-        #     format_scalar_definition(
-        #         "int32_t", "delta_local_in", 0
-        #     ),
-        #     format_scalar_definition(
-        #         "int32_t", "delta_local_out", padded_input_tensor_h * padded_input_tensor_w * kwargs["Cin"]
-        #     ),
-        # ]
-
-        # # Generating random input data vector
-        # data_in = np.random.randint(MIN, MAX, (kwargs["H"], kwargs["W"], kwargs["Cin"]))
-
-        # # Generating golden data
-        # c_golden = max_pooling_3d(
-        #     data_in,
-        #     kwargs["Kw"],
-        #     kwargs["Kh"],
-        #     kwargs["stride_w"],
-        #     kwargs["stride_h"],
-        #     kwargs["pad_w"],
-        #     kwargs["pad_h"],
-        # )
-
-        # padded_data_in = np.pad(
-        #     data_in,
-        #     ((kwargs["pad_h"], kwargs["pad_h"]), (kwargs["pad_w"], kwargs["pad_w"]), (0, 0)),
-        #     "constant",
-        # )
-
-        # # set opcode
-        # data_str += [format_scalar_definition("int", "opcode", 2)]
-
-        # # Writing testing data and golden data into data.h
-        # assert padded_data_in.shape == (padded_input_tensor_h, padded_input_tensor_w, kwargs["Cin"])
-        # assert padded_data_in.reshape(-1).shape[0] == input_data_len
-        # data_str += [format_vector_definition("int8_t", "DataIn", padded_data_in.reshape(-1))]
-
-        # assert c_golden.shape == (padded_output_tensor_h, padded_output_tensor_w, kwargs["Cin"])
-        # assert c_golden.reshape(-1).shape[0] == output_data_len
-
-        # data_str += [format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))]
-
-        # data_str = "\n\n".join(data_str)
-
+    elif kwargs['ifC8HW8datalayout'] == True:
         # data layout, C8HW8
         # Generating loop bounds settings
         padded_input_tensor_w = kwargs["W"] + kwargs["pad_w"] * 2
@@ -393,7 +293,7 @@ def emit_gemm_data(**kwargs):
         )
 
         # Generating golden data
-        c_golden = max_pooling_4d(
+        c_golden = max_pooling(
             data_in,
             kwargs["Kw"],
             kwargs["Kh"],
@@ -401,6 +301,7 @@ def emit_gemm_data(**kwargs):
             kwargs["stride_h"],
             kwargs["pad_w"],
             kwargs["pad_h"],
+            "C8HW8"
         )
 
         padded_data_in = np.pad(
@@ -440,6 +341,108 @@ def emit_gemm_data(**kwargs):
         data_str += [
             format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))
         ]
+
+        data_str = "\n\n".join(data_str)
+    else:
+        # data layout HWCin
+        # Generating loop bounds settings
+        padded_input_tensor_w = kwargs["W"] + kwargs["pad_w"] * 2
+        padded_input_tensor_h = kwargs["H"] + kwargs["pad_h"] * 2
+
+        padded_output_tensor_w = (
+            kwargs["W"] + kwargs["pad_w"] * 2 - kwargs["Kw"]
+        ) // kwargs["stride_w"] + 1
+        padded_output_tensor_h = (
+            kwargs["H"] + kwargs["pad_h"] * 2 - kwargs["Kh"]
+        ) // kwargs["stride_h"] + 1
+
+        input_data_len = padded_input_tensor_w * padded_input_tensor_h * kwargs["Cin"]
+        output_data_len = padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
+
+        assert padded_output_tensor_w == kwargs["W"]
+        assert padded_output_tensor_h == kwargs["H"]
+
+        data_str += [
+            # input data reshuffler loop bounds settings
+            format_scalar_definition("int8_t", "tempLoop0_in", kwargs["Kw"]),
+            format_scalar_definition("int8_t", "tempLoop1_in", kwargs["Kh"]),
+            format_scalar_definition(
+                "int8_t", "tempLoop2_in", kwargs["Cin"] // 8
+            ),
+            format_scalar_definition("int8_t", "tempLoop3_in", padded_output_tensor_w // 8),
+            format_scalar_definition("int8_t", "tempLoop4_in", padded_output_tensor_h),
+            # output data reshuffler loop bounds settings
+            format_scalar_definition(
+                "int8_t", "tempLoop0_out", kwargs["Cin"] // 8
+            ),
+            format_scalar_definition("int8_t", "tempLoop1_out", padded_output_tensor_w // 8),
+            format_scalar_definition("int8_t", "tempLoop2_out", padded_output_tensor_h),
+            # data length setting
+            format_scalar_definition("int32_t", "input_data_len", input_data_len),
+            format_scalar_definition("int32_t", "output_data_len", output_data_len),
+            format_scalar_definition("int32_t", "TloopLen", padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"] // 8 // 8),
+            format_scalar_definition("int32_t", "reduceLen", kwargs["Kw"] * kwargs["Kh"]),
+        ]
+
+        data_str += [
+            # data reshuffler input strides
+            format_scalar_definition("int32_t", "spatialStride1_in", kwargs["Cin"]),
+            format_scalar_definition(
+                "int32_t", "tempStride0_in", kwargs["stride_w"] * kwargs["Cin"]
+            ),
+            format_scalar_definition(
+                "int32_t", "tempStride1_in", padded_input_tensor_w * kwargs["Cin"]
+            ),
+            format_scalar_definition("int32_t", "tempStride2_in", 8),
+            format_scalar_definition("int32_t", "tempStride3_in", 8 * kwargs["Cin"]),
+            format_scalar_definition("int32_t", "tempStride4_in", padded_input_tensor_w * kwargs["Cin"]),
+            # data reshuffler output strides
+            format_scalar_definition("int32_t", "spatialStride1_out", kwargs["Cin"]),
+            format_scalar_definition("int32_t", "tempStride0_out", 8),
+            format_scalar_definition("int32_t", "tempStride1_out", 8 * kwargs["Cin"]),
+            format_scalar_definition("int32_t", "tempStride2_out", padded_output_tensor_w * kwargs["Cin"]),
+            # Generating base address pointers
+            format_scalar_definition(
+                "int32_t", "delta_local_in", 0
+            ),
+            format_scalar_definition(
+                "int32_t", "delta_local_out", padded_input_tensor_h * padded_input_tensor_w * kwargs["Cin"]
+            ),
+        ]
+
+        # Generating random input data vector
+        data_in = np.random.randint(MIN, MAX, (1, kwargs["H"], kwargs["W"], kwargs["Cin"]))
+
+        # Generating golden data
+        c_golden = max_pooling(
+            data_in,
+            kwargs["Kw"],
+            kwargs["Kh"],
+            kwargs["stride_w"],
+            kwargs["stride_h"],
+            kwargs["pad_w"],
+            kwargs["pad_h"],
+            "HWC"
+        )
+
+        padded_data_in = np.pad(
+            data_in,
+            ((0, 0), (kwargs["pad_h"], kwargs["pad_h"]), (kwargs["pad_w"], kwargs["pad_w"]), (0, 0)),
+            "constant",
+        )
+
+        # set opcode
+        data_str += [format_scalar_definition("int", "opcode", 2)]
+
+        # Writing testing data and golden data into data.h
+        assert padded_data_in.shape == (1, padded_input_tensor_h, padded_input_tensor_w, kwargs["Cin"])
+        assert padded_data_in.reshape(-1).shape[0] == input_data_len
+        data_str += [format_vector_definition("int8_t", "DataIn", padded_data_in.reshape(-1))]
+
+        assert c_golden.shape == (1, padded_output_tensor_h, padded_output_tensor_w, kwargs["Cin"])
+        assert c_golden.reshape(-1).shape[0] == output_data_len
+
+        data_str += [format_vector_definition("int8_t", "C_golden", c_golden.reshape(-1))]
 
         data_str = "\n\n".join(data_str)
 

--- a/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/params.hjson
@@ -5,6 +5,41 @@
 // Xiaoling Yi <xiaoling.yi@esat.kuleuven.be>
 
 {
+    // ifMaxPool: false,
+    ifMaxPool: true,
+
+    // parameters for maxpool
+    Nbatch: 1,
+    // works for HWC
+    // don't work for C8HW8
+    // H: 2,
+    // W: 24,
+    // Cin: 64,
+
+    // don't work for HWC
+    // same error as C8HW8
+    // H: 2,
+    // W: 8,
+    // Cin: 8,
+
+    // works for HWC
+    // work for C8HW8
+    // H: 1,
+    // W: 24,
+    // Cin: 64,
+
+    H: 32,
+    W: 32,
+    Cin: 8,
+    
+    Kh: 3,
+    Kw: 3,
+    pad_h: 1,
+    pad_w: 1,
+    stride_h: 1,
+    stride_w: 1,
+
+    // parameters for data layout reshuffling
     op: 'rowmajor2tiledrowmajor',
     tempLoop0: 8,
     tempLoop1: 8,

--- a/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/params.hjson
@@ -6,28 +6,13 @@
 
 {
     // ifMaxPool: false,
-    ifMaxPool: true,
+    // ifMaxPool: true,
+    ifMaxPool: false,
 
     // parameters for maxpool
+    // ifC8HW8datalayout: true,
+    ifC8HW8datalayout: false,
     Nbatch: 1,
-    // works for HWC
-    // don't work for C8HW8
-    // H: 2,
-    // W: 24,
-    // Cin: 64,
-
-    // don't work for HWC
-    // same error as C8HW8
-    // H: 2,
-    // W: 8,
-    // Cin: 8,
-
-    // works for HWC
-    // work for C8HW8
-    // H: 1,
-    // W: 24,
-    // Cin: 64,
-
     H: 32,
     W: 32,
     Cin: 8,

--- a/target/snitch_cluster/sw/snax/data-reshuffler/include/snax-data-reshuffler-lib.h
+++ b/target/snitch_cluster/sw/snax/data-reshuffler/include/snax-data-reshuffler-lib.h
@@ -15,16 +15,23 @@
 #define spatial_len (spatial_len_0 * spatial_len_1)
 
 // Set STREAMER configuration CSR
-void set_data_reshuffler_csr(int tempLoop0, int tempLoop1, int tempStride0_in,
-                             int tempStride1_in, int spatialStride1_in,
+void set_data_reshuffler_csr(int tempLoop0_in, int tempLoop1_in,
+                             int tempLoop2_in, int tempLoop3_in,
+                             int tempLoop4_in, int tempStride0_in,
+                             int tempStride1_in, int tempStride2_in,
+                             int tempStride3_in, int tempStride4_in,
+                             int spatialStride1_in, int tempLoop0_out,
+                             int tempLoop1_out, int tempLoop2_out,
                              int tempStride0_out, int tempStride1_out,
-                             int spatialStride1_out, int32_t delta_local_in,
-                             int32_t delta_local_out, bool transpose);
+                             int tempStride2_out, int spatialStride1_out,
+                             int32_t delta_local_in, int32_t delta_local_out);
 
 // Set CSR to start STREAMER
 void start_streamer();
 
 void wait_streamer();
+
+void set_data_reshuffler(int T2Len, int reduceLen, int opcode);
 
 void start_data_reshuffler();
 
@@ -42,3 +49,9 @@ uint32_t check_data_reshuffler_result(int tempLoop0, int tempLoop1,
                                       int spatialStride1,
                                       int8_t* base_ptr_local,
                                       int8_t* base_ptr_l2);
+
+void load_a_chrunk_of_data(int8_t* base_ptr_local, int8_t* base_ptr_l2,
+                           int len);
+
+uint32_t test_a_chrunk_of_data(int8_t* base_ptr_local, int8_t* base_ptr_l2,
+                               int len);

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -230,7 +230,14 @@ def postprocessing_simd_golden_model(
 
 
 def max_pooling(
-    input_tensor, pool_size_w, pool_size_h, stride_w, stride_h, padding_w, padding_h, mode = "HWC"
+    input_tensor,
+    pool_size_w,
+    pool_size_h,
+    stride_w,
+    stride_h,
+    padding_w,
+    padding_h,
+    mode="HWC",
 ):
 
     # if mode == "HWC", C8 is 1, C = realCin
@@ -238,6 +245,8 @@ def max_pooling(
     C8, H, W, C = input_tensor.shape
     if mode != "HWC":
         assert input_tensor.shape[3] == 8 and C == 8
+    elif mode == "HWC":
+        assert input_tensor.shape[0] == 1 and C8 == 1
 
     out_width = (W + 2 * padding_w - pool_size_w) // stride_w + 1
     out_height = (H + 2 * padding_h - pool_size_h) // stride_h + 1

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -229,44 +229,15 @@ def postprocessing_simd_golden_model(
     return var
 
 
-def max_pooling_3d(
-    input_tensor, pool_size_w, pool_size_h, stride_w, stride_h, padding_w, padding_h
+def max_pooling(
+    input_tensor, pool_size_w, pool_size_h, stride_w, stride_h, padding_w, padding_h, mode = "HWC"
 ):
 
-    H, W, C = input_tensor.shape
-
-    out_width = (W + 2 * padding_w - pool_size_w) // stride_w + 1
-    out_height = (H + 2 * padding_h - pool_size_h) // stride_h + 1
-
-    input_padded = np.pad(
-        input_tensor,
-        ((padding_h, padding_h), (padding_w, padding_w), (0, 0)),
-        mode="constant",
-        constant_values=0,
-    )
-
-    pooled_tensor = np.zeros((out_height, out_width, C), dtype=np.int8)
-
-    for i in range(out_height):
-        for j in range(out_width):
-            for k in range(C):
-                h_start = i * stride_h
-                h_end = h_start + pool_size_h
-                w_start = j * stride_w
-                w_end = w_start + pool_size_w
-                pooled_tensor[i, j, k] = np.max(
-                    input_padded[h_start:h_end, w_start:w_end, k]
-                )
-
-    return pooled_tensor
-
-
-def max_pooling_4d(
-    input_tensor, pool_size_w, pool_size_h, stride_w, stride_h, padding_w, padding_h
-):
-
-    C8, H, W, _ = input_tensor.shape
-    assert input_tensor.shape[3] == 8
+    # if mode == "HWC", C8 is 1, C = realCin
+    # if mode != "HWC", C8 is realCin/8, C = 8
+    C8, H, W, C = input_tensor.shape
+    if mode != "HWC":
+        assert input_tensor.shape[3] == 8 and C == 8
 
     out_width = (W + 2 * padding_w - pool_size_w) // stride_w + 1
     out_height = (H + 2 * padding_h - pool_size_h) // stride_h + 1
@@ -278,12 +249,12 @@ def max_pooling_4d(
         constant_values=0,
     )
 
-    pooled_tensor = np.zeros((C8, out_height, out_width, 8), dtype=np.int8)
+    pooled_tensor = np.zeros((C8, out_height, out_width, C), dtype=np.int8)
 
     for c in range(C8):
         for i in range(out_height):
             for j in range(out_width):
-                for k in range(8):
+                for k in range(C):
                     h_start = i * stride_h
                     h_end = h_start + pool_size_h
                     w_start = j * stride_w


### PR DESCRIPTION
In this PR, 
* we add the software test for max pool with two data layouts, namely HWC and C8WH8. 
* we also refactor the original data reshuffler test to accommodate with the max pool test together.
* replace the old data reshuffler with the new one in the bender