### PR TITLE
xdma Datapath and its Extension interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,10 @@ jobs:
         working-directory: hw/chisel
         run: |-
           sbt "testOnly snax.xdma.xdmaStreamer.*"
+      - name: Test xdma DataPath
+        working-directory: hw/chisel
+        run: |-
+          sbt "testOnly snax.xdma.xdmaFrontend.DMADataPathTester"
 
   ############################################
   # Build SW on Snitch Cluster w/ Banshee #

--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/ComplexQueue.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/ComplexQueue.scala
@@ -94,8 +94,8 @@ class ComplexQueueConcat(inputWidth: Int, outputWidth: Int, depth: Int)
   * params include:
   * @param dataType:
   *   the type of one channel
-  * @param N
-  *
+  * @param N:
+  *   the number of seperated channels at the input
   * @param depth:
   *   the depth of the FIFO If inputWidth is smaller than outputWidth, then it
   *   will be the first option If inputWidth is larger than outputWidth, then it

--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/CustomOperators.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/CustomOperators.scala
@@ -1,0 +1,64 @@
+package snax.xdma.CommonCells
+
+import chisel3._
+import chisel3.util._
+import chisel3.reflect.DataMirror
+import chisel3.internal.throwException
+import chisel3.internal.throwException
+
+/** The definition of <|> connector for decoupled signal It automatically
+  * determine the signal direction, connect leftward Decoupled signal and
+  * rightward Decoupled signal \ and insert one level of pipeline in between to
+  * avoid long combinatorial datapath
+  */
+object DecoupledCut {
+  implicit class BufferedDecoupledConnectionOp[T <: Data](
+      val left: DecoupledIO[T]
+  ) {
+    // This class defines the implicit class for the new operand -|>,-||>, -|||> for DecoupleIO
+
+    def -|>(
+        right: DecoupledIO[T]
+    )(implicit sourceInfo: chisel3.experimental.SourceInfo): Unit = {
+      val buffer = Module(
+        new Queue(chiselTypeOf(left.bits), entries = 1, pipe = false)
+      )
+      buffer.suggestName("cut1")
+
+      left <> buffer.io.enq
+      buffer.io.deq <> right
+    }
+
+    def -||>(
+        right: DecoupledIO[T]
+    )(implicit sourceInfo: chisel3.experimental.SourceInfo): Unit = {
+      val buffer = Module(
+        new Queue(chiselTypeOf(left.bits), entries = 2, pipe = false)
+      )
+      buffer.suggestName("cut2")
+      left <> buffer.io.enq
+      buffer.io.deq <> right
+    }
+
+    def -|||>(
+        right: DecoupledIO[T]
+    )(implicit sourceInfo: chisel3.experimental.SourceInfo): Unit = {
+      val buffer = Module(
+        new Queue(chiselTypeOf(left.bits), entries = 3, pipe = false)
+      )
+      buffer.suggestName("cut3")
+      left <> buffer.io.enq
+      buffer.io.deq <> right
+    }
+  }
+}
+
+object BitsConcat {
+  implicit class UIntConcatOp[T <: Bits](val left: T) {
+    // This class defines the implicit class for the new operand ++ for UInt
+    def ++(
+        right: T
+    )(implicit sourceInfo: chisel3.experimental.SourceInfo): T =
+      Cat(left, right).asInstanceOf[T]
+  }
+}

--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/CustomOperators.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/CustomOperators.scala
@@ -6,10 +6,10 @@ import chisel3.reflect.DataMirror
 import chisel3.internal.throwException
 import chisel3.internal.throwException
 
-/** The definition of <|> connector for decoupled signal It automatically
-  * determine the signal direction, connect leftward Decoupled signal and
-  * rightward Decoupled signal \ and insert one level of pipeline in between to
-  * avoid long combinatorial datapath
+/** The definition of -|> / -||> / -|||> connector for decoupled signal it
+  * connects leftward Decoupled signal (Decoupled port) and rightward Decoupled
+  * signal (Flipped port); and insert one level of pipeline in between to avoid
+  * long combinatorial datapath
   */
 object DecoupledCut {
   implicit class BufferedDecoupledConnectionOp[T <: Data](

--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/MuxDemuxDecoupled.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/MuxDemuxDecoupled.scala
@@ -1,0 +1,54 @@
+package snax.xdma.CommonCells
+
+import chisel3._
+import chisel3.util._
+
+/** The 1in, N-out Demux for Decoupled signal As the demux is the 1in, 2out
+  * system, we don't need to consider the demux of bits
+  */
+class DemuxDecoupled[T <: Data](dataType: T, numOutput: Int)
+    extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    val in = Flipped(Decoupled(dataType))
+    val out = Vec(numOutput, Decoupled(dataType))
+    val sel = Input(UInt(log2Ceil(numOutput).W))
+  })
+  // Default assigns
+  io.in.ready := false.B
+  // Demux logic
+  for (i <- 0 until numOutput) {
+    io.out(i).bits := io.in.bits
+    when(io.sel === i.U) {
+      io.out(i).valid := io.in.valid
+      io.in.ready := io.out(i).ready
+    } otherwise {
+      io.out(i).valid := false.B // Unselected output should not be valid
+    }
+  }
+}
+
+/** The N-in, 1out Demux for Decoupled signal
+  */
+class MuxDecoupled[T <: Data](dataType: T, numInput: Int)
+    extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    val in = Vec(numInput, Flipped(Decoupled(dataType)))
+    val out = Decoupled(dataType)
+    val sel = Input(UInt(log2Ceil(numInput).W))
+  })
+  // Default assigns
+  io.out.valid := false.B
+  io.out.bits := 0.U
+  // Mux logic
+  for (i <- 0 until numInput) {
+    when(io.sel === i.U) {
+      io.out.valid := io.in(i).valid
+      io.in(i).ready := io.out.ready
+      io.out.bits := io.in(i).bits
+    } otherwise {
+      io.in(i).ready := false.B // Unselected input should not be ready
+    }
+  }
+}

