### PR TITLE
Revert "Use verilator v5.006 (#211)"

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -57,7 +57,7 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
 # Install Verilator
 RUN git clone https://github.com/verilator/verilator && \
   cd verilator && \
-  git checkout v5.006 && \
+  git checkout stable && \
   unset VERILATOR_ROOT && \
   autoconf && \
   ./configure && \


### PR DESCRIPTION
Sorry! Need to revert back and will try to solve the AXI low bandwidth problem differently...

I'm having difficulty debugging it because when v5.006 build succeeds, the software tests fail when the low bandwidth AXI is used. Hence the only thing v5.006 fixes is the hardware build but I guess that is a clue to the problem I'm seeing.

I think it's indeed safer to be at the latest now hehe ^^;

