### PR TITLE
[WIP] Add lower bandwidth AXI switch

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -97,9 +97,7 @@ sources:
       - hw/future/src/idma_reg64_frontend_reg_pkg.sv
       - hw/future/src/idma_tf_id_gen.sv
       - hw/future/src/dma/axi_dma_data_path.sv
-      - hw/future/src/axi_interleaved_xbar.sv
       # Level 1
-      - hw/future/src/axi_zero_mem.sv
       - hw/future/src/idma_reg64_frontend_reg_top.sv
       # Level 2
       - hw/future/src/idma_reg64_frontend.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -97,7 +97,9 @@ sources:
       - hw/future/src/idma_reg64_frontend_reg_pkg.sv
       - hw/future/src/idma_tf_id_gen.sv
       - hw/future/src/dma/axi_dma_data_path.sv
+      - hw/future/src/axi_interleaved_xbar.sv
       # Level 1
+      - hw/future/src/axi_zero_mem.sv
       - hw/future/src/idma_reg64_frontend_reg_top.sv
       # Level 2
       - hw/future/src/idma_reg64_frontend.sv

--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -154,6 +154,16 @@
             "propertyNames": { "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
             "additionalProperties": { "type": "number", "minimum": 1 }
         },
+        "use_ax_bw_converter": {
+            "type": "boolean",
+            "description": "Enable lower bandwidth switch.",
+            "default": false
+        },
+        "converted_axi_bandwidth": {
+            "type": "number",
+            "description": "Effective bandwidth of the converted AXI ports.",
+            "default": 256
+        },
         "timing": {
             "type": "object",
             "title": "Timing and Latency Tuning Parameter",

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -352,7 +352,6 @@ module ${cfg['name']}_wrapper (
   // Convert input port
   // From AXI port to cluster 
   axi_dw_converter #(
-    .AxiMaxReads         ( ${cfg['wide_trans']}                       ), // Number of outstanding reads
     .AxiSlvPortDataWidth ( ${cfg['pkg_name']}::LowBWWideDataWidth     ), // Data width of the slv port
     .AxiMstPortDataWidth ( ${cfg['pkg_name']}::WideDataWidth          ), // Data width of the mst port
     .AxiAddrWidth        ( ${cfg['pkg_name']}::AddrWidth              ), // Address width
@@ -382,7 +381,6 @@ module ${cfg['name']}_wrapper (
   // Convert output ports
   // From cluster to AXI port
   axi_dw_converter #(
-    .AxiMaxReads         ( ${cfg['wide_trans']}                         ), // Number of outstanding reads
     .AxiSlvPortDataWidth ( ${cfg['pkg_name']}::WideDataWidth            ), // Data width of the slv port
     .AxiMstPortDataWidth ( ${cfg['pkg_name']}::LowBWWideDataWidth       ), // Data width of the mst port
     .AxiAddrWidth        ( ${cfg['pkg_name']}::AddrWidth                ), // Address width
@@ -408,6 +406,7 @@ module ${cfg['name']}_wrapper (
     .mst_req_o           ( wide_out_req_o  ),
     .mst_resp_i          ( wide_out_resp_i )
   );
+  
 % endif
 
 <%

--- a/hw/templates/testharness.sv.tpl
+++ b/hw/templates/testharness.sv.tpl
@@ -17,10 +17,25 @@ module testharness import ${cfg["cluster"]["name"]}_pkg::*; (
   narrow_in_resp_t  narrow_in_resp;
   narrow_out_req_t  narrow_out_req;
   narrow_out_resp_t narrow_out_resp;
+% if 'use_ax_bw_converter' in cfg['cluster']:
+  % if cfg['cluster']['use_ax_bw_converter']:
+  lowbw_wide_out_req_t  wide_out_req;
+  lowbw_wide_out_resp_t wide_out_resp;
+  lowbw_wide_in_req_t   wide_in_req;
+  lowbw_wide_in_resp_t  wide_in_resp;
+  % else:
   wide_out_req_t    wide_out_req;
   wide_out_resp_t   wide_out_resp;
   wide_in_req_t     wide_in_req;
   wide_in_resp_t    wide_in_resp;
+  % endif
+% else:
+  wide_out_req_t    wide_out_req;
+  wide_out_resp_t   wide_out_resp;
+  wide_in_req_t     wide_in_req;
+  wide_in_resp_t    wide_in_resp;
+% endif
+ 
 
   logic [${cfg["cluster"]["name"]}_pkg::NrCores-1:0] msip;
 
@@ -69,8 +84,18 @@ module testharness import ${cfg["cluster"]["name"]}_pkg::*; (
     .AxiDataWidth ( WideDataWidth   ),
     .AxiIdWidth   ( WideIdWidthOut  ),
     .AxiUserWidth ( WideUserWidth   ),
+% if 'use_ax_bw_converter' in cfg['cluster']:
+  % if cfg['cluster']['use_ax_bw_converter']:
+    .req_t        ( lowbw_wide_out_req_t  ),
+    .rsp_t        ( lowbw_wide_out_resp_t )
+  % else:
     .req_t        ( wide_out_req_t  ),
     .rsp_t        ( wide_out_resp_t )
+  % endif
+% else:
+    .req_t        ( wide_out_req_t  ),
+    .rsp_t        ( wide_out_resp_t )
+% endif
   ) i_dma (
     .clk_i        ( clk_i           ),
     .rst_ni       ( rst_ni          ),

--- a/hw/templates/testharness.sv.tpl
+++ b/hw/templates/testharness.sv.tpl
@@ -81,7 +81,15 @@ module testharness import ${cfg["cluster"]["name"]}_pkg::*; (
   // Wide port into simulation memory.
   tb_memory_axi #(
     .AxiAddrWidth ( AddrWidth       ),
+% if 'use_ax_bw_converter' in cfg['cluster']:
+  % if cfg['cluster']['use_ax_bw_converter']:
+    .AxiDataWidth ( LowBWWideDataWidth ),
+  % else:
     .AxiDataWidth ( WideDataWidth   ),
+  % endif
+% else:
+    .AxiDataWidth ( WideDataWidth   ),
+% endif
     .AxiIdWidth   ( WideIdWidthOut  ),
     .AxiUserWidth ( WideUserWidth   ),
 % if 'use_ax_bw_converter' in cfg['cluster']:

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -27,7 +27,7 @@
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,
         // AXI bandwidth switcher
-        use_ax_bw_converter: false,
+        use_ax_bw_converter: true,
         converted_axi_bandwidth: 256,
         // Timing parameters
         timing: {

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -26,6 +26,9 @@
         dma_data_width: 512,
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,
+        // AXI bandwidth switcher
+        use_ax_bw_converter: false,
+        converted_axi_bandwidth: 256,
         // Timing parameters
         timing: {
             lat_comp_fp32: 3,

--- a/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
@@ -26,6 +26,9 @@
         dma_data_width: 512,
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,
+        // AXI bandwidth switcher
+        use_ax_bw_converter: true,
+        converted_axi_bandwidth: 256,
         // Timing parameters
         timing: {
             lat_comp_fp32: 3,

--- a/target/snitch_cluster/cfg/snax-streamer-gemmX.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemmX.hjson
@@ -26,6 +26,9 @@
         dma_data_width: 512,
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,
+        // AXI bandwidth switcher
+        use_ax_bw_converter: true,
+        converted_axi_bandwidth: 256,
         // Timing parameters
         timing: {
             lat_comp_fp32: 3,


### PR DESCRIPTION
This PR caters to the requirements for the CONVOLVE tapeout.

We add a switch to lower the AXI bandwidth but maintain the high bandwidth connection within each cluster.

Major TODOs:
- [x] Update cluster wrapper template and instantiate the converter at this level
- [x] Update test harness to cater to lower bandwidth
- [x] Updates schema doc configuration to set default values
- [ ] Provide CI to check if it still works