--- a/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
@@ -1,6 +1,7 @@
 package snax.xdma.DesignParams
 
 import chisel3.util.log2Up
+import snax.xdma.xdmaExtension._
 
 /*
  *  This is the collection of all design Params
@@ -85,13 +86,12 @@ class ReaderWriterParam(
 }
 
 // DMA Params
-// import snax.xdma.xdmaExtension._
-// class DMADataPathParam(
-//     val rwParam: ReaderWriterParam,
-//     // val writerparam: ReaderWriterParam,
-//     val extParam: Seq[HasDMAExtension] = Seq[HasDMAExtension]()
-//     // val writerext: Seq[DMAExtension] = Seq[DMAExtension]()
-// )
+class DMADataPathParam(
+    val rwParam: ReaderWriterParam,
+    // val writerparam: ReaderWriterParam,
+    val extParam: Seq[HasDMAExtension] = Seq[HasDMAExtension]()
+    // val writerext: Seq[DMAExtension] = Seq[DMAExtension]()
+)
 
 class DMAExtensionParam(
     val moduleName: String,

--- a/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
@@ -88,9 +88,7 @@ class ReaderWriterParam(
 // DMA Params
 class DMADataPathParam(
     val rwParam: ReaderWriterParam,
-    // val writerparam: ReaderWriterParam,
     val extParam: Seq[HasDMAExtension] = Seq[HasDMAExtension]()
-    // val writerext: Seq[DMAExtension] = Seq[DMAExtension]()
 )
 
 class DMAExtensionParam(

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/DMAExtension.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/DMAExtension.scala
@@ -1,0 +1,96 @@
+package snax.xdma.xdmaExtension
+
+import chisel3._
+import chisel3.util._
+
+import snax.utils._
+import snax.xdma.CommonCells._
+import snax.xdma.DesignParams._
+
+/** The parent (abstract) Class for the DMA Extension Generation Params This
+  * class template is used to isolate the definition of class (when user provide
+  * the parameters) and the actual instantiation of Module, and allow other
+  * module to read some information about the Extension before the instantiation
+  * The idea is similar to Rocketchip's LazyModule and LazyModuleImp.
+  *
+  * Usage: 1) For every custom extension "CustomExtension", an object
+  * "HasCustomExtension" should be declared, extending from HasDMAExtension. 2)
+  * \@extensionParam, or basic parameters consumed by DMAExtension parent class
+  * needs to be provided 3) The instantiate method of the module needs to be
+  * provided
+  */
+
+abstract class HasDMAExtension {
+  implicit val extensionParam: DMAExtensionParam
+
+  def totalCsrNum = extensionParam.userCsrNum + 1
+  def instantiate: DMAExtension
+}
+
+/** The parent (abstract) Class for the DMA Extension Implementation (Circuit)
+  * All classes need to extends from this parent class like below: class
+  * CustomModule(userParams)(implicit extensionParam: DMAExtensionParam) extends
+  * DMAExtension Inside the body of CustomModule, the following thing must be
+  * done: 1) Connect ext_data_i to your module's datapath input: ext_data_i <>
+  * userDefinedInput 2) Connect ext_data_o to your module's datapath output:
+  * ext_data_o <> userDefinedOutput 3) Connect CSR to your module <>
+  * userDefinedCSR := ext_csr_i 4) Connect Start signal: userDefinedStart :=
+  * ext_start_i. The start signal is used to inform extension a new stream is
+  * coming 5) Connect Busy signal: ext_busy_o := userDefinedBusy. As the
+  * extension does not know the length of the stream, the extension should pull
+  * down the signal when there is data under processing
+  */
+
+abstract class DMAExtension(implicit extensionParam: DMAExtensionParam)
+    extends Module
+    with RequireAsyncReset {
+
+  override def desiredName: String = extensionParam.moduleName
+
+  val io = IO(new Bundle {
+    val csr_i = Input(
+      Vec(extensionParam.userCsrNum + 1, UInt(32.W))
+    ) // CSR with the first one always byPass signal
+    val start_i = Input(
+      Bool()
+    ) // The start signal triggers the local register to buffer the csr information
+    val data_i = Flipped(Decoupled(UInt(extensionParam.dataWidth.W)))
+    val data_o = Decoupled(UInt(extensionParam.dataWidth.W))
+    val busy_o = Output(Bool())
+  })
+
+  private[this] val bypass = io.csr_i.head(0)
+  private[this] val bypass_data = Wire(
+    Decoupled(UInt(extensionParam.dataWidth.W))
+  )
+
+  // Signals under user's namespace
+  val ext_data_i = Wire(Decoupled(UInt(extensionParam.dataWidth.W)))
+  val ext_data_o = Wire(Decoupled(UInt(extensionParam.dataWidth.W)))
+  val ext_csr_i = io.csr_i.tail
+  val ext_start_i = io.start_i
+  val ext_busy_o = Wire(Bool())
+  io.busy_o := ext_busy_o || ext_data_i.valid
+
+  // Structure to bypass extension: Demux
+  private[this] val inputDemux = Module(
+    new DemuxDecoupled(UInt(extensionParam.dataWidth.W), numOutput = 2)
+  )
+  inputDemux.io.sel := bypass
+  inputDemux.io.in <> io.data_i
+  // When bypass is 0, io.out(0) is connected with extension's input
+  inputDemux.io.out(0) <> ext_data_i
+  // When bypass is 1, io.out(1) is connected to bypass signal
+  inputDemux.io.out(1) <> bypass_data
+
+  // Structure to bypass extension: Mux
+  private[this] val outputMux = Module(
+    new MuxDecoupled(UInt(extensionParam.dataWidth.W), numInput = 2)
+  )
+  outputMux.io.sel := bypass
+  outputMux.io.out <> io.data_o
+  // When bypass is 0, io.in(0) is connected with extension's output
+  outputMux.io.in(0) <> ext_data_o
+  // When bypass is 1, io.in(1) is connected to bypass signal
+  outputMux.io.in(1) <> bypass_data
+}

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
@@ -208,7 +208,6 @@ class DMADataPath(readerparam: DMADataPathParam, writerparam: DMADataPathParam)
     i_reader_extentionList.foreach { i => i.io.start_i := io.reader_start_i }
 
     // Connect Data
