### PR TITLE
xdma's controller and three dma extensions: Transposer, Memset, and MaxPool

### DIFF
--- a/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/MaxPool.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/MaxPool.scala
@@ -1,0 +1,98 @@
+package snax.xdma.xdmaExtension
+
+import chisel3._
+import chisel3.util._
+import snax.xdma.CommonCells.DecoupledCut._
+import snax.xdma.DesignParams._
+
+// MAXPoolPE module
+class MAXPoolPE(dataWidth: Int) extends Module with RequireAsyncReset {
+  require(dataWidth > 0)
+
+  val io = IO(new Bundle {
+    val data_i = Flipped(Valid(SInt(dataWidth.W)))
+    val data_o = Output(SInt(dataWidth.W))
+    val init_i = Input(Bool())
+  })
+
+  val tempValue = Reg(chiselTypeOf(io.data_i.bits))
+  when(io.data_i.valid) {
+    when(io.init_i) {
+      tempValue := io.data_i.bits
+    }.otherwise {
+      tempValue := Mux(io.data_i.bits > tempValue, io.data_i.bits, tempValue)
+    }
+  }
+  io.data_o := tempValue
+}
+
+object HasMaxPool extends HasDMAExtension {
+  implicit val extensionParam: DMAExtensionParam = new DMAExtensionParam(
+    moduleName = "MaxPool",
+    userCsrNum = 1,
+    dataWidth = 512
+  )
+  def instantiate: MaxPool = Module(
+    new MaxPool(elementWidth = 8)
+  )
+}
+
+class MaxPool(elementWidth: Int)(implicit extensionParam: DMAExtensionParam)
+    extends DMAExtension {
+  require(extensionParam.dataWidth % elementWidth == 0)
+
+  // Counter to record the steps
+  // 256-element MaxPool maximum
+  val counters = Module(new snax.xdma.xdmaStreamer.BasicCounter(8))
+  counters.io.ceil := ext_csr_i(0)
+  counters.io.reset := ext_start_i
+  counters.io.tick := ext_data_i.fire
+  ext_busy_o := counters.io.value =/= 0.U
+
+  // The wire to connect the output result
+  val ext_data_o_bits = Wire(
+    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
+  )
+  ext_data_o.bits := ext_data_o_bits.asUInt
+
+  val PEs = for (i <- 0 until extensionParam.dataWidth / elementWidth) yield {
+    val PE = Module(new MAXPoolPE(dataWidth = elementWidth))
+    PE.io.init_i := counters.io.value === 0.U
+    PE.io.data_i.valid := ext_data_i.fire
+    PE.io.data_i.bits := ext_data_i
+      .bits((i + 1) * elementWidth - 1, i * elementWidth)
+      .asSInt
+    ext_data_o_bits(i) := PE.io.data_o.asUInt
+    PE
+  }
+  // FSM to handle handshake signals
+
+  val s_idle :: s_output :: Nil = Enum(2)
+  val current_state = RegInit(s_idle)
+
+  // Default values for ready and valid signals
+  ext_data_i.ready := false.B
+  ext_data_o.valid := false.B
+
+  switch(current_state) {
+    is(s_idle) {
+      // Under this condition, the system does not need to send the sum to the next stage
+      ext_data_i.ready := true.B
+      ext_data_o.valid := false.B
+      when(ext_data_i.fire && counters.io.lastVal) {
+        // The result is about to be ready, switching state to output
+        current_state := s_output
+      }
+    }
+    is(s_output) {
+      // Under this condition, the system does need to send the sum to the next stage
+      ext_data_o.valid := true.B
+      // If the output buffer is empty, then the idling is not necessary. Then the next input data can be fed in without problem
+      ext_data_i.ready := ext_data_o.fire
+      when(ext_data_o.fire) {
+        // The result is saved to the output buffer, state is transitted to idle
+        current_state := s_idle
+      }
+    }
+  }
+}

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/Memset.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/Memset.scala
@@ -1,0 +1,39 @@
+package snax.xdma.xdmaExtension
+
+import chisel3._
+import chisel3.util._
+import snax.xdma.DesignParams.DMAExtensionParam
+
+object HasMemset extends HasDMAExtension {
+  implicit val extensionParam: DMAExtensionParam = new DMAExtensionParam(
+    moduleName = "Memset",
+    userCsrNum = 1,
+    dataWidth = 512
+  )
+  def instantiate: Memset = Module(new Memset)
+}
+
+class Memset()(implicit extensionParam: DMAExtensionParam)
+    extends DMAExtension {
+  val out = WireInit(
+    VecInit(Seq.fill(extensionParam.dataWidth / 8)(ext_csr_i(0)(7, 0)))
+  )
+  ext_data_i.ready := ext_data_o.ready
+  ext_data_o.valid := ext_data_i.valid
+  ext_data_o.bits := out.asUInt
+  ext_busy_o := false.B
+}
+
+object MemsetEmitter extends App {
+  println(
+    getVerilogString(
+      new Memset()(
+        new DMAExtensionParam(
+          moduleName = "Memset",
+          userCsrNum = 1,
+          dataWidth = 512
+        )
+      )
+    )
+  )
+}

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/Transposer.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaExtension/Transposer.scala
@@ -1,0 +1,54 @@
+package snax.xdma.xdmaExtension
+
+import chisel3._
+import chisel3.util._
+import snax.xdma.DesignParams._
+
+object HasTransposer extends HasDMAExtension {
+  implicit val extensionParam: DMAExtensionParam = new DMAExtensionParam(
+    moduleName = "Transposer",
+    userCsrNum = 0,
+    dataWidth = 512
+  )
+
+  def instantiate: Transposer = Module(new Transposer)
+}
+
+class Transposer()(implicit extensionParam: DMAExtensionParam)
+    extends DMAExtension {
+
+  require(
+    extensionParam.dataWidth == 512 && 512 == extensionParam.dataWidth,
+    "transposeInWidth must be 512 for now"
+  )
+
+  // fixed pattern: transpose 8x8 matrix
+  val out_data_array = Wire(Vec(8, Vec(8, UInt(8.W))))
+
+  for (i <- 0 until 8) {
+    for (j <- 0 until 8) {
+      out_data_array(i)(j) := ext_data_i.bits(
+        i * 8 + j * 8 * 8 + 7,
+        i * 8 + j * 8 * 8 + 0
+      )
+    }
+  }
+  ext_data_i.ready := ext_data_o.ready
+  ext_data_o.valid := ext_data_i.valid
+  ext_busy_o := false.B
+  ext_data_o.bits := out_data_array.asUInt
+}
+
+object TransposerEmitter extends App {
+  println(
+    getVerilogString(
+      new Transposer()(
+        extensionParam = new DMAExtensionParam(
+          moduleName = "Transposer",
+          userCsrNum = 1,
+          dataWidth = 512
+        )
+      )
+    )
+  )
+}

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMACtrl.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMACtrl.scala
@@ -1,0 +1,442 @@
+package snax.xdma.xdmaFrontend
+
+import chisel3._
+import chisel3.util._
+
+import snax.utils._
+import snax.xdma.CommonCells.DecoupledCut._
+import snax.xdma.CommonCells.BitsConcat._
+
+import snax.xdma.xdmaStreamer.{AddressGenUnitCfgIO, Reader, Writer}
+
+import snax.csr_manager._
+import snax.xdma.xdmaStreamer.BasicCounter
+import snax.xdma.CommonCells.DemuxDecoupled
+import snax.xdma.DesignParams.DMADataPathParam
+
+class DMACtrlIO(
+    readerparam: DMADataPathParam,
+    writerparam: DMADataPathParam,
+    axiWidth: Int = 512
+) extends Bundle {
+  // clusterBaseAddress to determine if it is the local command or remote command
+  val clusterBaseAddress = Input(
+    UInt(readerparam.rwParam.agu_param.addressWidth.W)
+  )
+  // Local DMADatapath control signal (Which is connected to DMADataPath)
+  val localDMADataPath = new Bundle {
+    val reader_cfg_o = Output(new DMADataPathCfgInternalIO(readerparam))
+    val writer_cfg_o = Output(new DMADataPathCfgInternalIO(writerparam))
+
+    // Two start signal will inform the new cfg is available, trigger agu, and inform all extension that a stream is coming
+    val reader_start_o = Output(Bool())
+    val writer_start_o = Output(Bool())
+    // Two busy signal only go down if a stream fully passthrough the reader / writter, which is provided by DataPath
+    // These signals should be readable by the outside; these two will also be used to determine whether the next task can be executed.
+    val reader_busy_i = Input(Bool())
+    val writer_busy_i = Input(Bool())
+  }
+  // Remote control signal, which include the signal from other cluster or signal to other cluster. Both of them is AXI related, serialized signal
+  // The remote control signal will contain only src information, in other words, the DMA system can proceed remote read or local read, but only local write
+  val remoteDMADataPathCfg = new Bundle {
+    val fromRemote = Flipped(Decoupled(UInt(axiWidth.W)))
+    val toRemote = Decoupled(UInt(axiWidth.W))
+  }
+  // This is the port for CSR Manager to SNAX port
+  val csrIO = new SnaxCsrIO(csrAddrWidth = 32)
+}
+
+class SrcConfigRouter(dataType: DMADataPathCfgInternalIO, tcdmSize: Int)
+    extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    val clusterBaseAddress = Input(dataType.agu_cfg.Ptr)
+    val from = Flipped(new Bundle {
+      val remote = Decoupled(dataType)
+      val local = Decoupled(dataType)
+    })
+    val to = new Bundle {
+      val remote = Decoupled(dataType)
+      val local = Decoupled(dataType)
+    }
+  })
+
+  val i_from_arbiter = Module(new Arbiter(dataType, 2))
+  i_from_arbiter.io.in(0) <> io.from.local
+  i_from_arbiter.io.in(1) <> io.from.remote
+
+  val i_to_demux = Module(
+    new DemuxDecoupled(dataType = dataType, numOutput = 3)
+  )
+  i_from_arbiter.io.out -|> i_to_demux.io.in
+
+  // At the output of FIFO: Do the rule check
+  val cType_local :: cType_remote :: cType_discard :: Nil = Enum(3)
+  val cValue = Wire(chiselTypeOf(cType_discard))
+
+  when(
+    i_to_demux.io.in.bits.agu_cfg
+      .Ptr(
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
+        log2Up(tcdmSize) + 10
+      ) === io
+      .clusterBaseAddress(
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
+        log2Up(tcdmSize) + 10
+      )
+  ) {
+    cValue := cType_local // When cfg has the Ptr that fall within local TCDM, the data should be forwarded to the local ctrl path
+  }.elsewhen(i_to_demux.io.in.bits.agu_cfg.Ptr === 0.U) {
+    cValue := cType_discard // When cfg has the Ptr that is zero, This means that the frame need to be thrown away. This is important as when the data is moved from DRAM to TCDM or vice versa, DRAM part is handled by iDMA, thus only one config instead of two is submitted
+  }.otherwise {
+    cValue := cType_remote // For the remaining condition, the config is forward to remote DMA
+  }
+
+  i_to_demux.io.sel := cValue
+  // Port local is connected to the outside
+  i_to_demux.io.out(cType_local.litValue.toInt) <> io.to.local
+  // Port remote is connected to the outside
+  i_to_demux.io.out(cType_remote.litValue.toInt) <> io.to.remote
+  // Port discard is not connected and will always be discarded
+  i_to_demux.io.out(cType_discard.litValue.toInt).ready := true.B
+}
+
+class DstConfigRouter(dataType: DMADataPathCfgInternalIO, tcdmSize: Int)
+    extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    val clusterBaseAddress = Input(dataType.agu_cfg.Ptr)
+    val from = Flipped(new Bundle {
+      val local = Decoupled(dataType)
+    })
+    val to = new Bundle {
+      val local = Decoupled(dataType)
+    }
+  })
+  val i_to_demux = Module(
+    new DemuxDecoupled(dataType = dataType, numOutput = 2)
+  )
+  io.from.local <> i_to_demux.io.in
+
+  // At the output of cut: Do the rule check
+  val cType_local :: cType_discard :: Nil = Enum(2)
+  val cValue = Wire(chiselTypeOf(cType_discard))
+
+  when(
+    i_to_demux.io.in.bits.agu_cfg
+      .Ptr(
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
+        log2Up(tcdmSize) + 10
+      ) === io
+      .clusterBaseAddress(
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
+        log2Up(tcdmSize) + 10
+      )
+  ) {
+    cValue := cType_local // When cfg has the Ptr that fall within local TCDM, the data should be forwarded to the local ctrl path
+  }.otherwise {
+    cValue := cType_discard // For all other case, this frame needs to be discarded
+  }
+
+  i_to_demux.io.sel := cValue
+  // Port local is connected to the outside
+  i_to_demux.io.out(cType_local.litValue.toInt) <> io.to.local
+  // Port discard is not connected and will always be discarded
+  i_to_demux.io.out(cType_discard.litValue.toInt).ready := true.B
+}
+
+class DMACtrl(
+    readerparam: DMADataPathParam,
+    writerparam: DMADataPathParam,
+    axiWidth: Int = 512,
+    csrAddrWidth: Int = 32
+) extends Module
+    with RequireAsyncReset {
+  val io = IO(
+    new DMACtrlIO(
+      readerparam = readerparam,
+      writerparam = writerparam,
+      axiWidth = axiWidth
+    )
+  )
+
+  val i_csrmanager = Module(
+    new CsrManager(
+      csrNumReadWrite = 2 + // Reader Pointer needs two CSRs
+        readerparam.rwParam.agu_param.dimension * 2 + // Strides + Bounds for read
+        {
+          if (readerparam.extParam.length == 0) 0
+          else readerparam.extParam.map { i => i.totalCsrNum }.reduce(_ + _)
+        } + // The total num of param on reader extension
+        2 + // Writer Pointer needs two CSRs
+        writerparam.rwParam.agu_param.dimension * 2 + // Strides + Bounds for write
+        {
+          if (writerparam.extParam.length == 0) 0
+          else writerparam.extParam.map { i => i.totalCsrNum }.reduce(_ + _)
+        } + // The total num of param on writer
+        1, // The start CSR
+      csrNumReadOnly = 2,
+      // Set to two at current, 1) The number of submitted request; 2) The number of finished request. Since the reader path may be forward to remote, here I only count the writer branch
+      csrAddrWidth = csrAddrWidth,
+      // Set a name for the module class so that it will not overlapped with other csrManagers in user-defined accelerators
+      csrModuleTagName = "xDMA"
+    )
+  )
+
+  i_csrmanager.io.csr_config_in <> io.csrIO
+
+  val structuredCfg_src = Wire(new DMADataPathCfgIO(readerparam))
+  val structuredCfg_dst = Wire(new DMADataPathCfgIO(writerparam))
+  var remainingCSR = i_csrmanager.io.csr_config_out.bits.toIndexedSeq
+
+  // Pack the unstructured signal from csrManager to structured signal: Src side
+  // Connect agu_cfg.Ptr
+  structuredCfg_src.agu_cfg.Ptr := Cat(remainingCSR(1), remainingCSR(0))
+  remainingCSR = remainingCSR.tail.tail
+
+  // Connect agu_cfg.Bounds
+  for (i <- 0 until structuredCfg_src.agu_cfg.Bounds.length) {
+    structuredCfg_src.agu_cfg.Bounds(i) := remainingCSR.head
+    remainingCSR = remainingCSR.tail
+  }
+
+  // Connect agu_cfg.Strides
+  for (i <- 0 until structuredCfg_src.agu_cfg.Strides.length) {
+    structuredCfg_src.agu_cfg.Strides(i) := remainingCSR.head
+    remainingCSR = remainingCSR.tail
+  }
+
+  // Connect extension signal
+  for (i <- 0 until structuredCfg_src.ext_cfg.length) {
+    structuredCfg_src.ext_cfg(i) := remainingCSR.head
+    remainingCSR = remainingCSR.tail
+  }
+
+  // Pack the unstructured signal from csrManager to structured signal: Dst side
+  // Connect agu_cfg.Ptr
+  structuredCfg_dst.agu_cfg.Ptr := Cat(remainingCSR(1), remainingCSR(0))
+  remainingCSR = remainingCSR.tail.tail
+
+  // Connect agu_cfg.Bounds
+  for (i <- 0 until structuredCfg_dst.agu_cfg.Bounds.length) {
+    structuredCfg_dst.agu_cfg.Bounds(i) := remainingCSR.head
+    remainingCSR = remainingCSR.tail
+  }
+
+  // Connect agu_cfg.Strides
+  for (i <- 0 until structuredCfg_dst.agu_cfg.Strides.length) {
+    structuredCfg_dst.agu_cfg.Strides(i) := remainingCSR.head
+    remainingCSR = remainingCSR.tail
+  }
+
+  // Connect extension signal
+  for (i <- 0 until structuredCfg_dst.ext_cfg.length) {
+    structuredCfg_dst.ext_cfg(i) := remainingCSR.head
+    remainingCSR = remainingCSR.tail
+  }
+
+  if (remainingCSR.length > 1)
+    println("There is some error in CSR -> Structured CFG assigning")
+
+  // New class that pack the loopBack signal with the ReaderWriterCfg -> ReaderWriterCfgInternal (Local command)
+  val preRoute_src_local = Wire(
+    Decoupled(new DMADataPathCfgInternalIO(readerparam))
+  )
+  val preRoute_dst_local = Wire(
+    Decoupled(new DMADataPathCfgInternalIO(writerparam))
+  )
+  val preRoute_loopBack =
+    structuredCfg_src.agu_cfg.Ptr(
+      structuredCfg_src.agu_cfg.Ptr.getWidth - 1,
+      log2Up(readerparam.rwParam.tcdm_param.tcdmSize) + 10
+    ) === structuredCfg_dst.agu_cfg.Ptr(
+      structuredCfg_dst.agu_cfg.Ptr.getWidth - 1,
+      log2Up(readerparam.rwParam.tcdm_param.tcdmSize) + 10
+    )
+
+  // Connect bits
+  preRoute_src_local.bits.agu_cfg := structuredCfg_src.agu_cfg
+  preRoute_src_local.bits.ext_cfg := structuredCfg_src.ext_cfg
+  preRoute_dst_local.bits.agu_cfg := structuredCfg_dst.agu_cfg
+  preRoute_dst_local.bits.ext_cfg := structuredCfg_dst.ext_cfg
+  preRoute_src_local.bits.loopBack := preRoute_loopBack
+  preRoute_dst_local.bits.loopBack := preRoute_loopBack
+  preRoute_src_local.bits.oppositePtr := preRoute_dst_local.bits.agu_cfg.Ptr
+  preRoute_dst_local.bits.oppositePtr := preRoute_src_local.bits.agu_cfg.Ptr
+
+  // Connect Valid and bits: Only when both preRoutes are ready, postRulecheck is ready
+  i_csrmanager.io.csr_config_out.ready := preRoute_src_local.ready & preRoute_dst_local.ready
+  preRoute_src_local.valid := i_csrmanager.io.csr_config_out.ready & i_csrmanager.io.csr_config_out.valid
+  preRoute_dst_local.valid := i_csrmanager.io.csr_config_out.ready & i_csrmanager.io.csr_config_out.valid
+
+  // Cfg Frame Routing at src side
+  val preRoute_src_remote = Wire(
+    Decoupled(new DMADataPathCfgInternalIO(readerparam))
+  )
+  preRoute_src_remote.bits.deserialize(io.remoteDMADataPathCfg.fromRemote.bits)
+  preRoute_src_remote.valid := io.remoteDMADataPathCfg.fromRemote.valid
+  io.remoteDMADataPathCfg.fromRemote.ready := preRoute_src_remote.ready
+
+  // Command Router
+  val i_srcCfgRouter = Module(
+    new SrcConfigRouter(
+      dataType = chiselTypeOf(preRoute_src_local.bits),
+      tcdmSize = readerparam.rwParam.tcdm_param.tcdmSize
+    )
+  )
+  i_srcCfgRouter.io.clusterBaseAddress := io.clusterBaseAddress
+
+  i_srcCfgRouter.io.from.local <> preRoute_src_local
+  preRoute_src_remote <> i_srcCfgRouter.io.from.remote
+
+  val postRoute_src_local = Wire(
+    Decoupled(new DMADataPathCfgInternalIO(readerparam))
+  )
+  val postRoute_src_remote = Wire(
+    Decoupled(new DMADataPathCfgInternalIO(readerparam))
+  )
+  i_srcCfgRouter.io.to.local <> postRoute_src_local
+  i_srcCfgRouter.io.to.remote <> postRoute_src_remote
+
+  // Connect Port 3 to AXI Mst
+  io.remoteDMADataPathCfg.toRemote.bits := postRoute_src_remote.bits.serialize()
+  io.remoteDMADataPathCfg.toRemote.valid := postRoute_src_remote.valid
+  postRoute_src_remote.ready := io.remoteDMADataPathCfg.toRemote.ready
+
+  // Cfg Frame Routing at dst side: The fake router that only buffer the config and pop out invalid command
+  // Command Router
+  val i_dstCfgRouter = Module(
+    new DstConfigRouter(
+      dataType = chiselTypeOf(preRoute_dst_local.bits),
+      tcdmSize = writerparam.rwParam.tcdm_param.tcdmSize
+    )
+  )
+  i_dstCfgRouter.io.clusterBaseAddress := io.clusterBaseAddress
+
+  i_dstCfgRouter.io.from.local <> preRoute_dst_local
+
+  val postRoute_dst_local = Wire(
+    Decoupled(new DMADataPathCfgInternalIO(writerparam))
+  )
+  postRoute_dst_local <> i_dstCfgRouter.io.to.local
+
+  // Loopback / Non-loopback seperation for pseudo-OoO commit
+  val i_src_LoopbackDemux = Module(
+    new DemuxDecoupled(chiselTypeOf(postRoute_src_local.bits), numOutput = 2)
+  )
+  val i_dst_LoopbackDemux = Module(
+    new DemuxDecoupled(chiselTypeOf(postRoute_dst_local.bits), numOutput = 2)
+  )
+
+  // (1) is loopback; (0) is non-loopback
+  i_src_LoopbackDemux.io.sel := postRoute_src_local.bits.loopBack
+  i_dst_LoopbackDemux.io.sel := postRoute_dst_local.bits.loopBack
+  i_src_LoopbackDemux.io.in <> postRoute_src_local
+  i_dst_LoopbackDemux.io.in <> postRoute_dst_local
+
+  val i_srcCfgArbiter = Module(
+    new Arbiter(chiselTypeOf(postRoute_src_local.bits), 2)
+  )
+  // Non-loopback has lower priority, so that it is connect to 1st port of arbiter
+  // Optional FIFO for non-loopback cfg is added (depth = 2)
+  i_src_LoopbackDemux.io.out(0) -||> i_srcCfgArbiter.io.in(1)
+  // Loopback has higher priority, so that it is connect to 0th port of arbiter
+  // Optional FIFO for loopback cfg is not added
+  i_src_LoopbackDemux.io.out(1) <> i_srcCfgArbiter.io.in(0)
+
+  val i_dstCfgArbiter = Module(
+    new Arbiter(chiselTypeOf(postRoute_dst_local.bits), 2)
+  )
+  // Non-loopback has lower priority, so that it is connect to 1st port of arbiter
+  // Optional FIFO for non-loopback cfg is added (depth = 2)
+  i_dst_LoopbackDemux.io.out(0) -||> i_dstCfgArbiter.io.in(1)
+  // Loopback has higher priority, so that it is connect to 0th port of arbiter
+  // Optional FIFO for loopback cfg is not added
+  i_dst_LoopbackDemux.io.out(1) <> i_dstCfgArbiter.io.in(0)
+
+  // Connect these two cfg to the actual input: Need two small (Mealy) FSMs to manage the start signal and pop out the consumed cfg
+  val s_idle :: s_waitbusy :: s_busy :: Nil = Enum(3)
+
+  s_idle.suggestName("s_idle")
+  s_waitbusy.suggestName("s_waitbusy")
+  s_busy.suggestName("s_busy")
+
+  // Two registers to store the current state
+  val current_state_src = RegInit(s_idle)
+  val current_state_dst = RegInit(s_idle)
+
+  // Two Data Cut to store the buffer the current cfg
+  val current_cfg_src = Wire(chiselTypeOf(i_srcCfgArbiter.io.out))
+  val current_cfg_dst = Wire(chiselTypeOf(i_dstCfgArbiter.io.out))
+  i_srcCfgArbiter.io.out -|> current_cfg_src
+  i_dstCfgArbiter.io.out -|> current_cfg_dst
+
+  // Default value: Not pop out config, not start reader/writer, not change state
+  io.localDMADataPath.reader_start_o := false.B
+  io.localDMADataPath.writer_start_o := false.B
+  current_cfg_src.ready := false.B
+  current_cfg_dst.ready := false.B
+
+  // Control signals in Src Path
+  switch(current_state_src) {
+    is(s_idle) {
+      when(current_cfg_src.valid & (~io.localDMADataPath.reader_busy_i)) {
+        current_state_src := s_waitbusy
+        io.localDMADataPath.reader_start_o := true.B
+      }
+    }
+    is(s_waitbusy) {
+      when(io.localDMADataPath.reader_busy_i) {
+        current_state_src := s_busy
+      }
+    }
+    is(s_busy) {
+      when(~io.localDMADataPath.reader_busy_i) {
+        current_state_src := s_idle
+        current_cfg_src.ready := true.B
+      }
+    }
+  }
+
+  // Control signals in Dst Path
+  switch(current_state_dst) {
+    is(s_idle) {
+      when(current_cfg_dst.valid & (~io.localDMADataPath.writer_busy_i)) {
+        current_state_dst := s_waitbusy
+        io.localDMADataPath.writer_start_o := true.B
+      }
+    }
+    is(s_waitbusy) {
+      when(io.localDMADataPath.writer_busy_i) {
+        current_state_dst := s_busy
+      }
+    }
+    is(s_busy) {
+      when(~io.localDMADataPath.writer_busy_i) {
+        current_state_dst := s_idle
+        current_cfg_dst.ready := true.B
+      }
+    }
+  }
+
+  // Data Signals in Src Path
+  io.localDMADataPath.reader_cfg_o := current_cfg_src.bits
+  // Data Signals in Dst Path
+  io.localDMADataPath.writer_cfg_o := current_cfg_dst.bits
+
+  // Counter for submitted cfg and finished cfg (With these two values, the control core knows which task is finished)
+  val i_submittedTaskCounter = Module(new BasicCounter(32, hasCeil = false))
+  i_submittedTaskCounter.io.ceil := DontCare
+  i_submittedTaskCounter.io.reset := false.B
+  i_submittedTaskCounter.io.tick := i_csrmanager.io.csr_config_out.fire
+  i_csrmanager.io.read_only_csr(0) := i_submittedTaskCounter.io.value
+
+  val i_finishedTaskCounter = Module(new BasicCounter(32, hasCeil = false))
+  i_finishedTaskCounter.io.ceil := DontCare
+  i_finishedTaskCounter.io.reset := false.B
+  i_finishedTaskCounter.io.tick := (RegNext(
+    io.localDMADataPath.writer_busy_i,
+    init = false.B
+  ) === true.B) && (io.localDMADataPath.writer_busy_i === false.B)
+  i_csrmanager.io.read_only_csr(1) := i_finishedTaskCounter.io.value
+}

