### PR TITLE
Add harness target switch

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -467,6 +467,6 @@ sources:
   #---------------------------
   # Test harness declaration
   #---------------------------
-  - target: any(simulation, verilator)
+  - target: any(simulation, vsim_harness, vlt_harness, vcs_harness)
     files:
       - target/snitch_cluster/test/testharness.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -467,6 +467,6 @@ sources:
   #---------------------------
   # Test harness declaration
   #---------------------------
-  - target: any(simulation, vsim_harness, vlt_harness, vcs_harness)
+  - target: snax_test_harness
     files:
       - target/snitch_cluster/test/testharness.sv

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -234,6 +234,12 @@ rtl-gen: rtl-snax-gen rtl-cluster-gen
 
 VSIM_BENDER += -t QUESTA_SIM
 
+# Add these targets for 
+# SNAX cluster simulations only
+VSIM_BENDER += -t vsim_harness
+VLT_BENDER  += -t vlt_harness
+VCS_BENDER  += -t vcs_harness
+
 # Verilated and compiled snitch cluster
 VLT_AR = ${VLT_BUILDDIR}/Vtestharness__ALL.a
 

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -236,9 +236,9 @@ VSIM_BENDER += -t QUESTA_SIM
 
 # Add these targets for 
 # SNAX cluster simulations only
-VSIM_BENDER += -t vsim_harness
-VLT_BENDER  += -t vlt_harness
-VCS_BENDER  += -t vcs_harness
+VSIM_BENDER += -t snax_test_harness
+VLT_BENDER  += -t snax_test_harness
+VCS_BENDER  += -t snax_test_harness
 
 # Verilated and compiled snitch cluster
 VLT_AR = ${VLT_BUILDDIR}/Vtestharness__ALL.a


### PR DESCRIPTION
This PR is a small fix for the Hemaia bring up. We need to disable the SNAX cluster specific harness file in Hemaia. We just need to add more targets in Bender.

Major TODO:
- [x] Add harness target switch in Bender.yml
- [x] Add harness target switch in Makefile