### PR TITLE
Fix Snitch cluster CI

### DIFF
--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -844,9 +844,9 @@ module snitch_cc #(
     // We need to schedule the assignment into a safe region, otherwise
     // `hart_id_i` won't have a value assigned at the beginning of the first
     // delta cycle.
-    /* verilator lint_off STMTDLY */
+`ifndef VERILATOR
     #0;
-    /* verilator lint_on STMTDLY */
+`endif
     $system("mkdir logs -p");
     $sformat(fn, "logs/trace_hart_%05x.dasm", hart_id_i);
     f = $fopen(fn, "w");


### PR DESCRIPTION
The fix to this is because of the verilator definition for `#0` signals declarations in the file. The fix is similar to the fix in the original snitch cluster:

https://github.com/pulp-platform/snitch_cluster/blob/4652c6b05886757c5cbe3dfe77c196dcd71e08e7/hw/snitch_cluster/src/snitch_cc.sv#L862-L864

Essentially, this fixes the Snitch cluster fails. It's a simple fix 😄 