### PR TITLE
Clean-up double driven signal and declaration of generated directory

### DIFF
--- a/hw/templates/snax_streamer_wrapper.sv.tpl
+++ b/hw/templates/snax_streamer_wrapper.sv.tpl
@@ -128,7 +128,6 @@ module ${cfg["tag_name"]}_streamer_wrapper #(
       tcdm_req_amo          [i] = '0;
       tcdm_req_user_core_id [i] = '0;
       tcdm_req_user_is_core [i] = '0;
-      tcdm_req_strb         [i] = '1;
     end
   end
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -373,6 +373,8 @@ $(TARGET_C_HDRS_DIR)/snitch_cluster_peripheral.h: $(ROOT)/hw/snitch_cluster/src/
 #####################
 # Boot and Memories #
 #####################
+$(GENERATED_DIR):
+	mkdir -p $(GENERATED_DIR)
 
 $(GENERATED_DIR)/link.ld: ${CFG} ${CLUSTER_GEN_PREREQ} | $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --linker


### PR DESCRIPTION
This PR is a simple clean-up for the following:

- [x] Remove double-driven signal from the generated template. This was not captured in Verilator because Verilator assumes that the new assignment over-writes the initial assignment.
- [x] Add generated directory. This is for questa sim flow to work. It's a minor adjustment that just requires that the `/generated` directory needs to exist before writing the boot data and memories.

**Nothing changes functionally.**