### PR TITLE
Separating cluster name targets for ease of use in top-level integration

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -424,7 +424,7 @@ sources:
   - target: snax_streamer_gemm_conv_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_conv_cluster.sv
-  - target:
+  - target: snax_wide_gemm_data_reshuffler_cluster
     files:
       - target/snitch_cluster/generated/snax_wide_gemm_data_reshuffler_cluster.sv
   - target: snax_streamer_gemm_cluster

--- a/Bender.yml
+++ b/Bender.yml
@@ -413,6 +413,9 @@ sources:
   - target: snax_mac_cluster
     files:
       - target/snitch_cluster/generated/snax_mac_cluster_wrapper.sv
+  - target: snax_mac_mult_cluster
+    files:
+      - target/snitch_cluster/generated/snax_mac_mult_cluster_wrapper.sv
   - target: snax_alu_cluster
     files:
       - target/snitch_cluster/generated/snax_alu_cluster_wrapper.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -421,25 +421,28 @@ sources:
   - target: snax_gemm_cluster
     files:
       - target/snitch_cluster/generated/snax_gemm_cluster_wrapper.sv
-  - target: any(snax_streamer_gemm, snax_wide_gemm_data_reshuffler)
+  - target: snax_streamer_gemm_conv_cluster
+    files:
+      - target/snitch_cluster/generated/snax_streamer_gemm_conv_cluster.sv
+  - target:
+    files:
+      - target/snitch_cluster/generated/snax_wide_gemm_data_reshuffler_cluster.sv
+  - target: snax_streamer_gemm_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_cluster_wrapper.sv
-  - target: snax_streamer_simd
+  - target: snax_streamer_simd_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_simd_cluster_wrapper.sv
-  - target: snax_data_reshuffler
+  - target: snax_data_reshuffler_cluster
     files:
       - target/snitch_cluster/generated/snax_data_reshuffler_cluster_wrapper.sv
-  - target: snax_data_reshuffler
-    files:
-      - target/snitch_cluster/generated/snax_data_reshuffler_cluster_wrapper.sv
-  - target: snax_streamer_gemmX
+  - target: snax_streamer_gemmX_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemmX_cluster_wrapper.sv
-  - target: snax_streamer_gemmX_xdma
+  - target: snax_streamer_gemmX_xdma_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemmX_xdma_cluster_wrapper.sv
-  - target: snax_streamer_gemm_add_c
+  - target: snax_streamer_gemm_add_c_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_add_c_cluster_wrapper.sv
 

--- a/Bender.yml
+++ b/Bender.yml
@@ -426,10 +426,10 @@ sources:
       - target/snitch_cluster/generated/snax_gemm_cluster_wrapper.sv
   - target: snax_streamer_gemm_conv_cluster
     files:
-      - target/snitch_cluster/generated/snax_streamer_gemm_conv_cluster.sv
+      - target/snitch_cluster/generated/snax_streamer_gemm_conv_cluster_wrapper.sv
   - target: snax_wide_gemm_data_reshuffler_cluster
     files:
-      - target/snitch_cluster/generated/snax_wide_gemm_data_reshuffler_cluster.sv
+      - target/snitch_cluster/generated/snax_wide_gemm_data_reshuffler_cluster_wrapper.sv
   - target: snax_streamer_gemm_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_cluster_wrapper.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -410,15 +410,15 @@ sources:
   - target: snitch_cluster
     files:
       - target/snitch_cluster/generated/snitch_cluster_wrapper.sv
-  - target: snax_mac
+  - target: snax_mac_cluster
     files:
       - target/snitch_cluster/generated/snax_mac_cluster_wrapper.sv
-  - target: snax_alu
+  - target: snax_alu_cluster
     files:
       - target/snitch_cluster/generated/snax_alu_cluster_wrapper.sv
   # Note: this is about to be obsolete
   # but it uses the old snax-gemm still
-  - target: snax-gemm
+  - target: snax_gemm_cluster
     files:
       - target/snitch_cluster/generated/snax_gemm_cluster_wrapper.sv
   - target: any(snax_streamer_gemm, snax_wide_gemm_data_reshuffler)

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -77,9 +77,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-gemm.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile	
 
-	VSIM_BENDER += -t snax-gemm
-	VLT_BENDER  += -t snax-gemm
-	VCS_BENDER  += -t snax-gemm
+	VSIM_BENDER += -t snax-gemm -t snax-gemm_cluster
+	VLT_BENDER  += -t snax-gemm -t snax-gemm_cluster
+	VCS_BENDER  += -t snax-gemm -t snax-gemm_cluster
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
@@ -113,9 +113,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-alu.hjson)
 
 	CLUSTER_NAME = snax_alu_cluster
 
