### PR TITLE
New AddressGen for xdma

### DIFF
--- a/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
@@ -48,13 +48,62 @@ object AddressGenUnitParam {
   def apply(
       dimension: Int,
       addressWidth: Int,
-      spatialUnrollingFactor: Int,
+      channels: Int,
       outputBufferDepth: Int
   ) = new AddressGenUnitParam(
     dimension = dimension,
     addressWidth = addressWidth,
-    channels = spatialUnrollingFactor,
+    channels = channels,
     outputBufferDepth = outputBufferDepth
+  )
+}
+
+class AddressGenUnitNoMulDivParam(
+    val dimension: Int,
+    val addressWidth: Int,
+    val channels: Int,
+    val outputBufferDepth: Int,
+    val memorySize: Int
+) {
+  def toAddressGenUnitParam = AddressGenUnitParam(
+    dimension = dimension,
+    addressWidth = addressWidth,
+    channels = channels,
+    outputBufferDepth = outputBufferDepth
+  )
+}
+
+object AddressGenUnitNoMulDivParam {
+  // The Very Simple instantiation of the Param
+  def apply() = new AddressGenUnitNoMulDivParam(
+    dimension = 3,
+    addressWidth = 48,
+    channels = 8,
+    outputBufferDepth = 8,
+    memorySize = 128
+  )
+  def apply(
+      dimension: Int,
+      addressWidth: Int,
+      channels: Int,
+      outputBufferDepth: Int,
+      memorySize: Int
+  ) = new AddressGenUnitNoMulDivParam(
+    dimension = dimension,
+    addressWidth = addressWidth,
+    channels = channels,
+    outputBufferDepth = outputBufferDepth,
+    memorySize = memorySize
+  )
+  def apply(
+      agu_param: AddressGenUnitParam,
+      memorySize: Int
+  ) = new AddressGenUnitNoMulDivParam(
+    dimension = agu_param.dimension,
+    addressWidth = agu_param.addressWidth,
+    channels = agu_param.channels,
+    outputBufferDepth = agu_param.outputBufferDepth,
+    memorySize = memorySize
   )
 }
 