--- a/hw/chisel/src/test/scala/snax/xdma/CommonCells/CommonCellsTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/CommonCells/CommonCellsTester.scala
@@ -7,68 +7,82 @@ import snax.xdma.CommonCells._
 
 class ComplexQueueConcatTester extends AnyFlatSpec with ChiselScalatestTester {
   "The test of complexQueue (64->512)" should " pass" in {
-    test(new ComplexQueueConcat(64, 512, 16)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
-      // Can store 128 data
-      //Writing data
-      for (i <- 0 until 128) {
-        dut.io.in(i % 8).bits.poke(i)
-        dut.io.in(i % 8).valid.poke(true.B)
-        dut.io.in(i % 8).ready.expect(true.B)
+    test(new ComplexQueueConcat(64, 512, 16))
+      .withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+        // Can store 128 data
+        // Writing data
+        for (i <- 0 until 128) {
+          dut.io.in(i % 8).bits.poke(i)
+          dut.io.in(i % 8).valid.poke(true.B)
+          dut.io.in(i % 8).ready.expect(true.B)
+          dut.clock.step()
+          dut.io.in(i % 8).valid.poke(false.B)
+          print("Input " + i + " is passed. ")
+        }
+        // Can pop 16 512-bit data
+        dut.io.out(0).ready.poke(true.B)
+        for (i <- 0 until 16) {
+          dut.io
+            .out(0)
+            .bits
+            .expect(
+              (BigInt(i * 8 + 7) << (64 * 7)) + (BigInt(
+                i * 8 + 6
+              ) << (64 * 6)) + (BigInt(
+                i * 8 + 5
+              ) << (64 * 5)) + (BigInt(i * 8 + 4) << (64 * 4)) + (BigInt(
+                i * 8 + 3
+              ) << (64 * 3)) + (BigInt(
+                i * 8 + 2
+              ) << (64 * 2)) + (BigInt(i * 8 + 1) << (64 * 1)) + (BigInt(
+                i * 8 + 0
+              ) << (64 * 0))
+            )
+          print("Output " + i + " is passed. ")
+          dut.clock.step()
+        }
         dut.clock.step()
-        dut.io.in(i % 8).valid.poke(false.B)
-        print("Input " + i + " is passed. ")
       }
-      // Can pop 16 512-bit data
-      dut.io.out(0).ready.poke(true.B)
-      for (i <- 0 until 16) {
-        dut.io
-          .out(0)
-          .bits
-          .expect(
-            (BigInt(i * 8 + 7) << (64 * 7)) + (BigInt(i * 8 + 6) << (64 * 6)) + (BigInt(
-              i * 8 + 5
-            ) << (64 * 5)) + (BigInt(i * 8 + 4) << (64 * 4)) + (BigInt(i * 8 + 3) << (64 * 3)) + (BigInt(
-              i * 8 + 2
-            ) << (64 * 2)) + (BigInt(i * 8 + 1) << (64 * 1)) + (BigInt(i * 8 + 0) << (64 * 0))
-          )
-        print("Output " + i + " is passed. ")
-        dut.clock.step()
-      }
-      dut.clock.step()
-    }
   }
 
   "The test of complexQueue (512->64)" should " pass" in {
-    test(new ComplexQueueConcat(512, 64, 16)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
-      // Can store 16 512-bit data
-      //Writing data
-      for (i <- 0 until 16) {
-        dut.io
-          .in(0)
-          .bits
-          .poke(
-            (BigInt(i * 8 + 7) << (64 * 7)) + (BigInt(i * 8 + 6) << (64 * 6)) + (BigInt(
-              i * 8 + 5
-            ) << (64 * 5)) + (BigInt(i * 8 + 4) << (64 * 4)) + (BigInt(i * 8 + 3) << (64 * 3)) + (BigInt(
-              i * 8 + 2
-            ) << (64 * 2)) + (BigInt(i * 8 + 1) << (64 * 1)) + (BigInt(i * 8 + 0) << (64 * 0))
-          )
-        dut.io.in(0).valid.poke(true.B)
-        dut.io.in(0).ready.expect(true.B)
-        dut.clock.step()
-        dut.io.in(0).valid.poke(false.B)
-        print("Input " + i + " is passed. ")
-      }
-      // Can pop 128 64-bit data
-      dut.io.out(0).ready.poke(true.B)
-      for (i <- 0 until 128) {
-        dut.io.out(i % 8).ready.poke(true.B)
-        dut.io.out(i % 8).bits.expect(i)
-        dut.clock.step()
-        dut.io.out(i % 8).ready.poke(false.B)
-        print("Output " + i + " is passed. ")
+    test(new ComplexQueueConcat(512, 64, 16))
+      .withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+        // Can store 16 512-bit data
+        // Writing data
+        for (i <- 0 until 16) {
+          dut.io
+            .in(0)
+            .bits
+            .poke(
+              (BigInt(i * 8 + 7) << (64 * 7)) + (BigInt(
+                i * 8 + 6
+              ) << (64 * 6)) + (BigInt(
+                i * 8 + 5
+              ) << (64 * 5)) + (BigInt(i * 8 + 4) << (64 * 4)) + (BigInt(
+                i * 8 + 3
+              ) << (64 * 3)) + (BigInt(
+                i * 8 + 2
+              ) << (64 * 2)) + (BigInt(i * 8 + 1) << (64 * 1)) + (BigInt(
+                i * 8 + 0
+              ) << (64 * 0))
+            )
+          dut.io.in(0).valid.poke(true.B)
+          dut.io.in(0).ready.expect(true.B)
+          dut.clock.step()
+          dut.io.in(0).valid.poke(false.B)
+          print("Input " + i + " is passed. ")
+        }
+        // Can pop 128 64-bit data
+        dut.io.out(0).ready.poke(true.B)
+        for (i <- 0 until 128) {
+          dut.io.out(i % 8).ready.poke(true.B)
+          dut.io.out(i % 8).bits.expect(i)
+          dut.clock.step()
+          dut.io.out(i % 8).ready.poke(false.B)
+          print("Output " + i + " is passed. ")
 
+        }
       }
-    }
   }
 }