-	VSIM_BENDER += -t snax_alu
-	VLT_BENDER  += -t snax_alu
-	VCS_BENDER  += -t snax_alu
+	VSIM_BENDER += -t snax_alu -t snax_alu_cluster
+	VLT_BENDER  += -t snax_alu -t snax_alu_cluster
+	VCS_BENDER  += -t snax_alu -t snax_alu_cluster
 
 endif
 
@@ -211,21 +211,21 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-mac.hjson)
 
 	BYPASS_ACCGEN = true
 	
-	VSIM_BENDER += -t snax_mac
-	VLT_BENDER  += -t snax_mac
-	VCS_BENDER  += -t snax_mac
+	VSIM_BENDER += -t snax_mac -t snax_mac_cluster
+	VLT_BENDER  += -t snax_mac -t snax_mac_cluster
+	VCS_BENDER  += -t snax_mac -t snax_mac_cluster
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-mac-mult.hjson)
 
-	CLUSTER_NAME  = snax_mac_cluster
+	CLUSTER_NAME  = snax_mac_mult_cluster
 
 	BYPASS_ACCGEN = true
 	
-	VSIM_BENDER += -t snax_mac
-	VLT_BENDER  += -t snax_mac
-	VCS_BENDER  += -t snax_mac
+	VSIM_BENDER += -t snax_mac -t snax_mac_mult_cluster
+	VLT_BENDER  += -t snax_mac -t snax_mac_mult_cluster
+	VCS_BENDER  += -t snax_mac -t snax_mac_mult_cluster
 
 endif
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -77,9 +77,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-gemm.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile	
 
-	VSIM_BENDER += -t snax-gemm -t snax-gemm_cluster
-	VLT_BENDER  += -t snax-gemm -t snax-gemm_cluster
-	VCS_BENDER  += -t snax-gemm -t snax-gemm_cluster
+	VSIM_BENDER += -t snax-gemm -t snax_gemm_cluster
+	VLT_BENDER  += -t snax-gemm -t snax_gemm_cluster
+	VCS_BENDER  += -t snax-gemm -t snax_gemm_cluster
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
@@ -89,9 +89,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
-	VSIM_BENDER += -t snax_streamer_gemm
-	VLT_BENDER  += -t snax_streamer_gemm
-	VCS_BENDER  += -t snax_streamer_gemm
+	VSIM_BENDER += -t snax_streamer_gemm -t snax_streamer_gemm_cluster
+	VLT_BENDER  += -t snax_streamer_gemm -t snax_streamer_gemm_cluster
+	VCS_BENDER  += -t snax_streamer_gemm -t snax_streamer_gemm_cluster
 
 endif
 
@@ -102,9 +102,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-simd.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-postprocessing-simd)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
-	VSIM_BENDER += -t snax_streamer_simd
-	VLT_BENDER  += -t snax_streamer_simd
-	VCS_BENDER  += -t snax_streamer_simd
+	VSIM_BENDER += -t snax_streamer_simd -t snax_streamer_simd_cluster
+	VLT_BENDER  += -t snax_streamer_simd -t snax_streamer_simd_cluster
+	VCS_BENDER  += -t snax_streamer_simd -t snax_streamer_simd_cluster
 
 
 endif
@@ -126,9 +126,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-data-reshuffler.hjson)
 	SNAX_CHISEL_ACC_GEN = true
 	include $(SNAX_CHISEL_ACC_PATH)/Makefile
 
-	VSIM_BENDER += -t snax_data_reshuffler
-	VLT_BENDER  += -t snax_data_reshuffler
-	VCS_BENDER  += -t snax_data_reshuffler
+	VSIM_BENDER += -t snax_data_reshuffler -t snax_data_reshuffler_cluster
+	VLT_BENDER  += -t snax_data_reshuffler -t snax_data_reshuffler_cluster
+	VCS_BENDER  += -t snax_data_reshuffler -t snax_data_reshuffler_cluster
 
 endif
 
@@ -138,22 +138,22 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm-add-c.hjson)
 	SNAX_CHISEL_ACC_GEN = true
     include $(SNAX_CHISEL_ACC_PATH)/Makefile
  
-    VSIM_BENDER += -t snax_streamer_gemm_add_c
-    VLT_BENDER  += -t snax_streamer_gemm_add_c
-    VCS_BENDER  += -t snax_streamer_gemm_add_c
+    VSIM_BENDER += -t snax_streamer_gemm_add_c -t snax_streamer_gemm_add_c_cluster
+    VLT_BENDER  += -t snax_streamer_gemm_add_c -t snax_streamer_gemm_add_c_cluster
+    VCS_BENDER  += -t snax_streamer_gemm_add_c -t snax_streamer_gemm_add_c_cluster
  
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm-conv.hjson)
 
