### PR TITLE
Downgrade verilator to 5.024

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -57,7 +57,7 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
 # Install Verilator
 RUN git clone https://github.com/verilator/verilator && \
   cd verilator && \
-  git checkout stable && \
+  git checkout v5.024 && \
   unset VERILATOR_ROOT && \
   autoconf && \
   ./configure && \


### PR DESCRIPTION
This PR downgrade Verilator to 5.024, weird errors from 5.024 when simulating AXI components