### PR TITLE
Setting AXI version in bender to be fixed to 0.39.1

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -4,4 +4,4 @@
 
 overrides:
     # Some of our dependencies have false conflicts with our new AXI version; force our version.
-    axi: {git: https://github.com/pulp-platform/axi.git, version: 0.39.0}
+    axi: {git: https://github.com/pulp-platform/axi.git, version: =0.39.1}


### PR DESCRIPTION
This PR addresses issue #221 because the Bender.local overwrites the AXI version to be used. We need to use 0.39.1 for the CONVOLVE project.

The fix is to set `=0.39.1` in the Bender.local.

I opted to set it there than the main Bender file because the main Bender file will prompt to over-write:

![image](https://github.com/user-attachments/assets/62f0403e-3448-49bd-bd1b-f258b7239485)

Placing it in Bender.local overrides all the prompts.