### PR TITLE
prepare for ubuntu & llvm bump

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -52,7 +52,7 @@ VCS_BUILDDIR := work-vcs
 
 # fesvr is being installed here
 FESVR         ?= ${MKFILE_DIR}work
-FESVR_VERSION ?= 35d50bc40e59ea1d5566fbd3d9226023821b1bb6
+FESVR_VERSION ?= 98d2c29e431f3b14feefbda48c5f70c2f451acf2
 
 VLT_BENDER   += -t rtl
 VLT_SOURCES   = $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -75,7 +75,7 @@ VLT_FLAGS    += --unroll-count 1024
 ifeq ($(VERILATOR_VERSION), 5)
 	VLT_CXXSTD_FLAGS += -std=c++20 -pthread -latomic
 else 
-	VLT_CXXSTD_FLAGS += -std=c++14 -pthread
+	VLT_CXXSTD_FLAGS += -std=c++17 -pthread
 endif
 VLT_CFLAGS   += ${VLT_CXXSTD_FLAGS} -I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -278,7 +278,7 @@ TB_CC_SOURCES += \
 	$(GENERATED_DIR)/bootdata.cc
 
 TB_CC_FLAGS += \
-	-std=c++14 \
+	-std=c++17 \
 	-I${MKFILE_DIR}/test \
 	-I${FESVR}/include \
 	-I${TB_DIR}

--- a/target/snitch_cluster/sw/toolchain.mk
+++ b/target/snitch_cluster/sw/toolchain.mk
@@ -22,7 +22,7 @@ LLVM_BINROOT    = /tools/riscv-llvm/bin
 LLVM_VERSION    = 
 else
 LLVM_BINROOT    = /usr/bin
-LLVM_VERSION    = -17
+LLVM_VERSION    =
 endif
 RISCV_CC        ?= $(LLVM_BINROOT)/clang$(LLVM_VERSION)
 RISCV_LD        ?= $(LLVM_BINROOT)/ld.lld$(LLVM_VERSION)


### PR DESCRIPTION
FESVR version must be bumped to be compatible with new version of gcc: riscv-software-src/riscv-isa-sim#1284
llvm will be upgraded as well, I removed the version as symbolic links from llvm -> llvm-18 are placed by the container itself