### PR TITLE
Fix snitch_icache wire widths

### DIFF
--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -18,7 +18,7 @@ module snitch_icache_data #(
   input  logic [  CFG.SET_COUNT-1:0]                     ram_enable_i,
   input  logic                                           ram_write_i,
   input  logic [CFG.COUNT_ALIGN-1:0]                     ram_addr_i,
-  input  logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_wdata_i,
+  input  logic                      [CFG.LINE_WIDTH-1:0] ram_wdata_i,
   output logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_rdata_o
 );
 

--- a/hw/snitch_icache/src/snitch_icache_lookup.sv
+++ b/hw/snitch_icache/src/snitch_icache_lookup.sv
@@ -51,8 +51,10 @@ module snitch_icache_lookup #(
     // write accesses.
     logic [CFG.COUNT_ALIGN-1:0] ram_addr                             ;
     logic [CFG.SET_COUNT-1:0]   ram_enable                           ;
-    logic [CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0]  ram_wdata, ram_rdata  ;
-    logic [CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0]   ram_wtag,  ram_rtag  ;
+    logic [CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0]  ram_rdata         ;
+    logic [CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0]   ram_rtag          ;
+    logic                    [CFG.LINE_WIDTH-1:0]  ram_wdata         ;
+    logic                    [CFG.TAG_WIDTH+1:0]   ram_wtag          ;
     logic                       ram_write                            ;
     logic                       ram_write_q;
     logic [CFG.COUNT_ALIGN:0]   init_count_q;

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -18,7 +18,7 @@ module snitch_icache_tag #(
   input  logic [  CFG.SET_COUNT-1:0]                    ram_enable_i,
   input  logic                                          ram_write_i,
   input  logic [CFG.COUNT_ALIGN-1:0]                    ram_addr_i,
-  input  logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_wtag_i,
+  input  logic                      [CFG.TAG_WIDTH+1:0] ram_wtag_i,
   output logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_rtag_o
 );
 


### PR DESCRIPTION
Noticed a width mismatch warning!

Previously, the variables were defined as follows:
```systemverilog
logic [CFG.LINE_WIDTH-1:0] ram_wdata, ram_rdata [CFG.SET_COUNT] ;
logic [CFG.TAG_WIDTH+1:0]   ram_wtag,  ram_rtag  [CFG.SET_COUNT] ;
```
Which actually means that `ram_wdata` has a width of only `CFG.LINE_WIDTH`, not `CFG.LINE_WIDTH*CFG.SET_COUNT`

#198 changed the sizing, this PR changes it back. This should not affect anything in the actual output, just reduces the number of warnings.