--- a/hw/chisel/src/test/scala/snax/xdma/CommonCells/CommonCellsTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/CommonCells/CommonCellsTester.scala
@@ -1,0 +1,74 @@
+package snax.xdma.CommonCells
+
+import chisel3._
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+import snax.xdma.CommonCells._
+
+class ComplexQueueConcatTester extends AnyFlatSpec with ChiselScalatestTester {
+  "The test of complexQueue (64->512)" should " pass" in {
+    test(new ComplexQueueConcat(64, 512, 16)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+      // Can store 128 data
+      //Writing data
+      for (i <- 0 until 128) {
+        dut.io.in(i % 8).bits.poke(i)
+        dut.io.in(i % 8).valid.poke(true.B)
+        dut.io.in(i % 8).ready.expect(true.B)
+        dut.clock.step()
+        dut.io.in(i % 8).valid.poke(false.B)
+        print("Input " + i + " is passed. ")
+      }
+      // Can pop 16 512-bit data
+      dut.io.out(0).ready.poke(true.B)
+      for (i <- 0 until 16) {
+        dut.io
+          .out(0)
+          .bits
+          .expect(
+            (BigInt(i * 8 + 7) << (64 * 7)) + (BigInt(i * 8 + 6) << (64 * 6)) + (BigInt(
+              i * 8 + 5
+            ) << (64 * 5)) + (BigInt(i * 8 + 4) << (64 * 4)) + (BigInt(i * 8 + 3) << (64 * 3)) + (BigInt(
+              i * 8 + 2
+            ) << (64 * 2)) + (BigInt(i * 8 + 1) << (64 * 1)) + (BigInt(i * 8 + 0) << (64 * 0))
+          )
+        print("Output " + i + " is passed. ")
+        dut.clock.step()
+      }
+      dut.clock.step()
+    }
+  }
+
+  "The test of complexQueue (512->64)" should " pass" in {
+    test(new ComplexQueueConcat(512, 64, 16)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+      // Can store 16 512-bit data
+      //Writing data
+      for (i <- 0 until 16) {
+        dut.io
+          .in(0)
+          .bits
+          .poke(
+            (BigInt(i * 8 + 7) << (64 * 7)) + (BigInt(i * 8 + 6) << (64 * 6)) + (BigInt(
+              i * 8 + 5
+            ) << (64 * 5)) + (BigInt(i * 8 + 4) << (64 * 4)) + (BigInt(i * 8 + 3) << (64 * 3)) + (BigInt(
+              i * 8 + 2
+            ) << (64 * 2)) + (BigInt(i * 8 + 1) << (64 * 1)) + (BigInt(i * 8 + 0) << (64 * 0))
+          )
+        dut.io.in(0).valid.poke(true.B)
+        dut.io.in(0).ready.expect(true.B)
+        dut.clock.step()
+        dut.io.in(0).valid.poke(false.B)
+        print("Input " + i + " is passed. ")
+      }
+      // Can pop 128 64-bit data
+      dut.io.out(0).ready.poke(true.B)
+      for (i <- 0 until 128) {
+        dut.io.out(i % 8).ready.poke(true.B)
+        dut.io.out(i % 8).bits.expect(i)
+        dut.clock.step()
+        dut.io.out(i % 8).ready.poke(false.B)
+        print("Output " + i + " is passed. ")
+
+      }
+    }
+  }
+}

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaExtension/MaxPoolTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaExtension/MaxPoolTester.scala
@@ -1,0 +1,59 @@
+package snax.xdma.xdmaExtension
+
+import chisel3._
+import chisel3.util._
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+
+import snax.xdma.CommonCells.DecoupledCut._
+
+import snax.xdma.DesignParams._
+import scala.util.Random
+import org.scalatest.Args
+
+class MaxPoolTester extends DMAExtensionTester {
+
+  def hasExtension = HasMaxPool
+  val csr_vec = Seq(8) // 8 -> 1 Pooling
+  val input_data = for (i <- 0 until 1024) yield {
+    for (j <- 0 until 8) yield {
+      for (k <- 0 until 64) yield {
+        Random.between(-128, 128)
+      }
+    }
+  }
+
+  val output_data_pre_compare = for (i <- 0 until 1024) yield {
+    for (k <- 0 until 64) yield {
+      for (j <- 0 until 8) yield {
+        input_data(i)(j)(k)
+      }
+    }
+  }
+
+  val output_data = for (i <- output_data_pre_compare) yield {
+    for (j <- i) yield {
+      j.reduce { (a, b) =>
+        {
+          if (a > b) a
+          else b
+        }
+      }
+    }
+  }
+
+  val input_data_vec = for {
+    i <- input_data
+    j <- i
+  } yield {
+    j.zipWithIndex.foldLeft(BigInt(0)) { case (accum, (current, idx)) =>
+      (accum << 8) + (current.toByte & 0xff)
+    }
+  }
+
+  val output_data_vec = for (i <- output_data) yield {
+    i.zipWithIndex.foldLeft(BigInt(0)) { case (accum, (current, idx)) =>
+      (accum << 8) + (current.toByte & 0xff)
+    }
+  }
+}

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMACtrlTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMACtrlTester.scala
@@ -1,0 +1,319 @@
+package snax.xdma.xdmaFrontend
+
+import chisel3._
+import chisel3.util._
+// Import Chiseltest
+import chiseltest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.flatspec.AnyFlatSpec
+// Import Random number generator
+import scala.util.Random
+// Import break support for loops
+import scala.util.control.Breaks.{break, breakable}
+import snax.xdma.DesignParams._
+import snax.csr_manager._
+
+class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
+
+  def write_csr(dut: Module, port: SnaxCsrIO, addr: Int, data: Int) = {
+
+    // give the data and address to the right ports
+    port.req.bits.write.poke(true.B)
+
+    port.req.bits.data.poke(data.U)
+    port.req.bits.addr.poke(addr.U)
+    port.req.valid.poke(1.B)
+
+    // wait for grant
+    while (port.req.ready.peekBoolean() == false) {
+
+      dut.clock.step(1)
+    }
+
+    dut.clock.step(1)
+
+    port.req.valid.poke(0.B)
+  }
+
+  def extractBits(in: BigInt, upper: Int, lower: Int): BigInt = {
+    var temp = in >> lower
+    temp = temp & ((BigInt(1) << (upper - lower + 1)) - 1)
+    temp
+  }
+
+  "The DMACtrl" should " pass" in {
+    test(
+      new DMACtrl(
+        readerparam = new DMADataPathParam(new ReaderWriterParam, Seq()),
+        writerparam = new DMADataPathParam(new ReaderWriterParam, Seq())
+      )
+    ).withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
+      dut =>
+        val clusterBaseAddress = 0x1000_0000
+        dut.io.clusterBaseAddress.poke(clusterBaseAddress)
+
+        // The threads list (empty at the beginning)
+        var concurrent_threads = new chiseltest.internal.TesterThreadList(Seq())
+        val unreceived_reader_cfg = new collection.mutable.HashSet[Int]()
+        val unreceived_writer_cfg = new collection.mutable.HashSet[Int]()
+        var testTerminated = false
+
+        val endedThreadList = new collection.mutable.HashSet[String]()
+
+        dut.clock.setTimeout(0)
+
+        // The thread to push the data inside the Ctrl from local side and remote side
+        concurrent_threads = concurrent_threads.fork {
+          val Reader_PointerAddress = BigInt(0x1000_0000)
+          // Under This Configurations, the full TCDM will be copied
+          val Reader_Bounds = List(8, 32, 64)
+          val Reader_Strides = List(8, 64, 2048)
+
+          val Writer_PointerAddress = BigInt(0x1000_0000)
+          // Under This Configurations, the full TCDM will be copied
+          val Writer_Bounds = List(8, 32, 16)
+          val Writer_Strides = List(32, 256, 8192)
+
+          for (i <- 0 until 256) {
+            if (testTerminated) break()
+            if (Random.between(0, 2) == 0) {
+              // Local Cfg injection
+              // Applying Data into the CSRManager
+              var currentCSR = 0x0
+
+              val Reader_PointerAddress_ThisLoop =
+                Reader_PointerAddress + Random.between(0, 2) * 256 * 1024 + i
+              val Writer_PointerAddress_ThisLoop = Writer_PointerAddress + i
+              unreceived_reader_cfg.add(Reader_PointerAddress_ThisLoop.toInt)
+              unreceived_writer_cfg.add(Writer_PointerAddress_ThisLoop.toInt)
+
+              // Reader: Pointers LSB + MSB
+              write_csr(
+                dut,
+                dut.io.csrIO,
+                addr = currentCSR,
+                data = (Reader_PointerAddress_ThisLoop & 0xffff_ffff).toInt
+              )
+              currentCSR += 1
+              write_csr(
+                dut,
+                dut.io.csrIO,
+                addr = currentCSR,
+                data =
+                  ((Reader_PointerAddress_ThisLoop >> 32) & 0xffff_ffff).toInt
+              )
+              currentCSR += 1
+
+              // Reader: Bounds D0 -> D3
+              Reader_Bounds.foreach({ i =>
+                write_csr(dut, dut.io.csrIO, addr = currentCSR, data = i)
+                currentCSR += 1
+              })
+              // Reader: Strides D0 -> D3
+              Reader_Strides.foreach({ i =>
+                write_csr(dut, dut.io.csrIO, addr = currentCSR, data = i)
+                currentCSR += 1
+              })
+
+              // Writer: Pointers LSB + MSB
+              write_csr(
+                dut,
+                dut.io.csrIO,
+                addr = currentCSR,
+                data = ((Writer_PointerAddress_ThisLoop) & 0xffff_ffff).toInt
+              )
+              currentCSR += 1
+              write_csr(
+                dut,
+                dut.io.csrIO,
+                addr = currentCSR,
+                data =
+                  (((Writer_PointerAddress_ThisLoop) >> 32) & 0xffff_ffff).toInt
+              )
+              currentCSR += 1
+
+              // Writer: Bounds D0 -> D3
+              Reader_Bounds.foreach({ i =>
+                write_csr(dut, dut.io.csrIO, addr = currentCSR, data = i)
+                currentCSR += 1
+              })
+              // Writer: Strides D0 -> D3
+              Reader_Strides.foreach({ i =>
+                write_csr(dut, dut.io.csrIO, addr = currentCSR, data = i)
+                currentCSR += 1
+              })
+
+              // Commit the config
+              write_csr(dut, dut.io.csrIO, addr = currentCSR, data = 1)
+              println(
+                "[Local Reader Generator] " + Reader_PointerAddress_ThisLoop.toInt.toHexString
+              )
+              println(
+                "[Local Writer Generator] " + Writer_PointerAddress_ThisLoop.toInt.toHexString
+              )
+
+            } else {
+
+              // Remote Cfg injection
+              unreceived_reader_cfg.add(
+                (Reader_PointerAddress + 0x0000_1000 + i).toInt
+              )
+              val remoteConfig: BigInt =
+                BigInt(0x2000_0000) +
+                  ((Reader_PointerAddress + 0x0000_1000 + i) << 48) +
+                  (BigInt(Reader_Strides(0)) << 96) +
+                  (BigInt(Reader_Strides(1)) << 128) +
+                  (BigInt(Reader_Strides(2)) << 160) +
+                  (BigInt(Reader_Bounds(0)) << 192) +
+                  (BigInt(Reader_Bounds(1)) << 208) +
+                  (BigInt(Reader_Bounds(2)) << 224)
+              // 240b for AGU, 272b / 34B / 17 INT16 for Extension
+
+              dut.io.remoteDMADataPathCfg.fromRemote.bits.poke(remoteConfig)
+              dut.clock.step(Random.between(1, 31))
+              dut.io.remoteDMADataPathCfg.fromRemote.valid.poke(true.B)
+              while (
+                !(dut.io.remoteDMADataPathCfg.fromRemote.ready.peekBoolean())
+              ) {
+                dut.clock.step()
+              }
+              dut.clock.step()
+              dut.io.remoteDMADataPathCfg.fromRemote.valid.poke(false.B)
+              println(
+                "[Remote Reader Generator] " + (Reader_PointerAddress + 0x0000_1000 + i).toInt.toHexString
+              )
+            }
+          }
+          endedThreadList.add("Generator")
+          println("Generator thread is terminated. ")
+        }
+
+        // The thread to pop the data outside the Ctrl from local reader side
+        concurrent_threads = concurrent_threads.fork {
+          breakable(
+            while (true) {
+              while (!dut.io.localDMADataPath.reader_start_o.peekBoolean()) {
+                dut.clock.step()
+                if (testTerminated) break()
+              }
+              dut.clock.step(Random.between(1, 16) + 32)
+              dut.io.localDMADataPath.reader_busy_i.poke(true)
+              println(
+                "[Local Reader Checker] " + dut.io.localDMADataPath.reader_cfg_o.agu_cfg.Ptr
+                  .peekInt()
+                  .toInt
+                  .toHexString
+              )
+              if (
+                !unreceived_reader_cfg.remove(
+                  dut.io.localDMADataPath.reader_cfg_o.agu_cfg.Ptr
+                    .peekInt()
+                    .toInt
+                )
+              )
+                throw new Exception(
+                  "[Local Reader Checker] The received pointer " + dut.io.localDMADataPath.reader_cfg_o.agu_cfg.Ptr
+                    .peekInt()
+                    .toInt
+                    .toHexString + " is not in the buffer"
+                )
+              dut.clock.step(Random.between(1, 16) + 32)
+              dut.io.localDMADataPath.reader_busy_i.poke(false)
+            }
+          )
+          println("Local Reader Checker is terminated. ")
+        }
+
+        // The thread to pop the data outside the Ctrl from local writer side
+        concurrent_threads = concurrent_threads.fork {
+          breakable(
+            while (true) {
+              while (!dut.io.localDMADataPath.writer_start_o.peekBoolean()) {
+                dut.clock.step()
+                if (testTerminated) break()
+              }
+              println(
+                "[Local Writer Checker] " + dut.io.localDMADataPath.writer_cfg_o.agu_cfg.Ptr
+                  .peekInt()
+                  .toInt
+                  .toHexString
+              )
+              if (
+                !unreceived_writer_cfg.remove(
+                  dut.io.localDMADataPath.writer_cfg_o.agu_cfg.Ptr
+                    .peekInt()
+                    .toInt
+                )
+              )
+                throw new Exception(
+                  "[Local Writer Checker] The received pointer " + dut.io.localDMADataPath.writer_cfg_o.agu_cfg.Ptr
+                    .peekInt()
+                    .toInt
+                    .toHexString + " is not in the buffer"
+                )
+              dut.clock.step(Random.between(1, 16) + 32)
+              dut.io.localDMADataPath.writer_busy_i.poke(true)
+              dut.clock.step(Random.between(1, 16) + 32)
+              dut.io.localDMADataPath.writer_busy_i.poke(false)
+            }
+          )
+          println("Local Writer Checker is terminated. ")
+        }
+
+        // The thread to pop the data outside the Ctrl from remote side
+        concurrent_threads = concurrent_threads.fork {
+          dut.io.remoteDMADataPathCfg.toRemote.ready.poke(false)
+          breakable(
+            while (true) {
+              if (testTerminated) break()
+              if (dut.io.remoteDMADataPathCfg.toRemote.valid.peekBoolean()) {
+                println(
+                  "[Remote Reader Checker] " + extractBits(
+                    dut.io.remoteDMADataPathCfg.toRemote.bits.peekInt(),
+                    95,
+                    48
+                  ).toInt.toHexString
+                )
+                if (
+                  !unreceived_reader_cfg.remove(
+                    extractBits(
+                      dut.io.remoteDMADataPathCfg.toRemote.bits.peekInt(),
+                      95,
+                      48
+                    ).toInt
+                  )
+                )
+                  throw new Exception(
+                    "[Remote Reader Checker] The received pointer " + extractBits(
+                      dut.io.remoteDMADataPathCfg.toRemote.bits.peekInt(),
+                      95,
+                      48
+                    ).toInt.toHexString + " is not in the buffer"
+                  )
+                dut.clock.step(Random.between(1, 16) + 32)
+                dut.io.remoteDMADataPathCfg.toRemote.ready.poke(true)
+                dut.clock.step(1)
+                dut.io.remoteDMADataPathCfg.toRemote.ready.poke(false)
+              } else dut.clock.step(1)
+            }
+          )
+          println("Remote Reader Checker is terminated. ")
+        }
+
+        // The supervision thread
+        concurrent_threads = concurrent_threads.fork {
+          dut.clock.step(512)
+          while (endedThreadList.size < 1) dut.clock.step()
+          while (
+            (!unreceived_reader_cfg.isEmpty) & (!unreceived_writer_cfg.isEmpty)
+          ) {
+            dut.clock.step()
+          }
+          println("Testbench finished. The checker will be terminated soon...")
+          testTerminated = true
+        }
+
+        concurrent_threads.joinAndStep()
+    }
+  }
+}


### PR DESCRIPTION
[xdma] the controller of xdma to support local loopback, and inter-cluster config forwarding (disabled, but will be enabled in the future)

New files:

DMACtrl.scala: The controller of xdma, with csr interface to snitch core and custom interface to the DMADataPath
MaxPool.scala: The MaxPool SIMD acting as the golden reference of a xdma DataPath Extension. 
Transposer.scala: The Transposer of 8x8 INT8 matrix acting as the golden reference of a xdma DataPath Extension. 
Memset.scala: The memset module acting as the golden reference of a xdma DataPath Extension. The function is similar to memset in POSIX API. 
Testers for these modules. 