### PR TITLE
Synthesis switches for memory

### DIFF
--- a/hw/snitch_cluster/src/snitch_data_mem.sv
+++ b/hw/snitch_cluster/src/snitch_data_mem.sv
@@ -7,6 +7,9 @@
 // The actual data memory. This memory is made into a module
 // to support multiple power domain needed by the floor plan tool
 
+(* no_ungroup *)
+(* no_boundary_optimization *)
+
 module snitch_data_mem #(
   parameter int unsigned TCDMDepth       = 1024,
   parameter int unsigned NarrowDataWidth = 64,
@@ -30,6 +33,9 @@ module snitch_data_mem #(
 );
 
   for (genvar i = 0; i < NumTotalBanks; i++) begin: gen_banks
+
+`ifndef TAPEOUT_SYNTHESIS
+
     tc_sram_impl #(
       .NumWords   ( TCDMDepth         ),
       .DataWidth  ( NarrowDataWidth   ),
@@ -49,6 +55,37 @@ module snitch_data_mem #(
       .wdata_i    ( mem_wdata_i[i]    ),
       .rdata_o    ( mem_rdata_o[i]    )
     );
+
+`else
+
+    //----------------------------------------------------
+    // This is just a place holder for the synthesis tool
+    // The cache memory is wide hence we break it into two
+    //----------------------------------------------------
+
+    // Memory implementation for synthesis
+    // Converting the byte enable to bit enable
+    logic [NarrowDataWidth - 1 : 0] bit_en;
+
+    always_comb begin
+      for (int j = 0; j < NarrowDataWidth / 8; j = j + 1) begin
+        bit_en[j*8+:8] = {8{mem_be_i[j]}};
+      end
+    end
+
+    syn_data_mem i_data_mem(
+              .CLK    ( clk_i                               ),
+              .CEB    ( ~mem_cs_i[i]                        ),
+              .WEB    ( ~mem_wen_i[i]                       ),
+              .A      ( mem_add_i[i][$clog2(TCDMDepth)-1:0] ),
+              .D      ( mem_wdata_i[i]                      ),
+              .BWEB   ( ~bit_en                             ),
+              .RTSEL  ( 2'b01                               ),
+              .WTSEL  ( 2'b01                               ),
+              .Q      ( mem_rdata_o[i]                      )
+    );
+
+`endif
   end
 
 endmodule

--- a/hw/snitch_cluster/src/snitch_data_mem.sv
+++ b/hw/snitch_cluster/src/snitch_data_mem.sv
@@ -34,7 +34,7 @@ module snitch_data_mem #(
 
   for (genvar i = 0; i < NumTotalBanks; i++) begin: gen_banks
 
-`ifndef TAPEOUT_SYNTHESIS
+`ifndef TARGET_TAPEOUT
 
     tc_sram_impl #(
       .NumWords   ( TCDMDepth         ),

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -7,6 +7,9 @@
 // The actual cache memory. This memory is made into a module
 // to support multiple power domain needed by the floor plan tool
 
+(* no_ungroup *)
+(* no_boundary_optimization *)
+
 module snitch_icache_data #(
   parameter snitch_icache_pkg::config_t CFG = '0,
   /// Configuration input types for SRAMs used in implementation.
@@ -18,30 +21,62 @@ module snitch_icache_data #(
   input  logic [  CFG.SET_COUNT-1:0]                     ram_enable_i,
   input  logic                                           ram_write_i,
   input  logic [CFG.COUNT_ALIGN-1:0]                     ram_addr_i,
-  input  logic                      [CFG.LINE_WIDTH-1:0] ram_wdata_i,
+  input  logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_wdata_i,
   output logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_rdata_o
 );
 
   for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_data_sets
-    tc_sram_impl #(
-      .NumWords   ( CFG.LINE_COUNT  ),
-      .DataWidth  ( CFG.LINE_WIDTH  ),
-      .ByteWidth  ( 8               ),
-      .NumPorts   ( 1               ),
-      .Latency    ( 1               ),
-      .impl_in_t  ( sram_cfg_data_t )
-    ) i_data (
-      .clk_i      ( clk_i           ),
-      .rst_ni     ( rst_ni          ),
-      .impl_i     ( sram_cfg_data_i ),
-      .impl_o     ( /*Unused*/      ),
-      .req_i      ( ram_enable_i[i] ),
-      .we_i       ( ram_write_i     ),
-      .addr_i     ( ram_addr_i      ),
-      .wdata_i    ( ram_wdata_i     ),
-      .be_i       ( '1              ),
-      .rdata_o    ( ram_rdata_o[i]  )
-    );
-  end
 
+`ifndef TAPEOUT_SYNTHESIS
+
+      tc_sram_impl #(
+        .NumWords   ( CFG.LINE_COUNT  ),
+        .DataWidth  ( CFG.LINE_WIDTH  ),
+        .ByteWidth  ( 8               ),
+        .NumPorts   ( 1               ),
+        .Latency    ( 1               ),
+        .impl_in_t  ( sram_cfg_data_t )
+      ) i_data (
+        .clk_i      ( clk_i           ),
+        .rst_ni     ( rst_ni          ),
+        .impl_i     ( sram_cfg_data_i ),
+        .impl_o     ( /*Unused*/      ),
+        .req_i      ( ram_enable_i[i] ),
+        .we_i       ( ram_write_i     ),
+        .addr_i     ( ram_addr_i      ),
+        .wdata_i    ( ram_wdata_i[i]  ),
+        .be_i       ( '1              ),
+        .rdata_o    ( ram_rdata_o[i]  )
+      );
+
+`else
+
+      //----------------------------------------------------
+      // This is just a place holder for the synthesis tool
+      // The cache memory is wide hence we break it into two
+      //----------------------------------------------------
+      syn_memory i_cache_mem_0(
+                  .CLK    ( clk_i                                                  ),
+                  .CEB    ( ~ram_enable_i[i]                                       ),
+                  .WEB    ( ~ram_write_i                                           ),
+                  .A      ( ram_addr_i                                             ),
+                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2]  ),
+                  .BWEB   ( '0                                                     ),
+                  .RTSEL  ( 2'b01                                                  ),
+                  .WTSEL  ( 2'b01                                                  ),
+                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2]) );
+
+      syn_memory i_cache_mem_1(
+                  .CLK    ( clk_i                                   ),
+                  .CEB    ( ~ram_enable_i[i]                        ),
+                  .WEB    ( ~ram_write_i                            ),
+                  .A      ( ram_addr_i                              ),
+                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)/2-1:0]  ),
+                  .BWEB   ( '0                                      ),
+                  .RTSEL  ( 2'b01                                   ),
+                  .WTSEL  ( 2'b01                                   ),
+                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)/2-1:0]) );
+`endif
+
+  end
 endmodule

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -21,7 +21,7 @@ module snitch_icache_data #(
   input  logic [  CFG.SET_COUNT-1:0]                     ram_enable_i,
   input  logic                                           ram_write_i,
   input  logic [CFG.COUNT_ALIGN-1:0]                     ram_addr_i,
-  input  logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_wdata_i,
+  input  logic                      [CFG.LINE_WIDTH-1:0] ram_wdata_i,
   output logic [  CFG.SET_COUNT-1:0][CFG.LINE_WIDTH-1:0] ram_rdata_o
 );
 
@@ -44,7 +44,7 @@ module snitch_icache_data #(
         .req_i      ( ram_enable_i[i] ),
         .we_i       ( ram_write_i     ),
         .addr_i     ( ram_addr_i      ),
-        .wdata_i    ( ram_wdata_i[i]  ),
+        .wdata_i    ( ram_wdata_i     ),
         .be_i       ( '1              ),
         .rdata_o    ( ram_rdata_o[i]  )
       );
@@ -60,7 +60,7 @@ module snitch_icache_data #(
                   .CEB    ( ~ram_enable_i[i]                                      ),
                   .WEB    ( ~ram_write_i                                          ),
                   .A      ( ram_addr_i                                            ),
-                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] ),
+                  .D      ( ram_wdata_i   [(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] ),
                   .BWEB   ( '0                                                    ),
                   .RTSEL  ( 2'b01                                                 ),
                   .WTSEL  ( 2'b01                                                 ),
@@ -72,7 +72,7 @@ module snitch_icache_data #(
                   .CEB    ( ~ram_enable_i[i]                       ),
                   .WEB    ( ~ram_write_i                           ),
                   .A      ( ram_addr_i                             ),
-                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)/2-1:0] ),
+                  .D      ( ram_wdata_i   [(CFG.LINE_WIDTH)/2-1:0] ),
                   .BWEB   ( '0                                     ),
                   .RTSEL  ( 2'b01                                  ),
                   .WTSEL  ( 2'b01                                  ),

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -76,10 +76,11 @@ module snitch_icache_data #(
                   .BWEB   ( '0                                     ),
                   .RTSEL  ( 2'b01                                  ),
                   .WTSEL  ( 2'b01                                  ),
-                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)/2-1:0] ) 
+                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)/2-1:0] )
       );
 
 `endif
 
   end
+
 endmodule

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -55,7 +55,7 @@ module snitch_icache_data #(
       // This is just a place holder for the synthesis tool
       // The cache memory is wide hence we break it into two
       //----------------------------------------------------
-      syn_memory i_cache_mem_0(
+      syn_cache_data_mem i_cache_mem_0(
                   .CLK    ( clk_i                                                 ),
                   .CEB    ( ~ram_enable_i[i]                                      ),
                   .WEB    ( ~ram_write_i                                          ),
@@ -67,7 +67,7 @@ module snitch_icache_data #(
                   .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] )
       );
 
-      syn_memory i_cache_mem_1(
+      syn_cache_data_mem i_cache_mem_1(
                   .CLK    ( clk_i                                  ),
                   .CEB    ( ~ram_enable_i[i]                       ),
                   .WEB    ( ~ram_write_i                           ),

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -56,26 +56,29 @@ module snitch_icache_data #(
       // The cache memory is wide hence we break it into two
       //----------------------------------------------------
       syn_memory i_cache_mem_0(
-                  .CLK    ( clk_i                                                  ),
-                  .CEB    ( ~ram_enable_i[i]                                       ),
-                  .WEB    ( ~ram_write_i                                           ),
-                  .A      ( ram_addr_i                                             ),
-                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2]  ),
-                  .BWEB   ( '0                                                     ),
-                  .RTSEL  ( 2'b01                                                  ),
-                  .WTSEL  ( 2'b01                                                  ),
-                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2]) );
+                  .CLK    ( clk_i                                                 ),
+                  .CEB    ( ~ram_enable_i[i]                                      ),
+                  .WEB    ( ~ram_write_i                                          ),
+                  .A      ( ram_addr_i                                            ),
+                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] ),
+                  .BWEB   ( '0                                                    ),
+                  .RTSEL  ( 2'b01                                                 ),
+                  .WTSEL  ( 2'b01                                                 ),
+                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] )
+      );
 
       syn_memory i_cache_mem_1(
-                  .CLK    ( clk_i                                   ),
-                  .CEB    ( ~ram_enable_i[i]                        ),
-                  .WEB    ( ~ram_write_i                            ),
-                  .A      ( ram_addr_i                              ),
-                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)/2-1:0]  ),
-                  .BWEB   ( '0                                      ),
-                  .RTSEL  ( 2'b01                                   ),
-                  .WTSEL  ( 2'b01                                   ),
-                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)/2-1:0]) );
+                  .CLK    ( clk_i                                  ),
+                  .CEB    ( ~ram_enable_i[i]                       ),
+                  .WEB    ( ~ram_write_i                           ),
+                  .A      ( ram_addr_i                             ),
+                  .D      ( ram_wdata_i[i][(CFG.LINE_WIDTH)/2-1:0] ),
+                  .BWEB   ( '0                                     ),
+                  .RTSEL  ( 2'b01                                  ),
+                  .WTSEL  ( 2'b01                                  ),
+                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)/2-1:0] ) 
+      );
+
 `endif
 
   end

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -27,7 +27,7 @@ module snitch_icache_data #(
 
   for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_data_sets
 
