### PR TITLE
Move memories into modules for PNR power routing

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -208,6 +208,8 @@ sources:
       # Level 0
       - hw/snitch_icache/src/snitch_icache_pkg.sv
       # Level 1
+      - hw/snitch_icache/src/snitch_icache_data.sv
+      - hw/snitch_icache/src/snitch_icache_tag.sv
       - hw/snitch_icache/src/snitch_icache_l0.sv
       - hw/snitch_icache/src/snitch_icache_refill.sv
       - hw/snitch_icache/src/snitch_icache_lfsr.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -258,6 +258,7 @@ sources:
   # snitch_cluster
   - files:
       # Level 0
+      - hw/snitch_cluster/src/snitch_data_mem.sv
       - hw/snitch_cluster/src/snitch_amo_shim.sv
       - hw/snitch_cluster/src/snitch_cluster_peripheral/snitch_cluster_peripheral_reg_pkg.sv
       - hw/snitch_cluster/src/snitch_cluster_peripheral/snitch_cluster_peripheral_reg_top.sv

--- a/hw/snitch_cluster/src/snitch_data_mem.sv
+++ b/hw/snitch_cluster/src/snitch_data_mem.sv
@@ -1,0 +1,54 @@
+// Copyright 2024 KU Leuven.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+// The actual data memory. This memory is made into a module
+// to support multiple power domain needed by the floor plan tool
+
+module snitch_data_mem #(
+  parameter int unsigned TCDMDepth       = 1024,
+  parameter int unsigned NarrowDataWidth = 64,
+  parameter int unsigned NumTotalBanks   = 32,
+  // Memory configuration input types; these vary depending on implementation.
+  parameter type sram_cfg_t       = logic,
+  parameter type sram_cfgs_t      = logic,
+  parameter type tcdm_mem_addr_t  = logic,
+  parameter type strb_t           = logic,
+  parameter type data_t           = logic
+)(
+  input  logic                               clk_i,
+  input  logic                               rst_ni,
+  input  sram_cfgs_t                         sram_cfgs_i,
+  input  logic           [NumTotalBanks-1:0] mem_cs_i,
+  input  tcdm_mem_addr_t [NumTotalBanks-1:0] mem_add_i,
+  input  logic           [NumTotalBanks-1:0] mem_wen_i,
+  input  strb_t          [NumTotalBanks-1:0] mem_be_i,
+  input  data_t          [NumTotalBanks-1:0] mem_wdata_i,
+  output data_t          [NumTotalBanks-1:0] mem_rdata_o
+);
+
+  for (genvar i = 0; i < NumTotalBanks; i++) begin: gen_banks
+    tc_sram_impl #(
+      .NumWords   ( TCDMDepth         ),
+      .DataWidth  ( NarrowDataWidth   ),
+      .ByteWidth  ( 8                 ),
+      .NumPorts   ( 1                 ),
+      .Latency    ( 1                 ),
+      .impl_in_t  ( sram_cfg_t        )
+    ) i_data_mem (
+      .clk_i      ( clk_i             ),
+      .rst_ni     ( rst_ni            ),
+      .impl_i     ( sram_cfgs_i.tcdm  ),
+      .impl_o     ( /*Unused*/        ),
+      .req_i      ( mem_cs_i[i]       ),
+      .we_i       ( mem_wen_i[i]      ),
+      .addr_i     ( mem_add_i[i]      ),
+      .be_i       ( mem_be_i[i]       ),
+      .wdata_i    ( mem_wdata_i[i]    ),
+      .rdata_o    ( mem_rdata_o[i]    )
+    );
+  end
+
+endmodule

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -1,0 +1,47 @@
+// Copyright 2024 KU Leuven.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+// The actual cache memory. This memory is made into a module
+// to support multiple power domain needed by the floor plan tool
+
+module snitch_icache_data #(
+  parameter snitch_icache_pkg::config_t CFG = '0,
+  /// Configuration input types for SRAMs used in implementation.
+  parameter type sram_cfg_data_t    = logic
+)(
+  input  logic                                           clk_i,
+  input  logic                                           rst_ni,
+  input  sram_cfg_data_t                                 sram_cfg_data_i,
+  input  logic [  CFG.SET_COUNT-1:0]                     ram_enable_i,
+  input  logic                                           ram_write_i,
+  input  logic [CFG.COUNT_ALIGN-1:0]                     ram_addr_i,
+  input  logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_wdata_i,
+  output logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_rdata_o
+);
+
+  for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_data_sets
+    tc_sram_impl #(
+      .NumWords   ( CFG.LINE_COUNT  ),
+      .DataWidth  ( CFG.LINE_WIDTH  ),
+      .ByteWidth  ( 8               ),
+      .NumPorts   ( 1               ),
+      .Latency    ( 1               ),
+      .impl_in_t  ( sram_cfg_data_t )
+    ) i_data (
+      .clk_i      ( clk_i           ),
+      .rst_ni     ( rst_ni          ),
+      .impl_i     ( sram_cfg_data_i ),
+      .impl_o     ( /*Unused*/      ),
+      .req_i      ( ram_enable_i[i] ),
+      .we_i       ( ram_write_i     ),
+      .addr_i     ( ram_addr_i      ),
+      .wdata_i    ( ram_wdata_i     ),
+      .be_i       ( '1              ),
+      .rdata_o    ( ram_rdata_o[i]  )
+    );
+  end
+
+endmodule

--- a/hw/snitch_icache/src/snitch_icache_lookup.sv
+++ b/hw/snitch_icache/src/snitch_icache_lookup.sv
@@ -51,8 +51,8 @@ module snitch_icache_lookup #(
     // write accesses.
     logic [CFG.COUNT_ALIGN-1:0] ram_addr                             ;
     logic [CFG.SET_COUNT-1:0]   ram_enable                           ;
-    logic [CFG.LINE_WIDTH-1:0]  ram_wdata, ram_rdata [CFG.SET_COUNT] ;
-    logic [CFG.TAG_WIDTH+1:0]   ram_wtag,  ram_rtag  [CFG.SET_COUNT] ;
+    logic [CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0]  ram_wdata, ram_rdata  ;
+    logic [CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0]   ram_wtag,  ram_rtag  ;
     logic                       ram_write                            ;
     logic                       ram_write_q;
     logic [CFG.COUNT_ALIGN:0]   init_count_q;
@@ -144,47 +144,75 @@ module snitch_icache_lookup #(
     end
 
     // Instantiate the RAM sets.
-    for (genvar i = 0; i < CFG.SET_COUNT; i++) begin : g_sets
-        tc_sram_impl #(
-          .NumWords (CFG.LINE_COUNT),
-          .DataWidth (CFG.TAG_WIDTH+2),
-          .ByteWidth (8),
-          .NumPorts (1),
-          .Latency (1),
-          .impl_in_t (sram_cfg_tag_t)
-        ) i_tag (
-          .clk_i (clk_i),
-          .rst_ni (rst_ni),
-          .impl_i (sram_cfg_tag_i),
-          .impl_o (  ),
-          .req_i (ram_enable[i]),
-          .we_i (ram_write),
-          .addr_i (ram_addr),
-          .wdata_i (ram_wtag),
-          .be_i ('1),
-          .rdata_o (ram_rtag[i])
-        );
+    snitch_icache_data #(
+        .CFG             ( CFG              ),
+        .sram_cfg_data_t ( sram_cfg_data_t  )
+    ) i_snitch_icache_data (
+        .clk_i           ( clk_i            ),
+        .rst_ni          ( rst_ni           ),
+        .sram_cfg_data_i ( sram_cfg_data_i  ),
+        .ram_enable_i    ( ram_enable       ),
+        .ram_write_i     ( ram_write        ),
+        .ram_addr_i      ( ram_addr         ),
+        .ram_wdata_i     ( ram_wdata        ),
+        .ram_rdata_o     ( ram_rdata        )
+    );
 