-    // The new <|> operator to implement a Decoupled Signal Cut in between the connection <> had been implemented, but haven't go through the detailed test. Shall we provide this function to the user?
     i_reader.io.data <> i_reader_extentionList.head.io.data_i
     i_reader_extentionList.last.io.data_o <> reader_data_after_extension
     if (i_reader_extentionList.length > 1)
@@ -307,7 +306,7 @@ class DMADataPath(readerparam: DMADataPathParam, writerparam: DMADataPathParam)
   writerMux.io.sel := io.writer_cfg_i.loopBack
   reader_data_after_extension <> readerDemux.io.in
   writerMux.io.out <> writer_data_before_extension
-  // Why there is a problem?
+
   readerDemux.io.out(1) <> writerMux.io.in(1)
   readerDemux.io.out(0) <> io.remoteDMADataPath.toRemote
   writerMux.io.in(0) <> io.remoteDMADataPath.fromRemote
@@ -315,7 +314,7 @@ class DMADataPath(readerparam: DMADataPathParam, writerparam: DMADataPathParam)
 
 // Below is the class to determine if chisel generate Verilog correctly
 
-object DMADataPath_SystemVerilogEmitter extends App {
+object DMADataPathEmitter extends App {
   println(
     getVerilogString(
       new DMADataPath(
@@ -326,31 +325,6 @@ object DMADataPath_SystemVerilogEmitter extends App {
         writerparam = new DMADataPathParam(
           rwParam = new ReaderWriterParam,
           extParam = Seq()
-        )
-      )
-    )
-  )
-}
-
-class Serializer_Deserializer_Tester(param: DMADataPathParam) extends Module {
-  val io = IO(new Bundle {
-    val in = Input(new DMADataPathCfgIO(param))
-    val out_serialized = Output(UInt(512.W))
-    val out = Output(new DMADataPathCfgIO(param))
-  })
-
-  io.out_serialized := io.in.serialize()
-  val out = Wire(new DMADataPathCfgIO(param))
-  out.deserialize(io.out_serialized)
-  io.out := out
-}
-
-object Serializer_Deserializer_Tester_SystemVerilogEmitter extends App {
-  println(
-    getVerilogString(
-      new Serializer_Deserializer_Tester(
-        new DMADataPathParam(
-          rwParam = new ReaderWriterParam
         )
       )
     )

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
@@ -1,0 +1,358 @@
+package snax.xdma.xdmaFrontend
+
+import chisel3._
+import chisel3.util._
+
+import snax.utils._
+
+import snax.xdma.CommonCells.DecoupledCut._
+import snax.xdma.CommonCells.BitsConcat._
+
+import snax.xdma.xdmaStreamer._
+import snax.xdma.CommonCells._
+import snax.xdma.DesignParams._
+
+// The ReaderWriterCfg Class that used for interface between local Datapath and DMA Ctrl
+class DMADataPathCfgIO(param: DMADataPathParam) extends Bundle {
+  val agu_cfg =
+    new AddressGenUnitCfgIO(param =
+      param.rwParam.agu_param
+    ) // Buffered within AGU
+  val ext_cfg = if (param.extParam.length != 0) {
+    Vec(
+      param.extParam.map { i => i.totalCsrNum }.reduce(_ + _),
+      UInt(32.W)
+    ) // Buffered within Extension Base Module
+  } else Vec(0, UInt(32.W))
+
+  // The config forwarding technics is easy to be implemented: Just by reading agu_cfg.Ptr, the destination can be determined
+  // However, the data forwarding is still challenging: Shall we use the current DMA to move the data? (I suggest that we do this in the initial implementation)
+  // Serialize function to convert config into one long UInt
+  def serialize(): UInt = {
+    ext_cfg.asUInt ++ agu_cfg.Bounds.asUInt ++ agu_cfg.Strides.asUInt ++ agu_cfg.Ptr
+  }
+
+  // Deserialize function to convert long UInt back to config
+  // The conversion is done from LSB to MSB
+  // After the conversion, the remaining data is returned for further conversion
+  def deserialize(data: UInt): UInt = {
+    var remainingData = data
+
+    // Assigning Ptr
+    agu_cfg.Ptr := remainingData(agu_cfg.Ptr.getWidth - 1, 0)
+    remainingData =
+      remainingData(remainingData.getWidth - 1, agu_cfg.Ptr.getWidth)
+
+    // Assigning Strides
+    agu_cfg.Strides := remainingData(agu_cfg.Strides.asUInt.getWidth - 1, 0)
+      .asTypeOf(agu_cfg.Strides)
+    remainingData =
+      remainingData(remainingData.getWidth - 1, agu_cfg.Strides.asUInt.getWidth)
+
+    // Assigning Bounds
+    agu_cfg.Bounds := remainingData(agu_cfg.Strides.asUInt.getWidth - 1, 0)
+      .asTypeOf(agu_cfg.Bounds)
+    remainingData =
+      remainingData(remainingData.getWidth - 1, agu_cfg.Bounds.asUInt.getWidth)
+
+    // Assigning ext_cfg
+    ext_cfg := remainingData(ext_cfg.asUInt.getWidth - 1, 0).asTypeOf(ext_cfg)
+    remainingData =
+      remainingData(remainingData.getWidth - 1, ext_cfg.asUInt.getWidth)
+    remainingData
+  }
+}
+
+// The internal sturctured class that used to store the CFG of reader and writer
+// The serialized version of this class will be the actual output and input of the DMACtrl (which is to AXI)
+// It is the ReaderWriterCfg class, with loopBack signal (early judgement) and Ptr of the opposite side (So that the Data can be forwarded to the remote side)
+class DMADataPathCfgInternalIO(param: DMADataPathParam)
+    extends DMADataPathCfgIO(param: DMADataPathParam) {
+  val loopBack = Bool()
+  val oppositePtr = UInt(param.rwParam.tcdm_param.addrWidth.W)
+  override def serialize(): UInt = {
+    super.serialize() ++ oppositePtr
+  }
+
+  override def deserialize(data: UInt): UInt = {
+    var remainingData = data;
+
+    // Assigning oppositePtr
+    oppositePtr := remainingData(oppositePtr.getWidth - 1, 0)
+    remainingData =
+      remainingData(remainingData.getWidth - 1, oppositePtr.getWidth)
+
+    // Assigning loopBack
+    loopBack := false.B
+
+    // Assigning remaining wires
+    remainingData = super.deserialize(remainingData)
+    remainingData
+  }
+
+}
+
+class DMADataPath(readerparam: DMADataPathParam, writerparam: DMADataPathParam)
+    extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    // All config signal for reader and writer
+    val reader_cfg_i = Input(new DMADataPathCfgInternalIO(readerparam))
+    val writer_cfg_i = Input(new DMADataPathCfgInternalIO(writerparam))
+
+    // Two start signal will inform the new cfg is available, trigger agu, and inform all extension that a stream is coming
+    val reader_start_i = Input(Bool())
+    val writer_start_i = Input(Bool())
+    // Two busy signal only go down if a stream fully passthrough the reader / writter.
+    // reader_busy_o signal == 0 indicates that the reader side is available for next task
+    val reader_busy_o = Output(Bool())
+    // writer_busy_o signal == 0 indicates that the writer side is available for next task
+    val writer_busy_o = Output(Bool())
+
+    // TCDM request and response signal
+    val tcdm_reader = new Bundle {
+      val req = Vec(
+        readerparam.rwParam.tcdm_param.numChannel,
+        Decoupled(
+          new TcdmReq(
+            readerparam.rwParam.tcdm_param.addrWidth,
+            readerparam.rwParam.tcdm_param.dataWidth
+          )
+        )
+      )
+      val rsp = Vec(
+        readerparam.rwParam.tcdm_param.numChannel,
+        Flipped(
+          Valid(
+            new TcdmRsp(tcdmDataWidth =
+              readerparam.rwParam.tcdm_param.dataWidth
+            )
+          )
+        )
+      )
+    }
+    val tcdm_writer = new Bundle {
+      val req = Vec(
+        writerparam.rwParam.tcdm_param.numChannel,
+        Decoupled(
+          new TcdmReq(
+            writerparam.rwParam.tcdm_param.addrWidth,
+            writerparam.rwParam.tcdm_param.dataWidth
+          )
+        )
+      )
+    }
+
+    // The data for the cluster-level in/out
+    // Cluster-level input <> Writer
+    // Cluster-level output <> Reader
+    val remoteDMADataPath = new Bundle {
+      val fromRemote = Flipped(
+        Decoupled(
+          UInt(
+            (writerparam.rwParam.tcdm_param.dataWidth * writerparam.rwParam.tcdm_param.numChannel).W
+          )
+        )
+      )
+      val toRemote =
+        Decoupled(
+          UInt(
+            (writerparam.rwParam.tcdm_param.dataWidth * writerparam.rwParam.tcdm_param.numChannel).W
+          )
+        )
+    }
+  })
+
+  val i_reader = Module(new Reader(readerparam.rwParam))
+  val i_writer = Module(new Writer(writerparam.rwParam))
+
+  // Connect TCDM memory to reader and writer
+  i_reader.io.tcdm_req <> io.tcdm_reader.req
+  i_reader.io.tcdm_rsp <> io.tcdm_reader.rsp
+  i_writer.io.tcdm_req <> io.tcdm_writer.req
+
+  // Connect the wire (ctrl plane)
+  i_reader.io.cfg := io.reader_cfg_i.agu_cfg
+  i_reader.io.start := io.reader_start_i
+  // reader_busy_o is connected later as the busy signal from the signal is needed
+
+  i_writer.io.cfg := io.writer_cfg_i.agu_cfg
+  i_writer.io.start := io.writer_start_i
+  // writer_busy_o is connected later as the busy signal from the signal is needed
+
+  // Connect the extension
+  // Reader Side
+  val reader_data_after_extension = Wire(chiselTypeOf(i_reader.io.data))
+
+  // No extension is provided, the reader.io.data is directly connected to the out
+  if (readerparam.extParam.length == 0) {
+    i_reader.io.data <> reader_data_after_extension
+    io.reader_busy_o := i_reader.io.busy | (~i_reader.io.bufferEmpty)
+  } else {
+    // There is some extension available: connect them
+    // Connect CSR interface
+    var remainingCSR =
+      io.reader_cfg_i.ext_cfg.toIndexedSeq // Give an alias to all extension's csr for a easier manipulation
+    val i_reader_extentionList = for (i <- readerparam.extParam) yield {
+      val extension = i.instantiate
+      extension.io.csr_i := remainingCSR.take(extension.io.csr_i.length)
+      remainingCSR = remainingCSR.drop(extension.io.csr_i.length)
+      extension
+    }
+    if (remainingCSR.length != 0)
+      println(
+        "Debug: Some remaining CSRs are unconnected at reader. Check the code. "
+      )
+
+    // Connect Start signal
+    i_reader_extentionList.foreach { i => i.io.start_i := io.reader_start_i }
+
+    // Connect Data
+    // The new <|> operator to implement a Decoupled Signal Cut in between the connection <> had been implemented, but haven't go through the detailed test. Shall we provide this function to the user?
+    i_reader.io.data <> i_reader_extentionList.head.io.data_i
+    i_reader_extentionList.last.io.data_o <> reader_data_after_extension
+    if (i_reader_extentionList.length > 1)
+      i_reader_extentionList.zip(i_reader_extentionList.tail).foreach {
+        case (a, b) =>
+          a.io.data_o -||> b.io.data_i
+      }
+
+    // Connect busy
+    // Reader side is busy if reader is busy (addressgen is busy or addressgen fifo is non-empty) or data fifo is non-empty or any extension is busy
+    // TODO: Is it better to implement a counter at the end of readerpath / at the beginning of writerpath to ensure all the data flows through the datapath?
+    io.reader_busy_o := i_reader.io.busy | (~i_reader.io.bufferEmpty) | (i_reader_extentionList
+      .map { _.io.busy_o }
+      .reduce(_ | _))
+
+    // Suggest a name for each extension
+    for (i <- 0 until i_reader_extentionList.length)
+      i_reader_extentionList(i)
+        .suggestName(
+          "reader_ext_" + i.toString() + "_" + readerparam
+            .extParam(i)
+            .extensionParam
+            .moduleName
+        )
+
+  }
+
+  // Writer side
+  val writer_data_before_extension = Wire(chiselTypeOf(i_writer.io.data))
+
+  // No extension is provided, the writer_data_before_extension is directly connected to the writer.io.data
+  if (writerparam.extParam.length == 0) {
+    writer_data_before_extension <> i_writer.io.data
+    io.writer_busy_o := i_writer.io.busy | (~i_writer.io.bufferEmpty)
+  } else {
+    // There is some extension available: connect them
+    // Connect CSR interface
+    var remainingCSR =
+      io.writer_cfg_i.ext_cfg.toIndexedSeq // Give an alias to all extension's csr for a easier manipulation
+    val i_writer_extentionList = for (i <- writerparam.extParam) yield {
+      val extension = i.instantiate
+      extension.io.csr_i := remainingCSR.take(extension.io.csr_i.length)
+      remainingCSR = remainingCSR.drop(extension.io.csr_i.length)
+      extension
+    }
+    if (remainingCSR.length != 0)
+      println(
+        "Debug: Some remaining CSRs are unconnected at writer. Check the XDMA Extension that number of CSRs in config file is coherent with number of CSRs required in the actually instantiated module. "
+      )
+
+    // Connect Start signal
+    i_writer_extentionList.foreach { i => i.io.start_i := io.reader_start_i }
+
+    // Connect Data
+    // The new -|[||]> operator to implement a Decoupled Signal Cut had been implemented, and used in between each extension.
+    writer_data_before_extension <> i_writer_extentionList.head.io.data_i
+    i_writer_extentionList.last.io.data_o <> i_writer.io.data
+    if (i_writer_extentionList.length > 1)
+      i_writer_extentionList.zip(i_writer_extentionList.tail).foreach {
+        case (a, b) =>
+          a.io.data_o -||> b.io.data_i
+      }
+
+    // Connect busy
+    // Writer side is busy if writer is busy (addressgen is busy or addressgen fifo is non-empty) or data fifo is non-empty or any extension is busy
+    io.writer_busy_o := i_writer.io.busy | (~i_writer.io.bufferEmpty) | (i_writer_extentionList
+      .map { _.io.busy_o }
+      .reduce(_ | _))
+
+    // Suggest a name for each extension
+    for (i <- 0 until i_writer_extentionList.length)
+      i_writer_extentionList(i)
+        .suggestName(
+          "writer_ext_" + i.toString() + "_" + writerparam
+            .extParam(i)
+            .extensionParam
+            .moduleName
+        )
+  }
+
+  // The following code only tackle with reader_data_after_extension and writer_data_before_extension: they should be either loopbacked or forwarded to the external interface (cluster_data_i / cluster_data_o)
+  val readerDemux = Module(
+    new DemuxDecoupled(
+      chiselTypeOf(reader_data_after_extension.bits),
+      numOutput = 2
+    )
+  )
+  val writerMux = Module(
+    new MuxDecoupled(
+      chiselTypeOf(writer_data_before_extension.bits),
+      numInput = 2
+    )
+  )
+
+  readerDemux.io.sel := io.reader_cfg_i.loopBack
+  writerMux.io.sel := io.writer_cfg_i.loopBack
+  reader_data_after_extension <> readerDemux.io.in
+  writerMux.io.out <> writer_data_before_extension
+  // Why there is a problem?
+  readerDemux.io.out(1) <> writerMux.io.in(1)
+  readerDemux.io.out(0) <> io.remoteDMADataPath.toRemote
+  writerMux.io.in(0) <> io.remoteDMADataPath.fromRemote
+}
+
+// Below is the class to determine if chisel generate Verilog correctly
+
+object DMADataPath_SystemVerilogEmitter extends App {
+  println(
+    getVerilogString(
+      new DMADataPath(
+        readerparam = new DMADataPathParam(
+          rwParam = new ReaderWriterParam,
+          extParam = Seq()
+        ),
+        writerparam = new DMADataPathParam(
+          rwParam = new ReaderWriterParam,
+          extParam = Seq()
+        )
+      )
+    )
+  )
+}
+
+class Serializer_Deserializer_Tester(param: DMADataPathParam) extends Module {
+  val io = IO(new Bundle {
+    val in = Input(new DMADataPathCfgIO(param))
+    val out_serialized = Output(UInt(512.W))
+    val out = Output(new DMADataPathCfgIO(param))
+  })
+
+  io.out_serialized := io.in.serialize()
+  val out = Wire(new DMADataPathCfgIO(param))
+  out.deserialize(io.out_serialized)
+  io.out := out
+}
+
+object Serializer_Deserializer_Tester_SystemVerilogEmitter extends App {
+  println(
+    getVerilogString(
+      new Serializer_Deserializer_Tester(
+        new DMADataPathParam(
+          rwParam = new ReaderWriterParam
+        )
+      )
+    )
+  )
+}

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaExtension/DMAExtensionTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaExtension/DMAExtensionTester.scala
@@ -1,0 +1,106 @@
+package snax.xdma.xdmaExtension
+
+import chisel3._
+import chisel3.util._
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+
+import snax.xdma.CommonCells.DecoupledCut._
+
+import snax.xdma.DesignParams._
+import scala.util.Random
+
+/** The parent (abstract) Class for the DMA Extension Testbench It includes two
+  * things: 1) A Testharness to wrap the extension 2) A Testbench to emulate
+  * DMACtrl, the prior extension and posterior extension
+  *
+  * Usage: (See MaxPoolTester as an example) 1) Define the dut (HasDMAExtension
+  * class) 2) Define CSR value for this test 3) Define input data 4) Define
+  * expected output data The testbench will then automatically control the dut
+  * and verify output data's correctness.
+  */
+
+class DMAExtensionHarness(extension: HasDMAExtension)
+    extends Module
+    with RequireAsyncReset {
+  val dut = extension.instantiate
+  val io = IO(chiselTypeOf(dut.io))
+
+  io.busy_o := dut.io.busy_o
+  dut.io.csr_i := io.csr_i
+  dut.io.start_i := io.start_i
+
+  io.data_i -||> dut.io.data_i
+  dut.io.data_o -||> io.data_o
+}
+
+abstract class DMAExtensionTester
+    extends AnyFlatSpec
+    with ChiselScalatestTester {
+  val csr_vec: Seq[Int]
+  val input_data_vec: Seq[BigInt]
+  val output_data_vec: Seq[BigInt]
+  def hasExtension: HasDMAExtension
+
+  hasExtension.extensionParam.moduleName should "pass" in {
+    test(new DMAExtensionHarness(hasExtension))
+      .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
+        dut =>
+          dut.io.csr_i.head.poke(0) // Bypass disabled
+          dut.io.csr_i.tail.zip(csr_vec).foreach { case (csrPort, csrData) =>
+            csrPort.poke(csrData)
+          }
+
+          var concurrent_threads =
+            new chiseltest.internal.TesterThreadList(Seq())
+
+          // Input Injector
+          concurrent_threads = concurrent_threads.fork {
+            // Emulate the delay of previous extensions
+            dut.io.start_i.poke(true)
+            dut.clock.step(1)
+            dut.io.start_i.poke(false)
+            // Emulate the delay of previous extensions
+            dut.clock.step(Random.between(1, 16))
+            // Real transmission is starting
+            dut.io.data_i.valid.poke(true)
+            for (i <- input_data_vec) {
+              while (!dut.io.data_i.ready.peekBoolean()) dut.clock.step(1)
+              dut.io.data_i.bits.poke(i)
+              println(
+                "[Input Injector] The input of DMAExtension is: " + i.toString(
+                  16
+                )
+              )
+              dut.clock.step(1)
+            }
+            dut.io.data_i.valid.poke(false)
+          }
+
+          // Output checker
+          concurrent_threads = concurrent_threads.fork {
+            // Real transmission is starting
+            for (i <- output_data_vec) {
+              while (!dut.io.data_o.valid.peekBoolean()) dut.clock.step()
+              val returned_value = dut.io.data_o.bits.peekInt()
+              println(
+                "[Output Checker] The output of DMAExtension is: " + returned_value
+                  .toString(16)
+              )
+              if (i == returned_value)
+                println("[Output Checker] Result is correct. ")
+              else
+                throw new Exception("[Output Checker] Result is not correct. ")
+
+              // Emulate the jamming at later stage
+              dut.clock.step(Random.between(1, 5))
+              dut.io.data_o.ready.poke(true)
+              dut.clock.step()
+              dut.io.data_o.ready.poke(false)
+            }
+          }
+
+          concurrent_threads.joinAndStep()
+      }
+  }
+}

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
@@ -1,0 +1,292 @@
+package snax.xdma.xdmaFrontend
+
+import chisel3._
+import chisel3.util._
+// Import Chiseltest
+import chiseltest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.flatspec.AnyFlatSpec
+// Import Random number generator
+import scala.util.Random
+// Import break support for loops
+import scala.util.control.Breaks.{break, breakable}
+import snax.xdma.xdmaFrontend.DMADataPath
+import snax.xdma.DesignParams.{DMADataPathParam, ReaderWriterParam}
+
+class ReaderWriterTesterParam(
+    val address: Int,
+    val dimension: Int,
+    val spatial_bound: Int,
+    val temporal_bound: Array[Int],
+    val spatial_stride: Int,
+    val temporal_stride: Array[Int]
+)
+
+class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
+  "DMA Data Path behavior is as expected" in test(
+    new DMADataPath(
+      readerparam = new DMADataPathParam(
+        rwParam = new ReaderWriterParam
+      ),
+      writerparam = new DMADataPathParam(
+        rwParam = new ReaderWriterParam
+      )
+    )
+  ).withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
+    dut =>
+      // ************************ Prepare the simulation data ************************//
+
+      // Prepare the data in the tcdm
+      val tcdm_mem = collection.mutable.Map[Int, Long]()
+      // We have 128KB of the tcdm data
+      // Each element is 64bit(8B) long
+      // Hence in total we have 128KB/8B = 16K entried of the tcdm
+      // First we generate the first half (64KB) of the data ramdomly
+
+      // We first test only to read 8 rows of data
+      // Each row we have 256B
+      for (i <- 0 until (8 * 256) / 8) {
+        // tcdm_mem(8*i) = Math.abs(Random.nextLong())
+        tcdm_mem(8 * i) = i * 1L
+      }
+      // Queues to temporarily store the address at request side, which will be consumed by responser
+      val queues = Seq.fill(8)(collection.mutable.Queue[Int]())
+
+      // Prepare AGU config
+      // Prepare read cfg
+      val readerTestingParams = new ReaderWriterTesterParam(
+        address = 0,
+        dimension = 3,
+        // spatial_bound is fixed to 8 -> every time we fetch 8 banks
+        spatial_bound = 8,
+        temporal_bound = Array(4, 8),
+        spatial_stride = 8,
+        temporal_stride = Array(64, 256)
+      )
+      // Prepare write cfg
+      val writerTestingParams = new ReaderWriterTesterParam(
+        address = 8 * 256,
+        dimension = 3,
+        // spatial_bound is fixed to 8 -> every time we fetch 8 banks
+        spatial_bound = 8,
+        temporal_bound = Array(4, 8),
+        spatial_stride = 8,
+        temporal_stride = Array(64, 256)
+      )
+      // ************************ Start Simulation **********************************//
+      // Start up the system
+      dut.clock.step(10)
+      // Poke the reader agu
+      dut.io.reader_cfg_i.agu_cfg.Ptr.poke(readerTestingParams.address)
+      dut.io.reader_cfg_i.agu_cfg
+        .Bounds(0)
+        .poke(readerTestingParams.spatial_bound)
+      dut.io.reader_cfg_i.agu_cfg
+        .Bounds(1)
+        .poke(readerTestingParams.temporal_bound(0))
+      dut.io.reader_cfg_i.agu_cfg
+        .Bounds(2)
+        .poke(readerTestingParams.temporal_bound(1))
+      dut.io.reader_cfg_i.agu_cfg
+        .Strides(0)
+        .poke(readerTestingParams.spatial_stride)
+      dut.io.reader_cfg_i.agu_cfg
+        .Strides(1)
+        .poke(readerTestingParams.temporal_stride(0))
+      dut.io.reader_cfg_i.agu_cfg
+        .Strides(2)
+        .poke(readerTestingParams.temporal_stride(1))
+      // Poke the write agu
+      dut.io.writer_cfg_i.agu_cfg.Ptr.poke(writerTestingParams.address)
+      dut.io.writer_cfg_i.agu_cfg
+        .Bounds(0)
+        .poke(writerTestingParams.spatial_bound)
+      dut.io.writer_cfg_i.agu_cfg
+        .Bounds(1)
+        .poke(writerTestingParams.temporal_bound(0))
+      dut.io.writer_cfg_i.agu_cfg
+        .Bounds(2)
+        .poke(writerTestingParams.temporal_bound(1))
+      dut.io.writer_cfg_i.agu_cfg
+        .Strides(0)
+        .poke(writerTestingParams.spatial_stride)
+      dut.io.writer_cfg_i.agu_cfg
+        .Strides(1)
+        .poke(writerTestingParams.temporal_stride(0))
+      dut.io.writer_cfg_i.agu_cfg
+        .Strides(2)
+        .poke(writerTestingParams.temporal_stride(1))
+      // Poke the loop back to ture since we are only testing w/o any axi transactions
+      dut.io.reader_cfg_i.loopBack.poke(true)
+      dut.io.writer_cfg_i.loopBack.poke(true)
+
+      // Start the reader and writer
+      dut.io.reader_start_i.poke(true)
+      dut.io.writer_start_i.poke(true)
+      dut.clock.step()
+      dut.io.reader_start_i.poke(false)
+      dut.io.writer_start_i.poke(false)
+      // Waiting for the AGU to begin
+      if (
+        !(dut.io.reader_busy_o.peekBoolean() && dut.io.writer_busy_o
+          .peekBoolean())
+      )
+        dut.clock.step()
+      // AGU started work. Now we need to create branches to emulate each channels of TCDM ports
+      var concurrent_threads = new chiseltest.internal.TesterThreadList(Seq())
+      var testTerminated = false
+
+      // eight threads to mimic the reader req side
+      // Each threads will emulate a random delay in the req_ready side
+      // ---------                ------------
+      // |       |----->addr----->|          |
+      // |reader |----->valid---->| tcdm port|
+      // |   req |<-----ready----<|          |
+      // ---------                ------------
+      for (i <- 0 until 8) {
+        concurrent_threads = concurrent_threads.fork {
+          breakable(
+            while (true) {
+              if (testTerminated) break()
+              val random_delay = Random.between(0, 3)
+              if (random_delay > 1) {
+                dut.io.tcdm_reader.req(i).ready.poke(false)
+                dut.clock.step(random_delay)
+                dut.io.tcdm_reader.req(i).ready.poke(true)
+              } else dut.io.tcdm_reader.req(i).ready.poke(true)
+              val reader_req_addr =
+                dut.io.tcdm_reader.req(i).bits.addr.peekInt().toInt
+              if (dut.io.tcdm_reader.req(i).valid.peekBoolean()) {
+                queues(i).enqueue(reader_req_addr)
+
+                println(
+                  f"[Reader Req] Read the TCDM with Addr = $reader_req_addr%d"
+                )
+              }
+
+              dut.clock.step()
+            }
+          )
+        }
+      }
+      // eight threads to mimic the reader resp side
+      // There are no ready port in the reader side, so we just pop out the data accoring to
+      // the addr recored in queues
+      // ---------                ------------
+      // |       |<-----data-----<|          |
+      // |reader |<-----valid----<| tcdm port|
+      // |   resp|                |          |
+      // ---------                ------------
+      for (i <- 0 until 8) {
+        concurrent_threads = concurrent_threads.fork {
+          breakable(
+            while (true) {
+              if (testTerminated) break()
+              if (queues(i).isEmpty) dut.clock.step()
+              else {
+                dut.io.tcdm_reader.rsp(i).valid.poke(true)
+                val reader_addr = queues(i).dequeue()
+                val reader_resp_data = tcdm_mem(reader_addr)
+                //   println(
+                //     f"[Reader Resp] TCDM Response to Reader with Addr = $reader_addr%d Data = 0x${reader_resp_data}%016x"
+                //   )
+                println(
+                  f"[Reader Resp] TCDM Response to Reader with Addr = $reader_addr%d Data = $reader_resp_data%d"
+                )
+                dut.io.tcdm_reader.rsp(i).bits.data.poke(reader_resp_data.U)
+                dut.clock.step()
+                dut.io.tcdm_reader.rsp(i).valid.poke(false)
+              }
+
+            }
+          )
+        }
+      }
+      // eight threads to mimic the writer req side
+      // Like the reader req side, we emulate the random delay by poking to ready signal
+      // ---------                ------------
+      // |       |>-----addr----->|          |
+      // |writer |>-----write---->| tcdm port|
+      // |   req |>-----data----->|          |
+      // |       |>-----valid---->|          |
+      // |       |<-----ready----<|          |
+      // ---------                ------------
+      for (i <- 0 until 8) {
+        concurrent_threads = concurrent_threads.fork {
+          breakable(
+            while (true) {
+              if (testTerminated) break()
+
+              if (dut.io.tcdm_writer.req(i).valid.peekBoolean()) {
+                val writer_req_addr =
+                  dut.io.tcdm_writer.req(i).bits.addr.peekInt().toInt
+                val writer_req_data =
+                  dut.io.tcdm_writer.req(i).bits.data.peek().litValue.toLong
+
+                val random_delay = Random.between(0, 3)
+                if (random_delay > 1) {
+                  dut.io.tcdm_writer.req(i).ready.poke(false)
+                  dut.clock.step(random_delay)
+                  dut.io.tcdm_writer.req(i).ready.poke(true)
+                } else dut.io.tcdm_writer.req(i).ready.poke(true)
+                //   dut.io.tcdm_writer.req(i).ready.poke(true)
+                val writer_expected_data = (writer_req_addr - 2048) / 8
+                //   println(
+                //     f"[Writer Req] Writes to TCDM with Addr: $writer_req_addr%d and Data = 0x${writer_req_data}%016x"
+                //   )
+                println(
+                  f"[Writer Req] Writes to TCDM with Addr: $writer_req_addr and Data = ${writer_req_data} (Expected Data = $writer_expected_data)"
+                )
+                tcdm_mem(writer_req_addr) = writer_req_data
+
+                dut.clock.step()
+              } else dut.clock.step()
+
+            }
+          )
+        }
+      }
+
+      // one threads to monitor the simulation
+      concurrent_threads = concurrent_threads.fork {
+        println("[Monitor] The monitor is launched. ")
+        // Wait for the dut to start
+        dut.clock.step(20)
+        // After the dut is start, we poll the busy signal of both writer and reader
+        while (
+          dut.io.reader_busy_o.peekBoolean() && dut.io.writer_busy_o
+            .peekBoolean()
+        )
+          dut.clock.step()
+        // If they are both zero => system is done
+        // Everything finished: The simulation is ended
+        println(
+          "[Monitor] The test is finished and all threads are about to be terminated by the monitor. "
+        )
+        dut.clock.step()
+        testTerminated = true
+      }
+
+      concurrent_threads.joinAndStep()
+      // Verify the system
+
+      // // Determine the midpoint of the tcdm
+      // val midPoint = tcdm_mem.size / 2
+      // // Split the tcdm into two halves
+      // val firstHalf = collection.mutable.Map() ++ tcdm_mem.take(midPoint)
+      // val secondHalf = collection.mutable.Map() ++ tcdm_mem.drop(midPoint)
+      // // Compare the two halves
+      // val areEqual = firstHalf == secondHalf
+      // println(s"Are the two halves equal? $areEqual")
+  }
+}
+
+object DMADataPathTester extends App {
+  emitVerilog(
+    new DMADataPath(
+      readerparam = new DMADataPathParam(new ReaderWriterParam, Seq()),
+      writerparam = new DMADataPathParam(new ReaderWriterParam, Seq())
+    ),
+    Array("--target-dir", "generated")
+  )
+}

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
@@ -46,7 +46,6 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
       // We first test only to read 8 rows of data
       // Each row we have 256B
       for (i <- 0 until (8 * 256) / 8) {
-        // tcdm_mem(8*i) = Math.abs(Random.nextLong())
         tcdm_mem(8 * i) = i * 1L
       }
       // Queues to temporarily store the address at request side, which will be consumed by responser