-`ifndef TAPEOUT_SYNTHESIS
+`ifndef TARGET_TAPEOUT
 
       tc_sram_impl #(
         .NumWords   ( CFG.LINE_COUNT  ),

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -21,7 +21,7 @@ module snitch_icache_tag #(
   input  logic [  CFG.SET_COUNT-1:0]                    ram_enable_i,
   input  logic                                          ram_write_i,
   input  logic [CFG.COUNT_ALIGN-1:0]                    ram_addr_i,
-  input  logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_wtag_i,
+  input  logic                      [CFG.TAG_WIDTH+1:0] ram_wtag_i,
   output logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_rtag_o
 );
 
@@ -44,7 +44,7 @@ module snitch_icache_tag #(
         .req_i      ( ram_enable_i[i] ),
         .we_i       ( ram_write_i     ),
         .addr_i     ( ram_addr_i      ),
-        .wdata_i    ( ram_wtag_i[i]   ),
+        .wdata_i    ( ram_wtag_i      ),
         .be_i       ( '1              ),
         .rdata_o    ( ram_rtag_o[i]   )
       );
@@ -59,7 +59,7 @@ module snitch_icache_tag #(
                 .CEB   ( ~ram_enable_i[i] ),
                 .WEB   ( ~ram_write_i     ),
                 .A     ( ram_addr_i       ),
