### PR TITLE
Set Verilator version v5.006

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -57,7 +57,7 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
 # Install Verilator
 RUN git clone https://github.com/verilator/verilator && \
   cd verilator && \
-  git checkout stable && \
+  git checkout v5.006 && \
   unset VERILATOR_ROOT && \
   autoconf && \
   ./configure && \


### PR DESCRIPTION
This PR sets the Verilator version to v5.006. This is more stable as it is in accordance with what the Snitch cluster is using.

Why need this?

- The CONVOLVE project must use the reduced AXI bandwidth to minimize routing congestion problems. The current AXI version they use is only working in v5.006 that's why they use it.

Nothing changes functionally and this is actually more "stable"

This will help PR #173  to finish building.

Please approve 😭 