@@ -229,11 +228,8 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
                   dut.clock.step(random_delay)
                   dut.io.tcdm_writer.req(i).ready.poke(true)
                 } else dut.io.tcdm_writer.req(i).ready.poke(true)
-                //   dut.io.tcdm_writer.req(i).ready.poke(true)
+
                 val writer_expected_data = (writer_req_addr - 2048) / 8
-                //   println(
-                //     f"[Writer Req] Writes to TCDM with Addr: $writer_req_addr%d and Data = 0x${writer_req_data}%016x"
-                //   )
                 println(
                   f"[Writer Req] Writes to TCDM with Addr: $writer_req_addr and Data = ${writer_req_data} (Expected Data = $writer_expected_data)"
                 )
@@ -268,16 +264,6 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
       }
 
       concurrent_threads.joinAndStep()
-      // Verify the system
-
-      // // Determine the midpoint of the tcdm
-      // val midPoint = tcdm_mem.size / 2
-      // // Split the tcdm into two halves
-      // val firstHalf = collection.mutable.Map() ++ tcdm_mem.take(midPoint)
-      // val secondHalf = collection.mutable.Map() ++ tcdm_mem.drop(midPoint)
-      // // Compare the two halves
-      // val areEqual = firstHalf == secondHalf
-      // println(s"Are the two halves equal? $areEqual")
   }
 }
 


### PR DESCRIPTION
[xdma] the xdma DataPath. This datapath module is capable of forwarding data from tcdm to tcdm (loopback). Interface to forwarding data to AXI bus is also implemented and will be enabled in the future. 

New files:

CustomOprators.scala: Including two custom operators to do the pipelining of the Decoupled Signals and concatenating UInt signals
MuxDemuxDecoupled.scala: The Mux and Demux for Decoupled signals, which can be the building block of arbitrators and more
DMADataPathExtension.scala: The abstract class for the DMA Extension. Every DMAExtension should be extended from this abstract class so that it can be integrated into the DataPath
DMADataPath: The DataPath of xdma. 
Testers for these modules