-                .D     ( ram_wtag_i[i]    ),
+                .D     ( ram_wtag_i       ),
                 .BWEB  ( '0               ),
                 .RTSEL ( 2'b01            ),
                 .WTSEL ( 2'b01            ),

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -54,7 +54,7 @@ module snitch_icache_tag #(
     //----------------------------------------------------
     // This is just a place holder for the synthesis tool
     //----------------------------------------------------
-    syn_memory i_tag_mem(
+    syn_cache_tag_mem i_tag_mem(
                 .CLK   ( clk_i            ),
                 .CEB   ( ~ram_enable_i[i] ),
                 .WEB   ( ~ram_write_i     ),

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -25,49 +25,49 @@ module snitch_icache_tag #(
   output logic [  CFG.SET_COUNT-1:0][CFG.TAG_WIDTH+1:0] ram_rtag_o
 );
 
-for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_tag_sets
+  for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_tag_sets
 
 `ifndef TAPEOUT_SYNTHESIS
 
-    tc_sram_impl #(
-      .NumWords   ( CFG.LINE_COUNT  ),
-      .DataWidth  ( CFG.TAG_WIDTH+2 ),
-      .ByteWidth  ( 8               ),
-      .NumPorts   ( 1               ),
-      .Latency    ( 1               ),
-      .impl_in_t  ( sram_cfg_tag_t  )
-    ) i_tag (
-      .clk_i      ( clk_i           ),
-      .rst_ni     ( rst_ni          ),
-      .impl_i     ( sram_cfg_tag_i  ),
-      .impl_o     ( /*Unused*/      ),
-      .req_i      ( ram_enable_i[i] ),
-      .we_i       ( ram_write_i     ),
-      .addr_i     ( ram_addr_i      ),
-      .wdata_i    ( ram_wtag_i[i]   ),
-      .be_i       ( '1              ),
-      .rdata_o    ( ram_rtag_o[i]   )
-    );
+      tc_sram_impl #(
+        .NumWords   ( CFG.LINE_COUNT  ),
+        .DataWidth  ( CFG.TAG_WIDTH+2 ),
+        .ByteWidth  ( 8               ),
+        .NumPorts   ( 1               ),
+        .Latency    ( 1               ),
+        .impl_in_t  ( sram_cfg_tag_t  )
+      ) i_tag (
+        .clk_i      ( clk_i           ),
+        .rst_ni     ( rst_ni          ),
+        .impl_i     ( sram_cfg_tag_i  ),
+        .impl_o     ( /*Unused*/      ),
+        .req_i      ( ram_enable_i[i] ),
+        .we_i       ( ram_write_i     ),
+        .addr_i     ( ram_addr_i      ),
+        .wdata_i    ( ram_wtag_i[i]   ),
+        .be_i       ( '1              ),
+        .rdata_o    ( ram_rtag_o[i]   )
+      );
 
 `else
 
-  //----------------------------------------------------
-  // This is just a place holder for the synthesis tool
-  //----------------------------------------------------
-  syn_memory i_tag_mem(
-              .CLK   ( clk_i            ),
-              .CEB   ( ~ram_enable_i[i] ),
-              .WEB   ( ~ram_write_i     ),
-              .A     ( ram_addr_i       ),
-              .D     ( ram_wtag_i[i]    ),
-              .BWEB  ( '0               ),
-              .RTSEL ( 2'b01            ),
-              .WTSEL ( 2'b01            ),
-              .Q     ( ram_rtag_o[i]    )
-    );
+    //----------------------------------------------------
+    // This is just a place holder for the synthesis tool
+    //----------------------------------------------------
+    syn_memory i_tag_mem(
+                .CLK   ( clk_i            ),
+                .CEB   ( ~ram_enable_i[i] ),
+                .WEB   ( ~ram_write_i     ),
+                .A     ( ram_addr_i       ),
+                .D     ( ram_wtag_i[i]    ),
+                .BWEB  ( '0               ),
+                .RTSEL ( 2'b01            ),
+                .WTSEL ( 2'b01            ),
+                .Q     ( ram_rtag_o[i]    )
+      );
 
 `endif
 
-end
+  end
 
 endmodule

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -27,7 +27,7 @@ module snitch_icache_tag #(
 
   for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_tag_sets
 
-`ifndef TAPEOUT_SYNTHESIS
+`ifndef TARGET_TAPEOUT
 
       tc_sram_impl #(
         .NumWords   ( CFG.LINE_COUNT  ),


### PR DESCRIPTION
This is a PR request from @guilherme-paim to add switch hooks for our internal tape out. Nothing changes functionally but just adding `TARGET_TAPEOUT` as macro defined switches.