-        tc_sram_impl #(
-          .NumWords (CFG.LINE_COUNT),
-          .DataWidth (CFG.LINE_WIDTH),
-          .ByteWidth (8),
-          .NumPorts (1),
-          .Latency (1),
-          .impl_in_t (sram_cfg_data_t)
-        ) i_data (
-          .clk_i (clk_i),
-          .rst_ni (rst_ni),
-          .impl_i (sram_cfg_data_i),
-          .impl_o (  ),
-          .req_i (ram_enable[i]),
-          .we_i (ram_write),
-          .addr_i (ram_addr),
-          .wdata_i (ram_wdata),
-          .be_i ('1),
-          .rdata_o (ram_rdata[i])
-        );
-    end
+    snitch_icache_tag #(
+        .CFG             ( CFG             ),
+        .sram_cfg_tag_t  ( sram_cfg_tag_t  )
+    ) i_snitch_icache_tag (
+        .clk_i           ( clk_i           ),
+        .rst_ni          ( rst_ni          ),
+        .sram_cfg_tag_i  ( sram_cfg_tag_i  ),
+        .ram_enable_i    ( ram_enable      ),
+        .ram_write_i     ( ram_write       ),
+        .ram_addr_i      ( ram_addr        ),
+        .ram_wtag_i      ( ram_wtag        ),
+        .ram_rtag_o      ( ram_rtag        )
+    );
+
+    // for (genvar i = 0; i < CFG.SET_COUNT; i++) begin : g_sets
+    //     tc_sram_impl #(
+    //       .NumWords (CFG.LINE_COUNT),
+    //       .DataWidth (CFG.TAG_WIDTH+2),
+    //       .ByteWidth (8),
+    //       .NumPorts (1),
+    //       .Latency (1),
+    //       .impl_in_t (sram_cfg_tag_t)
+    //     ) i_tag (
+    //       .clk_i (clk_i),
+    //       .rst_ni (rst_ni),
+    //       .impl_i (sram_cfg_tag_i),
+    //       .impl_o (  ),
+    //       .req_i (ram_enable[i]),
+    //       .we_i (ram_write),
+    //       .addr_i (ram_addr),
+    //       .wdata_i (ram_wtag),
+    //       .be_i ('1),
+    //       .rdata_o (ram_rtag[i])
+    //     );
+
+    //     tc_sram_impl #(
+    //       .NumWords (CFG.LINE_COUNT),
+    //       .DataWidth (CFG.LINE_WIDTH),
+    //       .ByteWidth (8),
+    //       .NumPorts (1),
+    //       .Latency (1),
+    //       .impl_in_t (sram_cfg_data_t)
+    //     ) i_data (
+    //       .clk_i (clk_i),
+    //       .rst_ni (rst_ni),
+    //       .impl_i (sram_cfg_data_i),
+    //       .impl_o (  ),
+    //       .req_i (ram_enable[i]),
+    //       .we_i (ram_write),
+    //       .addr_i (ram_addr),
+    //       .wdata_i (ram_wdata),
+    //       .be_i ('1),
+    //       .rdata_o (ram_rdata[i])
+    //     );
+    // end
 
     // Determine which RAM line hit, and multiplex that data to the output.
     logic [CFG.TAG_WIDTH-1:0] required_tag;

