### PR TITLE
Improve XDMA extension generation process

### DIFF
--- a/hw/chisel/build.sbt
+++ b/hw/chisel/build.sbt
@@ -10,6 +10,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "snax-streamer",
     libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-compiler" % "2.13.14",
       "org.chipsalliance" %% "chisel" % chiselVersion,
       "edu.berkeley.cs" %% "chiseltest" % "6.0.0" % "test"
     ),

--- a/hw/chisel/build.sc
+++ b/hw/chisel/build.sc
@@ -18,6 +18,7 @@ object Snax extends SbtModule with ScalafmtModule { m =>
     "-Xcheckinit"
   )
   override def ivyDeps = Agg(
+    ivy"org.scala-lang:scala-compiler:2.13.14",
     ivy"org.chipsalliance::chisel:6.4.0",
     ivy"edu.berkeley.cs::chiseltest:6.0.0"
   )

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -11,6 +11,10 @@ import snax.xdma.xdmaExtension._
 import snax.xdma.DesignParams._
 import os.write
 
+import scala.reflect.runtime.currentMirror
+import scala.tools.reflect.ToolBox
+import scala.reflect.runtime.universe._
+
 class xdmaTopIO(
     readerparam: DMADataPathParam,
     writerparam: DMADataPathParam,
@@ -195,12 +199,28 @@ object xdmaTopGen extends App {
   )
   var readerextensionparam = Seq[HasDMAExtension]()
   var writerextensionparam = Seq[HasDMAExtension]()
-  if (parsed_args.contains("HasMemset"))
-    writerextensionparam = writerextensionparam :+ HasMemset
-  if (parsed_args.contains("HasMaxPool"))
-    writerextensionparam = writerextensionparam :+ HasMaxPool
-  if (parsed_args.contains("HasTransposer"))
-    writerextensionparam = writerextensionparam :+ HasTransposer
+
+  // The following complex code is to dynamically load the extension modules
+  // The target is that: 1) the sequence of the extension can be specified by the user 2) users can add their own extensions in the minimal effort (Does not need to modify the generation code)
+  // The mechanism is that a small and temporary scala binary is compiled during the execution, to retrieve the instantiation object from the name
+  // E.g. "HasMaxPool" -> HasMaxPool object
+  // Thus, the generation function does not need to be modified by the extension developers. 
+  // Extension developers only need to 1) Add the Extension source code 2) Add Has...: #priority in hjson configuration file
+
+  val toolbox = currentMirror.mkToolBox()
+  parsed_args
+    .filter(i => i._1.startsWith("Has") && i._2.toInt > 0)
+    .toSeq
+    .map(i => (i._1, i._2.toInt))
+    .sortWith(_._2 < _._2)
+    .foreach(i => {
+      writerextensionparam = writerextensionparam :+ toolbox
+        .compile(toolbox.parse(s"""
+import snax.xdma.xdmaExtension._
+return ${i._1}
+      """))()
+        .asInstanceOf[HasDMAExtension]
+    })
 
   // Generation of the hardware
   emitVerilog(

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -204,7 +204,7 @@ object xdmaTopGen extends App {
   // The target is that: 1) the sequence of the extension can be specified by the user 2) users can add their own extensions in the minimal effort (Does not need to modify the generation code)
   // The mechanism is that a small and temporary scala binary is compiled during the execution, to retrieve the instantiation object from the name
   // E.g. "HasMaxPool" -> HasMaxPool object
-  // Thus, the generation function does not need to be modified by the extension developers. 
+  // Thus, the generation function does not need to be modified by the extension developers.
   // Extension developers only need to 1) Add the Extension source code 2) Add Has...: #priority in hjson configuration file
 
   val toolbox = currentMirror.mkToolBox()

--- a/target/snitch_cluster/cfg/snax-streamer-gemmX-xdma.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemmX-xdma.hjson
@@ -136,9 +136,9 @@
             writer_buffer: 8, 
             reader_agu_dimension: 3, 
             writer_agu_dimension: 3, 
-            has_transposer: true, 
-            has_maxpool: true, 
-            has_memset: true
+            HasTransposer: 3, 
+            HasMemset: 1, 
+            HasMaxPool: 2
         }
         xdma: false
         xssr: false

--- a/util/wrappergen/wrappergen.py
+++ b/util/wrappergen/wrappergen.py
@@ -325,7 +325,11 @@ def main():
             file_name=cfg["cluster"]["name"] + "_xdma_wrapper.sv",
         )
 
-        print(args.gen_path)
+        xdma_extension_arg = ""
+        for key, value in snax_xdma_cfg.items():
+            if key.startswith("Has"):
+                xdma_extension_arg += f" --{key} {value}"
+
         gen_chisel_file(
             chisel_path=args.chisel_path,
             chisel_param="snax.xdma.xdmaTop.xdmaTopGen",
@@ -338,9 +342,7 @@ def main():
             " --writerDimension " + str(snax_xdma_cfg["writer_agu_dimension"]) +
             " --readerBufferDepth " + str(snax_xdma_cfg["reader_buffer"]) +
             " --writerBufferDepth " + str(snax_xdma_cfg["writer_buffer"]) +
-            (" --HasMemset " if snax_xdma_cfg["has_memset"] else "") +
-            (" --HasMaxPool " if snax_xdma_cfg["has_maxpool"] else "") +
-            (" --HasTransposer " if snax_xdma_cfg["has_transposer"] else "") +
+            xdma_extension_arg +
             " --hw-target-dir " + args.gen_path +
             cfg["cluster"]["name"] + "_xdma/" +
             " --sw-target-dir " + args.gen_path + "../sw/snax/xdma"


### PR DESCRIPTION
This PR adds a fancy feature during the hardware generation. 

Now, the extension developer does not need to add the long if-else statement for each new extension. Only by providing the name in the main cfg file, the xdma generator can automatically find the classes in the source file, and append it to extension list. 