### PR TITLE
fix occamy integration error

### DIFF
--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -291,7 +291,6 @@ module ${cfg['name']}_wrapper (
   //-----------------------------
   input  logic [9:0]                             hart_base_id_i,
   input  logic [${cfg['addr_width']-1}:0]        cluster_base_addr_i,
-  input  logic [31:0]                            boot_addr_i,
 % if cfg['timing']['iso_crossings']:
   //-----------------------------
   // ISO crossings
@@ -612,7 +611,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     //-----------------------------
     .hart_base_id_i ( hart_base_id_i ),
     .cluster_base_addr_i ( cluster_base_addr_i ),
-    .boot_addr_i  (boot_addr_i),
+    .boot_addr_i  (${cfg['pkg_name']}::BootAddr),
     //-----------------------------
     // ISO crossings
     //-----------------------------

--- a/hw/templates/testharness.sv.tpl
+++ b/hw/templates/testharness.sv.tpl
@@ -29,7 +29,6 @@ module testharness import ${cfg["cluster"]["name"]}_pkg::*; (
     .rst_ni               ( rst_ni          ),
     .hart_base_id_i       ( HartBaseID      ),
     .cluster_base_addr_i  ( ClusterBaseAddr ),
-    .boot_addr_i          ( BootAddr        ),
     .debug_req_i          ( '0              ),
     .meip_i               ( '0              ),
     .mtip_i               ( '0              ),


### PR DESCRIPTION
This PR fixes errors when snitch's boot address is not driven when integrating with snax. 