@@ -70,7 +119,7 @@ class ReaderWriterParam(
   val agu_param = AddressGenUnitParam(
     dimension = dimension,
     addressWidth = tcdmAddressWidth,
-    spatialUnrollingFactor = numChannel,
+    channels = numChannel,
     outputBufferDepth = addressBufferDepth
   )
 

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -77,7 +77,7 @@ class ProgrammableCounter(width: Int, hasCeil: Boolean = true)
   nextValue := {
     if (hasCeil) {
       Mux(
-        io.reset || io.lastVal,
+        io.reset || (io.lastVal && io.tick),
         0.U,
         Mux(io.tick, value + io.step, value)
       )

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -6,6 +6,14 @@ import chisel3.util._
 import snax.xdma.CommonCells._
 import snax.xdma.DesignParams._
 
+/** This class represents a basic counter module in Chisel.
+  *
+  * @param width
+  *   The width of the counter.
+  * @param hasCeil
+  *   Indicates whether the counter has a ceiling value.
+  */
+
 class BasicCounter(width: Int, hasCeil: Boolean = true)
     extends Module
     with RequireAsyncReset {
@@ -36,6 +44,49 @@ class BasicCounter(width: Int, hasCeil: Boolean = true)
   io.lastVal := {
     if (hasCeil) (value === io.ceil - 1.U) else (value.andR)
   }
+}
+
+class ProgrammableCounter(width: Int, hasCeil: Boolean = true)
+    extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    val tick = Input(Bool())
+    val reset = Input(Bool())
+    val ceil = Input(UInt(width.W))
+    val step = Input(UInt((width - 1).W))
+
+    val value = Output(UInt(width.W))
+    val lastVal = Output(Bool())
+  })
+  val nextValue = Wire(UInt(width.W))
+  val value = RegNext(nextValue, 0.U)
+
+  // If has ceil, a small counter is used to count the step
+  // The small counter's function is to determine whether the ceil is reached, and a reset is needed.
+  if (hasCeil) {
+    val smallCounter = Module(new BasicCounter(width, hasCeil) {
+      override val desiredName = "ProgrammableCounter_SmallCounter"
+    })
+
+    smallCounter.io.tick := io.tick
+    smallCounter.io.reset := io.reset
+    smallCounter.io.ceil := io.ceil
+    io.lastVal := smallCounter.io.lastVal
+  }
+
+  nextValue := {
+    if (hasCeil) {
+      Mux(
+        io.reset || io.lastVal,
+        0.U,
+        Mux(io.tick, value + io.step, value)
+      )
+    } else {
+      Mux(io.reset, 0.U, Mux(io.tick, value + io.step, value))
+    }
+  }
+
+  io.value := value
 }
 
 /** AGU is the module to automatically generate the address for all ports.
@@ -161,4 +212,133 @@ class AddressGenUnit(
 
   // Connect io.bufferEmpty signal: If all output is 0, then all addresses are empty, which means io.bufferEmpty should be high
   io.bufferEmpty := ~(outputBuffer.io.out.map(i => i.valid).reduce(_ | _))
+}
+
+/** AGU is the module to automatically generate the address for all ports.
+  * @input
+  *   cfg The description of the Address Generation Task. It is normally
+  *   configured by CSR manager
+  * @input
+  *   start The signal to start a address generation task
+  * @output
+  *   busy The signal to indicate whether all address generation is finished.
+  *   Only when busy == 0 the next address generation task can be launched
+  * @output
+  *   addresses The Vec[Decoupled[UInt]] signal to give tcdm_requestors the
+  *   address
+  * @param AddressGenUnitParam
+  *   The parameter used for generation of the module This version of AGU aims
+  *   to totally remove multiplication and division in temporal address
+  *   generation
+  */
+class AddressGenUnitNoMulDiv(
+    param: AddressGenUnitNoMulDivParam,
+    module_name_prefix: String = "unnamed_cluster"
+) extends Module
+    with RequireAsyncReset {
+  val io = IO(new Bundle {
+    val cfg = Input(new AddressGenUnitCfgIO(param.toAddressGenUnitParam))
+    // Intake the new cfg file and reset all the counters
+    val start = Input(Bool())
+    // If the address is all generated and pushed into FIFO, busy is false
+    val busy = Output(Bool())
+    // If all signal in address buffer is consumed, bufferEmpty becomes high (Dont know if it is useful)
+    val bufferEmpty = Output(Bool())
+    // The calculated address. This equals to # of output channels (64-bit narrow TCDM)
+    val addr =
+      Vec(param.channels, Decoupled(UInt(param.addressWidth.W)))
+    val enabled_channels = Vec(param.channels, Output(Bool()))
+  })
+
+  override val desiredName = s"${module_name_prefix}_AddressGenUnitNoMulDiv"
+
+  // Create counters for each dimension
+  // Be aware that counter is not needed for the first dimension, because it is the spatial bound
+  val counters = for (i <- 1 until param.dimension) yield {
+    val counter = Module(
+      new ProgrammableCounter(log2Up(param.memorySize << 10)) {
+        override val desiredName =
+          s"${module_name_prefix}_AddressGenUnitNoMulDiv_Counter_${i}"
+      }
+    )
+    counter.io.reset := io.start
+    // counter.io.tick is conenected later, when all necessary signal becomes available
+    counter.io.ceil := io.cfg.Bounds(i)
+    counter.io.step := io.cfg.Strides(i)
+    counter
+  }
+
+  // Create the outputBuffer to store the generated address: one input + spatialUnrollingFactor outputs
+  val outputBuffer = Module(
+    new ComplexQueueConcat(
+      inputWidth = io.addr.head.bits.getWidth * param.channels,
+      outputWidth = io.addr.head.bits.getWidth,
+      depth = param.outputBufferDepth
+    ) {
+      override val desiredName = s"${module_name_prefix}_AddressBufferFIFO"
+    }
+  )
+
+  // Calculate the current base address: the first stride need to be left-shifted
+  val temporalOffset = VecInit(counters.map(_.io.value)).reduceTree(_ + _)
+  val spatialOffsets = for (i <- 0 until param.channels) yield {
+    val spatialOffset = temporalOffset + io.cfg.Strides
+      .head(log2Up(param.memorySize << 10) - 1, 0) * i.U
+    spatialOffset
+  }
+
+  // Calculate all addresses for different channels together
+  val currentAddress = Wire(Vec(io.addr.length, UInt(param.addressWidth.W)))
+  currentAddress.zipWithIndex.foreach { case (address, index) =>
+    address := io.cfg.Ptr + spatialOffsets(index)
+  }
+
+  // Connect it to the input of outputBuffer
+  outputBuffer.io.in.head.bits := currentAddress.reduce((a, b) => Cat(b, a))
+
+  // Connect the outputs of the buffer out
+  outputBuffer.io.out.zip(io.addr).foreach { case (a, b) => a <> b }
+
+  // Connect io.bufferEmpty signal: If all output is 0, then all addresses are empty, which means io.bufferEmpty should be high
+  io.bufferEmpty := ~(outputBuffer.io.out.map(i => i.valid).reduce(_ | _))
+
+  // The FSM to record if the AddressGenUnit is busy
+  val sIDLE :: sBUSY :: Nil = Enum(2)
+  val currentState = RegInit(sIDLE)
+  when(io.start) {
+    currentState := sBUSY
+  }.elsewhen(
+    counters.map(_.io.lastVal).reduce(_ & _) && outputBuffer.io.in.head.fire
+  ) { // The output FIFO already accept the result
+    currentState := sIDLE
+  }.otherwise {
+    currentState := currentState
+  }
+
+  // When the AGU becomes busy, the valid signal is pulled up to put address in the fifo
+  outputBuffer.io.in.head.valid := currentState === sBUSY
+  // io.busy also determined by currentState
+  io.busy := currentState === sBUSY
+
+  // Spatial bound
+  // The innermost one is the spatial bound, so it should not be multiplied with other bounds. It should be used to generate enabled_channels signal
+  io.enabled_channels.zipWithIndex.foreach { case (a, b) =>
+    a := io.cfg.Bounds.head > b.U
+  }
+  assert(
+    io.cfg.Bounds.head <= param.channels.U,
+    "[AddressGenUnit] The innermost bound is spatial bound, so it should be less than or equal to the number of channels"
+  )
+
+  // Temporal bounds' tick signal (enable signal)
+  val counters_tick =
+    currentState === sBUSY && outputBuffer.io.in.head.fire // FIFO still have the space to take the new address
+  // First counter's tick is connected to the start signal
+  counters.head.io.tick := counters_tick
+  // Other counters' tick is connected to the previous counter's lastVal & counters_tick
+  if (counters.length > 1) {
+    counters.tail.zip(counters).foreach { case (a, b) =>
+      a.io.tick := b.io.lastVal && counters_tick
+    }
+  }
 }

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -242,7 +242,7 @@ class AddressGenUnitNoMulDiv(
     val start = Input(Bool())
     // If the address is all generated and pushed into FIFO, busy is false
     val busy = Output(Bool())
-    // If all signal in address buffer is consumed, bufferEmpty becomes high (Dont know if it is useful)
+    // If all signal in address buffer is consumed, bufferEmpty becomes high
     val bufferEmpty = Output(Bool())
     // The calculated address. This equals to # of output channels (64-bit narrow TCDM)
     val addr =

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -238,7 +238,7 @@ class AddressGenUnitNoMulDiv(
     with RequireAsyncReset {
   val io = IO(new Bundle {
     val cfg = Input(new AddressGenUnitCfgIO(param.toAddressGenUnitParam))
-    // Intake the new cfg file and reset all the counters
+    // Take in the new cfg file and reset all the counters
     val start = Input(Bool())
     // If the address is all generated and pushed into FIFO, busy is false
     val busy = Output(Bool())

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
@@ -45,9 +45,20 @@ class Reader(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
   })
 
   // Address Generator
+  // val addressgen = Module(
+  //   new AddressGenUnit(
+  //     param.agu_param,
+  //     module_name_prefix = s"${clusterName}_xdma_Reader"
+  //   )
+  // )
+
+  // Address Generator
   val addressgen = Module(
-    new AddressGenUnit(
-      param.agu_param,
+    new AddressGenUnitNoMulDiv(
+      AddressGenUnitNoMulDivParam(
+        param.agu_param,
+        memorySize = param.tcdm_param.tcdmSize
+      ),
       module_name_prefix = s"${clusterName}_xdma_Reader"
     )
   )

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
@@ -44,15 +44,7 @@ class Reader(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
 
   })
 
-  // Address Generator
-  // val addressgen = Module(
-  //   new AddressGenUnit(
-  //     param.agu_param,
-  //     module_name_prefix = s"${clusterName}_xdma_Reader"
-  //   )
-  // )
-
-  // Address Generator
+  // New Address Generator
   val addressgen = Module(
     new AddressGenUnitNoMulDiv(
       AddressGenUnitNoMulDivParam(

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
@@ -40,12 +40,25 @@ class Writer(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
     val bufferEmpty = Output(Bool())
   })
 
+  // Address Generator
+  // val addressgen = Module(
+  //   new AddressGenUnit(
+  //     param.agu_param,
+  //     module_name_prefix = s"${clusterName}_xdma_Writer"
+  //   )
+  // )
+
+  // Address Generator
   val addressgen = Module(
-    new AddressGenUnit(
-      param.agu_param,
-      module_name_prefix = s"${clusterName}_xdma_Writer"
+    new AddressGenUnitNoMulDiv(
+      AddressGenUnitNoMulDivParam(
+        param.agu_param,
+        memorySize = param.tcdm_param.tcdmSize
+      ),
+      module_name_prefix = s"${clusterName}_xdma_Reader"
     )
   )
+
   // Write Requestors
   // Requestors to send address and data to TCDM
   val requestors = Module(

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
@@ -40,15 +40,7 @@ class Writer(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
     val bufferEmpty = Output(Bool())
   })
 
-  // Address Generator
-  // val addressgen = Module(
-  //   new AddressGenUnit(
-  //     param.agu_param,
-  //     module_name_prefix = s"${clusterName}_xdma_Writer"
-  //   )
-  // )
-
-  // Address Generator
+  // New Address Generator
   val addressgen = Module(
     new AddressGenUnitNoMulDiv(
       AddressGenUnitNoMulDivParam(

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
@@ -72,3 +72,79 @@ class AddressGenUnitTester extends AnyFlatSpec with ChiselScalatestTester {
         }
     }
 }
+
+class AddressGenUnitNoMulDivTester
+    extends AnyFlatSpec
+    with ChiselScalatestTester {
+
+  println(
+    getVerilogString(new AddressGenUnitNoMulDiv(AddressGenUnitNoMulDivParam()))
+  )
+
+  "AddressGenUnitNoMulDiv: continuous fetch with first temporal loop disabled" should " pass" in test(
+    new AddressGenUnitNoMulDiv(
+      AddressGenUnitNoMulDivParam(
+        dimension = 3,
+        addressWidth = 48,
+        channels = 8,
+        outputBufferDepth = 2,
+        memorySize = 128
+      )
+    )
+  )
+    .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
+      dut =>
+        dut.io.cfg.Ptr.poke(0x100000.U)
+        dut.io.cfg.Bounds(0).poke(8)
+        dut.io.cfg.Bounds(1).poke(1)
+        dut.io.cfg.Bounds(2).poke(16)
+        dut.io.cfg.Strides(0).poke(8)
+        dut.io.cfg.Strides(1).poke(64)
+        dut.io.cfg.Strides(2).poke(64)
+        dut.io.start.poke(true)
+        dut.clock.step()
+        dut.io.start.poke(false)
+        for (i <- 0 until 16) {
+          dut.clock.step()
+        }
+
+        dut.io.addr.foreach(_.ready.poke(true.B))
+        for (i <- 0 until 48) {
+          dut.clock.step()
+        }
+
+    }
+
+  "AddressGenUnitNoMulDiv: continuous fetch with first temporal loop enabled" should " pass" in test(
+    new AddressGenUnitNoMulDiv(
+      AddressGenUnitNoMulDivParam(
+        dimension = 3,
+        addressWidth = 48,
+        channels = 8,
+        outputBufferDepth = 2,
+        memorySize = 128
+      )
+    )
+  )
+    .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
+      dut =>
+        dut.io.cfg.Ptr.poke(0x100000.U)
+        dut.io.cfg.Bounds(0).poke(8)
+        dut.io.cfg.Bounds(1).poke(4)
+        dut.io.cfg.Bounds(2).poke(4)
+        dut.io.cfg.Strides(0).poke(8)
+        dut.io.cfg.Strides(1).poke(64)
+        dut.io.cfg.Strides(2).poke(256)
+        dut.io.start.poke(true)
+        dut.clock.step()
+        dut.io.start.poke(false)
+        for (i <- 0 until 16) {
+          dut.clock.step()
+        }
+
+        dut.io.addr.foreach(_.ready.poke(true.B))
+        for (i <- 0 until 48) {
+          dut.clock.step()
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in Issue #225 , the Address Generator is suspected to be the main cause of the long critical path. This PR redesign the AGU of XDMA while keeping the interface compatible to the original AGU. 

The key changes include: 
- Remove the original design where there is only one centralized counter, and each dimension is calculated based on division of centralized counter's value. This removes the division in the original addressgen. 
- Early addition of stride: introduce a programmable counter that the step size equals to stride. This removes the multiplication in the original addressgen
- Log2 addition in address offset: The addition of address offset is replaced by an automatic adder tree to reduce the critical path. 
- Bitwidth control: instead of letting Chisel to automatically infer the bitwidth of operand, the bitwidth is explicitly defined: the bitwidth is log2(tcdmSize). And this is done by automatic reading the cfg. 
- Late addition of base address: the base address is added at the very end, so most of the adder has width of just 17 bit (128KB condition). 