-	CLUSTER_NAME = snax_streamer_gemm_cluster
+	CLUSTER_NAME = snax_streamer_gemm_conv_cluster
  
     SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
     include $(SNAX_GEMM_ROOT)/Makefile
 
-    VSIM_BENDER += -t snax_streamer_gemm
-    VLT_BENDER  += -t snax_streamer_gemm
-    VCS_BENDER  += -t snax_streamer_gemm
+    VSIM_BENDER += -t snax_streamer_gemm -t snax_streamer_gemm_conv_cluster
+    VLT_BENDER  += -t snax_streamer_gemm -t snax_streamer_gemm_conv_cluster
+    VCS_BENDER  += -t snax_streamer_gemm -t snax_streamer_gemm_conv_cluster
  
 endif
 
@@ -164,9 +164,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemmX.hjson)
 	SNAX_CHISEL_ACC_GEN = true
     include $(SNAX_CHISEL_ACC_PATH)/Makefile
  
-    VSIM_BENDER += -t snax_streamer_gemmX
-    VLT_BENDER  += -t snax_streamer_gemmX
-    VCS_BENDER  += -t snax_streamer_gemmX
+    VSIM_BENDER += -t snax_streamer_gemmX -t snax_streamer_gemmX_cluster
+    VLT_BENDER  += -t snax_streamer_gemmX -t snax_streamer_gemmX_cluster
+    VCS_BENDER  += -t snax_streamer_gemmX -t snax_streamer_gemmX_cluster
  
 endif
 
@@ -183,15 +183,15 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemmX-xdma.hjson)
 	$(GENERATED_DIR)/$(CLUSTER_NAME)_xdma/$(CLUSTER_NAME)_xdma.sv \
 	$(GENERATED_DIR)/$(CLUSTER_NAME)_xdma/$(CLUSTER_NAME)_xdma_wrapper.sv
  
-    VSIM_BENDER += -t snax_streamer_gemmX_xdma
-    VLT_BENDER  += -t snax_streamer_gemmX_xdma
-    VCS_BENDER  += -t snax_streamer_gemmX_xdma
+    VSIM_BENDER += -t snax_streamer_gemmX_xdma -t snax_streamer_gemmX_xdma_cluster
+    VLT_BENDER  += -t snax_streamer_gemmX_xdma -t snax_streamer_gemmX_xdma_cluster
+    VCS_BENDER  += -t snax_streamer_gemmX_xdma -t snax_streamer_gemmX_xdma_cluster
  
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-wide-gemm-data-reshuffler.hjson)
  
- 	CLUSTER_NAME = snax_streamer_gemm_cluster
+ 	CLUSTER_NAME = snax_wide_gemm_data_reshuffler_cluster
  
     SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
     include $(SNAX_GEMM_ROOT)/Makefile
@@ -199,9 +199,9 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-wide-gemm-data-reshuffler.hjson)
 	SNAX_CHISEL_ACC_GEN = true
 	include $(SNAX_CHISEL_ACC_PATH)/Makefile
 
-	VSIM_BENDER += -t snax_wide_gemm_data_reshuffler
-	VLT_BENDER  += -t snax_wide_gemm_data_reshuffler
-	VCS_BENDER  += -t snax_wide_gemm_data_reshuffler
+	VSIM_BENDER += -t snax_wide_gemm_data_reshuffler -t snax_wide_gemm_data_reshuffler_cluster
+	VLT_BENDER  += -t snax_wide_gemm_data_reshuffler -t snax_wide_gemm_data_reshuffler_cluster
+	VCS_BENDER  += -t snax_wide_gemm_data_reshuffler -t snax_wide_gemm_data_reshuffler_cluster
  
 endif
 

--- a/target/snitch_cluster/cfg/snax-streamer-gemm-conv.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm-conv.hjson
@@ -9,7 +9,7 @@
     },
 
     cluster: {
-        name: "snax_streamer_gemm_cluster",
+        name: "snax_streamer_gemm_conv_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 0, // 0x0

--- a/target/snitch_cluster/cfg/snax-wide-gemm-data-reshuffler.hjson
+++ b/target/snitch_cluster/cfg/snax-wide-gemm-data-reshuffler.hjson
@@ -12,7 +12,7 @@
     },
 
     cluster: {
-        name: "snax_streamer_gemm_cluster",
+        name: "snax_wide_gemm_data_reshuffler_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 0, // 0x0


### PR DESCRIPTION
This PR simply adds a new target definition to the bender to separate the cluster names. This is useful for top-level integration ensuring that each configuration file has its own cluster generated.