--- a/hw/snitch_icache/src/snitch_icache_lookup.sv
+++ b/hw/snitch_icache/src/snitch_icache_lookup.sv
@@ -172,48 +172,6 @@ module snitch_icache_lookup #(
         .ram_rtag_o      ( ram_rtag        )
     );
 
-    // for (genvar i = 0; i < CFG.SET_COUNT; i++) begin : g_sets
-    //     tc_sram_impl #(
-    //       .NumWords (CFG.LINE_COUNT),
-    //       .DataWidth (CFG.TAG_WIDTH+2),
-    //       .ByteWidth (8),
-    //       .NumPorts (1),
-    //       .Latency (1),
-    //       .impl_in_t (sram_cfg_tag_t)
-    //     ) i_tag (
-    //       .clk_i (clk_i),
-    //       .rst_ni (rst_ni),
-    //       .impl_i (sram_cfg_tag_i),
-    //       .impl_o (  ),
-    //       .req_i (ram_enable[i]),
-    //       .we_i (ram_write),
-    //       .addr_i (ram_addr),
-    //       .wdata_i (ram_wtag),
-    //       .be_i ('1),
-    //       .rdata_o (ram_rtag[i])
-    //     );
-
-    //     tc_sram_impl #(
-    //       .NumWords (CFG.LINE_COUNT),
-    //       .DataWidth (CFG.LINE_WIDTH),
-    //       .ByteWidth (8),
-    //       .NumPorts (1),
-    //       .Latency (1),
-    //       .impl_in_t (sram_cfg_data_t)
-    //     ) i_data (
-    //       .clk_i (clk_i),
-    //       .rst_ni (rst_ni),
-    //       .impl_i (sram_cfg_data_i),
-    //       .impl_o (  ),
-    //       .req_i (ram_enable[i]),
-    //       .we_i (ram_write),
-    //       .addr_i (ram_addr),
-    //       .wdata_i (ram_wdata),
-    //       .be_i ('1),
-    //       .rdata_o (ram_rdata[i])
-    //     );
-    // end
-
     // Determine which RAM line hit, and multiplex that data to the output.
     logic [CFG.TAG_WIDTH-1:0] required_tag;
     logic [CFG.SET_COUNT-1:0] line_hit;

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -1,0 +1,47 @@
+// Copyright 2024 KU Leuven.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+// The actual cache tag memory. This memory is made into a module
+// to support multiple power domain needed by the floor plan tool
+
+module snitch_icache_tag #(
+  parameter snitch_icache_pkg::config_t CFG = '0,
+  /// Configuration input types for SRAMs used in implementation.
+  parameter type sram_cfg_tag_t   = logic
+)(
+  input  logic                                          clk_i,
+  input  logic                                          rst_ni,
+  input  sram_cfg_tag_t                                 sram_cfg_tag_i,
+  input  logic [  CFG.SET_COUNT-1:0]                    ram_enable_i,
+  input  logic                                          ram_write_i,
+  input  logic [CFG.COUNT_ALIGN-1:0]                    ram_addr_i,
+  input  logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_wtag_i,
+  output logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_rtag_o
+);
+
+  for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_tag_sets
+    tc_sram_impl #(
+      .NumWords   ( CFG.LINE_COUNT  ),
+      .DataWidth  ( CFG.TAG_WIDTH+2 ),
+      .ByteWidth  ( 8               ),
+      .NumPorts   ( 1               ),
+      .Latency    ( 1               ),
+      .impl_in_t  ( sram_cfg_tag_t  )
+    ) i_tag (
+      .clk_i      ( clk_i           ),
+      .rst_ni     ( rst_ni          ),
+      .impl_i     ( sram_cfg_tag_i  ),
+      .impl_o     ( /*Unused*/      ),
+      .req_i      ( ram_enable_i[i] ),
+      .we_i       ( ram_write_i     ),
+      .addr_i     ( ram_addr_i      ),
+      .wdata_i    ( ram_wtag_i      ),
+      .be_i       ( '1              ),
+      .rdata_o    ( ram_rtag_o[i]   )
+    );
+  end
+
+endmodule


### PR DESCRIPTION
This PR moves the instantiated memories into modules. This is necessary to allow better power routing for PNR.

**NOTE: This does not change anything functionally. So the only check is to see if all tests still pass.**
**DOUBLE NOTE: This is urgent for tapeout purposes**

Major TODOs:
- [x] Move icache data into a module
- [x] Move icache tag into a module
- [x] Move TCDM memories into a module
- [x] Make sure all tests pass