### PR TITLE
Shorter Address on XDMA Streamer + XDMA DataBuffer improvement

### DIFF
--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/ComplexQueue.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/ComplexQueue.scala
@@ -51,7 +51,7 @@ class ComplexQueueConcat(inputWidth: Int, outputWidth: Int, depth: Int)
     Module(new Queue(UInt(smallWidth.W), depth))
   }
 
-  if (io.in.length != 1 || (io.in.length == 1 && io.out.length == 1)) { 
+  if (io.in.length != 1 || (io.in.length == 1 && io.out.length == 1)) {
     // Cond 1: io.in is not equals to 1, thus it is a complexQueue
     // Cond 2: io.in is equals to 1 and io.out is equals to 1, thus it is a simpleQueue
     io.in.zip(queues).foreach { case (i, j) => i <> j.io.enq }

--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/ComplexQueue.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/ComplexQueue.scala
@@ -51,10 +51,12 @@ class ComplexQueueConcat(inputWidth: Int, outputWidth: Int, depth: Int)
     Module(new Queue(UInt(smallWidth.W), depth))
   }
 
-  if (io.in.length != 1) { // The input port has small width so that the valid signal and ready signal should be connected directly to the input
+  if (io.in.length != 1 || (io.in.length == 1 && io.out.length == 1)) { 
+    // Cond 1: io.in is not equals to 1, thus it is a complexQueue
+    // Cond 2: io.in is equals to 1 and io.out is equals to 1, thus it is a simpleQueue
     io.in.zip(queues).foreach { case (i, j) => i <> j.io.enq }
   } else {
-    // only ready when all signals are ready
+    // It is a complexQueue with 1 input and multiple output
     val enq_all_ready = queues.map(_.io.enq.ready).reduce(_ & _)
     io.in.head.ready := enq_all_ready
     // Only when all signals are ready, then valid signals in each channels can be passed to FIFO
@@ -69,10 +71,12 @@ class ComplexQueueConcat(inputWidth: Int, outputWidth: Int, depth: Int)
   }
 
   // The same thing for the output
-  if (io.out.length != 1) { // The output port has small width so that the valid signal and ready signal should be connected directly to the input
+  if (io.out.length != 1 || (io.in.length == 1 && io.out.length == 1)) {
+    // Cond 1: io.out is not equals to 1, thus it is a complexQueue
+    // Cond 2: io.in is equals to 1 and io.out is equals to 1, thus it is a simpleQueue
     io.out.zip(queues).foreach { case (i, j) => i <> j.io.deq }
   } else {
-    // only valid when all signals are valid
+    // It is a complexQueue with 1 output and multiple input
     val deq_all_valid = queues.map(_.io.deq.valid).reduce(_ & _)
     io.out.head.valid := deq_all_valid
     // Only when all signals are valid, then ready signals in each channels can be passed to FIFO
@@ -165,7 +169,7 @@ class ComplexQueueOnetoN[T <: Data](dataType: T, N: Int, depth: Int)
   })
 
   val queues = for (i <- 0 until N) yield {
-    Module(new Queue(dataType, depth))
+    Module(new Queue(dataType, depth, pipe = true))
   }
 
   io.out.zip(queues).foreach { case (i, j) => i <> j.io.deq }
@@ -179,4 +183,10 @@ class ComplexQueueOnetoN[T <: Data](dataType: T, N: Int, depth: Int)
 
   // Any full signal is a debug signal and derived from sub channels: if any fifo is full, then this signal is full
   io.anyFull := queues.map(queue => ~(queue.io.enq.ready)).reduce(_ | _)
+}
+
+object ComplexQueueEmitter extends App {
+  println(getVerilogString(new ComplexQueueConcat(64, 512, 16)))
+  println(getVerilogString(new ComplexQueueConcat(512, 64, 16)))
+  println(getVerilogString(new ComplexQueueConcat(64, 64, 16)))
 }

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMACtrl.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMACtrl.scala
@@ -14,11 +14,8 @@ import snax.xdma.xdmaStreamer.BasicCounter
 import snax.xdma.CommonCells.DemuxDecoupled
 import snax.xdma.DesignParams.DMADataPathParam
 
-class DMACtrlIO(
-    readerparam: DMADataPathParam,
-    writerparam: DMADataPathParam,
-    axiWidth: Int = 512
-) extends Bundle {
+class DMACtrlIO(readerparam: DMADataPathParam, writerparam: DMADataPathParam)
+    extends Bundle {
   // clusterBaseAddress to determine if it is the local command or remote command
   val clusterBaseAddress = Input(
     UInt(readerparam.rwParam.agu_param.addressWidth.W)
@@ -39,8 +36,8 @@ class DMACtrlIO(
   // Remote control signal, which include the signal from other cluster or signal to other cluster. Both of them is AXI related, serialized signal
   // The remote control signal will contain only src information, in other words, the DMA system can proceed remote read or local read, but only local write
   val remoteDMADataPathCfg = new Bundle {
-    val fromRemote = Flipped(Decoupled(UInt(axiWidth.W)))
-    val toRemote = Decoupled(UInt(axiWidth.W))
+    val fromRemote = Flipped(Decoupled(UInt(readerparam.axiParam.dataWidth.W)))
+    val toRemote = Decoupled(UInt(readerparam.axiParam.dataWidth.W))
   }
   // This is the port for CSR Manager to SNAX port
   val csrIO = new SnaxCsrIO(csrAddrWidth = 32)
@@ -48,7 +45,6 @@ class DMACtrlIO(
 
 class SrcConfigRouter(
     dataType: DMADataPathCfgInternalIO,
-    tcdmSize: Int,
     clusterName: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
@@ -89,12 +85,12 @@ class SrcConfigRouter(
   when(
     i_to_demux.io.in.bits.agu_cfg
       .Ptr(
-        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
-        log2Up(tcdmSize) + 10
+        i_to_demux.io.in.bits.readerPtr.getWidth - 1,
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth
       ) === io
       .clusterBaseAddress(
-        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
-        log2Up(tcdmSize) + 10
+        i_to_demux.io.in.bits.readerPtr.getWidth - 1,
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth
       )
   ) {
     cValue := cType_local // When cfg has the Ptr that fall within local TCDM, the data should be forwarded to the local ctrl path
@@ -115,7 +111,6 @@ class SrcConfigRouter(
 
 class DstConfigRouter(
     dataType: DMADataPathCfgInternalIO,
-    tcdmSize: Int,
     clusterName: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
@@ -146,12 +141,12 @@ class DstConfigRouter(
   when(
     i_to_demux.io.in.bits.agu_cfg
       .Ptr(
-        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
-        log2Up(tcdmSize) + 10
+        i_to_demux.io.in.bits.writerPtr.getWidth - 1,
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth
       ) === io
       .clusterBaseAddress(
-        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth - 1,
-        log2Up(tcdmSize) + 10
+        i_to_demux.io.in.bits.writerPtr.getWidth - 1,
+        i_to_demux.io.in.bits.agu_cfg.Ptr.getWidth
       )
   ) {
     cValue := cType_local // When cfg has the Ptr that fall within local TCDM, the data should be forwarded to the local ctrl path
@@ -169,16 +164,13 @@ class DstConfigRouter(
 class DMACtrl(
     readerparam: DMADataPathParam,
     writerparam: DMADataPathParam,
-    axiWidth: Int = 512,
-    csrAddrWidth: Int = 32,
     clusterName: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
   val io = IO(
     new DMACtrlIO(
       readerparam = readerparam,
-      writerparam = writerparam,
-      axiWidth = axiWidth
+      writerparam = writerparam
     )
   )
 
@@ -203,7 +195,7 @@ class DMACtrl(
         1, // The start CSR
       csrNumReadOnly = 2,
       // Set to two at current, 1) The number of submitted request; 2) The number of finished request. Since the reader path may be forward to remote, here I only count the writer branch
-      csrAddrWidth = csrAddrWidth,
+      csrAddrWidth = 32,
       // Set a name for the module class so that it will not overlapped with other csrManagers in user-defined accelerators
       csrModuleTagName = s"${clusterName}_xdma_"
     )
@@ -211,95 +203,84 @@ class DMACtrl(
 
   i_csrmanager.io.csr_config_in <> io.csrIO
 
-  val structuredCfg_src = Wire(new DMADataPathCfgIO(readerparam))
-  val structuredCfg_dst = Wire(new DMADataPathCfgIO(writerparam))
+  val preRoute_src_local = Decoupled(new DMADataPathCfgInternalIO(readerparam))
+  val preRoute_dst_local = Decoupled(new DMADataPathCfgInternalIO(writerparam))
   var remainingCSR = i_csrmanager.io.csr_config_out.bits.toIndexedSeq
 
   // Pack the unstructured signal from csrManager to structured signal: Src side
-  // Connect agu_cfg.Ptr
-  structuredCfg_src.agu_cfg.Ptr := Cat(remainingCSR(1), remainingCSR(0))
+  // Connect agu_cfg.Ptr & readerPtr
+  preRoute_src_local.bits.agu_cfg.Ptr := Cat(remainingCSR(1), remainingCSR(0))
+  preRoute_src_local.bits.readerPtr := Cat(remainingCSR(1), remainingCSR(0))
+  preRoute_dst_local.bits.readerPtr := Cat(remainingCSR(1), remainingCSR(0))
   remainingCSR = remainingCSR.tail.tail
 
   // Connect agu_cfg.Bounds
-  for (i <- 0 until structuredCfg_src.agu_cfg.Bounds.length) {
-    structuredCfg_src.agu_cfg.Bounds(i) := remainingCSR.head
+  for (i <- 0 until preRoute_src_local.bits.agu_cfg.Bounds.length) {
+    preRoute_src_local.bits.agu_cfg.Bounds(i) := remainingCSR.head
     remainingCSR = remainingCSR.tail
   }
 
   // Connect agu_cfg.Strides
-  for (i <- 0 until structuredCfg_src.agu_cfg.Strides.length) {
-    structuredCfg_src.agu_cfg.Strides(i) := remainingCSR.head
+  for (i <- 0 until preRoute_src_local.bits.agu_cfg.Strides.length) {
+    preRoute_src_local.bits.agu_cfg.Strides(i) := remainingCSR.head
     remainingCSR = remainingCSR.tail
   }
 
   // Connect strb signal. As the strb is not effective, so assign all true, and not take any value from CSR right now
-  structuredCfg_src.streamer_cfg.strb := VecInit(
+  preRoute_src_local.bits.streamer_cfg.strb := VecInit(
     Seq.fill(readerparam.rwParam.tcdm_param.dataWidth / 8)(true.B)
   ).asUInt
 
   // Connect extension signal
-  for (i <- 0 until structuredCfg_src.ext_cfg.length) {
-    structuredCfg_src.ext_cfg(i) := remainingCSR.head
+  for (i <- 0 until preRoute_src_local.bits.ext_cfg.length) {
+    preRoute_src_local.bits.ext_cfg(i) := remainingCSR.head
     remainingCSR = remainingCSR.tail
   }
 
   // Pack the unstructured signal from csrManager to structured signal: Dst side
-  // Connect agu_cfg.Ptr
-  structuredCfg_dst.agu_cfg.Ptr := Cat(remainingCSR(1), remainingCSR(0))
+  // Connect agu_cfg.Ptr & writerPtr
+  preRoute_dst_local.bits.agu_cfg.Ptr := Cat(remainingCSR(1), remainingCSR(0))
+  preRoute_src_local.bits.writerPtr := Cat(remainingCSR(1), remainingCSR(0))
+  preRoute_dst_local.bits.writerPtr := Cat(remainingCSR(1), remainingCSR(0))
   remainingCSR = remainingCSR.tail.tail
 
   // Connect agu_cfg.Bounds
-  for (i <- 0 until structuredCfg_dst.agu_cfg.Bounds.length) {
-    structuredCfg_dst.agu_cfg.Bounds(i) := remainingCSR.head
+  for (i <- 0 until preRoute_dst_local.bits.agu_cfg.Bounds.length) {
+    preRoute_dst_local.bits.agu_cfg.Bounds(i) := remainingCSR.head
     remainingCSR = remainingCSR.tail
   }
 
   // Connect agu_cfg.Strides
-  for (i <- 0 until structuredCfg_dst.agu_cfg.Strides.length) {
-    structuredCfg_dst.agu_cfg.Strides(i) := remainingCSR.head
+  for (i <- 0 until preRoute_dst_local.bits.agu_cfg.Strides.length) {
+    preRoute_dst_local.bits.agu_cfg.Strides(i) := remainingCSR.head
     remainingCSR = remainingCSR.tail
   }
 
   // Connect strb signal. As the strb is effective, so assign the value from CSR
-  structuredCfg_dst.streamer_cfg.strb := remainingCSR.head
+  preRoute_dst_local.bits.streamer_cfg.strb := remainingCSR.head
   remainingCSR = remainingCSR.tail
 
   // Connect extension signal
-  for (i <- 0 until structuredCfg_dst.ext_cfg.length) {
-    structuredCfg_dst.ext_cfg(i) := remainingCSR.head
+  for (i <- 0 until preRoute_dst_local.bits.ext_cfg.length) {
+    preRoute_dst_local.bits.ext_cfg(i) := remainingCSR.head
     remainingCSR = remainingCSR.tail
   }
 
   if (remainingCSR.length > 1)
     println("There is some error in CSR -> Structured CFG assigning")
 
-  // New class that pack the loopBack signal with the ReaderWriterCfg -> ReaderWriterCfgInternal (Local command)
-  val preRoute_src_local = Wire(
-    Decoupled(new DMADataPathCfgInternalIO(readerparam))
-  )
-  val preRoute_dst_local = Wire(
-    Decoupled(new DMADataPathCfgInternalIO(writerparam))
-  )
-  val preRoute_loopBack =
-    structuredCfg_src.agu_cfg.Ptr(
-      structuredCfg_src.agu_cfg.Ptr.getWidth - 1,
-      log2Up(readerparam.rwParam.tcdm_param.tcdmSize) + 10
-    ) === structuredCfg_dst.agu_cfg.Ptr(
-      structuredCfg_dst.agu_cfg.Ptr.getWidth - 1,
-      log2Up(readerparam.rwParam.tcdm_param.tcdmSize) + 10
-    )
+  // Connect the loopBack signal: The loopBack signal is generated by comparing the Ptr of two side
 
-  // Connect bits
-  preRoute_src_local.bits.agu_cfg := structuredCfg_src.agu_cfg
-  preRoute_src_local.bits.streamer_cfg := structuredCfg_src.streamer_cfg
-  preRoute_src_local.bits.ext_cfg := structuredCfg_src.ext_cfg
-  preRoute_dst_local.bits.agu_cfg := structuredCfg_dst.agu_cfg
-  preRoute_dst_local.bits.streamer_cfg := structuredCfg_dst.streamer_cfg
-  preRoute_dst_local.bits.ext_cfg := structuredCfg_dst.ext_cfg
-  preRoute_src_local.bits.loopBack := preRoute_loopBack
-  preRoute_dst_local.bits.loopBack := preRoute_loopBack
-  preRoute_src_local.bits.oppositePtr := preRoute_dst_local.bits.agu_cfg.Ptr
-  preRoute_dst_local.bits.oppositePtr := preRoute_src_local.bits.agu_cfg.Ptr
+  val loopBack =
+    preRoute_dst_local.bits.readerPtr(
+      preRoute_dst_local.bits.readerPtr.getWidth - 1,
+      preRoute_dst_local.bits.agu_cfg.Ptr.getWidth
+    ) === preRoute_dst_local.bits.writerPtr(
+      preRoute_dst_local.bits.writerPtr.getWidth - 1,
+      preRoute_dst_local.bits.agu_cfg.Ptr.getWidth
+    )
+  preRoute_src_local.bits.loopBack := loopBack
+  preRoute_dst_local.bits.loopBack := loopBack
 
   // Connect Valid and bits: Only when both preRoutes are ready, postRulecheck is ready
   i_csrmanager.io.csr_config_out.ready := preRoute_src_local.ready & preRoute_dst_local.ready
@@ -318,7 +299,6 @@ class DMACtrl(
   val i_srcCfgRouter = Module(
     new SrcConfigRouter(
       dataType = chiselTypeOf(preRoute_src_local.bits),
-      tcdmSize = readerparam.rwParam.tcdm_param.tcdmSize,
       clusterName = clusterName
     )
   )
@@ -346,7 +326,6 @@ class DMACtrl(
   val i_dstCfgRouter = Module(
     new DstConfigRouter(
       dataType = chiselTypeOf(preRoute_dst_local.bits),
-      tcdmSize = writerparam.rwParam.tcdm_param.tcdmSize,
       clusterName = clusterName
     )
   )

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -107,111 +107,8 @@ class ProgrammableCounter(width: Int, hasCeil: Boolean = true)
 
 class AddressGenUnitCfgIO(param: AddressGenUnitParam) extends Bundle {
   val Ptr = UInt(param.addressWidth.W)
-  val Strides = Vec(param.dimension, UInt(32.W))
-  val Bounds = Vec(param.dimension, UInt(16.W))
-}
-
-class AddressGenUnit(
-    param: AddressGenUnitParam,
-    module_name_prefix: String = "unnamed_cluster"
-) extends Module
-    with RequireAsyncReset {
-  val io = IO(new Bundle {
-    val cfg = Input(new AddressGenUnitCfgIO(param))
-    // Intake the new cfg file and reset all the counters
-    val start = Input(Bool())
-    // If the address is all generated and pushed into FIFO, busy is false
-    val busy = Output(Bool())
-    // If all signal in address buffer is consumed, bufferEmpty becomes high (Dont know if it is useful)
-    val bufferEmpty = Output(Bool())
-    // The calculated address. This equals to # of output channels (64-bit narrow TCDM)
-    val addr =
-      Vec(param.channels, Decoupled(UInt(param.addressWidth.W)))
-    val enabled_channels = Vec(param.channels, Output(Bool()))
-  })
-
-  override val desiredName = s"${module_name_prefix}_AddressGenUnit"
-
-  // Create a counter to count from 0 to product(bounds)
-  val counter = Module(new BasicCounter(32) {
-    override val desiredName = s"${module_name_prefix}_AddressGenUnit_Counter"
-  })
-  // When start signal is high, the counter is rest to zero.
-  counter.io.reset := io.start
-
-  // Create the outputBuffer to store the generated address: one input + spatialUnrollingFactor outputs
-  val outputBuffer = Module(
-    new ComplexQueueConcat(
-      inputWidth = io.addr.head.bits.getWidth * param.channels,
-      outputWidth = io.addr.head.bits.getWidth,
-      depth = param.outputBufferDepth
-    ) {
-      override val desiredName = s"${module_name_prefix}_AddressBufferFIFO"
-    }
-  )
-
-  // The FSM to record if the AddressGenUnit is busy
-  val sIDLE :: sBUSY :: Nil = Enum(2)
-  val currentState = RegInit(sIDLE)
-  when(io.start) {
-    currentState := sBUSY
-  }.elsewhen(counter.io.lastVal && outputBuffer.io.in.head.fire) { // The output FIFO already accept the result
-    currentState := sIDLE
-  }.otherwise {
-    currentState := currentState
-  }
-
-  // When the AGU becomes busy, the valid signal is pulled up to put address in the fifo
-  outputBuffer.io.in.head.valid := currentState === sBUSY
-  // io.busy also determined by currentState
-  io.busy := currentState === sBUSY
-
-  // Connect the ceil from config to inside
-  // The innermost one is the spatial bound, so it should not be multiplied with other bounds. It should be used to generate enabled_channels signal
-  io.enabled_channels.zipWithIndex.foreach { case (a, b) =>
-    a := io.cfg.Bounds.head > b.U
-  }
-  assert(
-    io.cfg.Bounds.head <= param.channels.U,
-    "[AddressGenUnit] The innermost bound is spatial bound, so it should be less than or equal to the number of channels"
-  )
-  counter.io.ceil := VecInit(io.cfg.Bounds.tail).reduceTree(_ * _)
-
-  // The counter's tick is the enable signal
-  counter.io.tick := currentState === sBUSY && outputBuffer.io.in.head.fire // FIFO still have the space to take the new address
-
-  // The counter's value is split to different rolls and connected to outside
-  val currentLoop = Wire(chiselTypeOf(VecInit(io.cfg.Bounds.tail)))
-  // temp value is a iterated value, so it is var here.
-  var temp = counter.io.value
-  // The counter's value is split to different dimensions, and connected to outside
-  for (i <- currentLoop.zipWithIndex) {
-    // The first dimension is spatial bound / stride, so should be skipped
-    i._1 := temp % io.cfg.Bounds(i._2 + 1)
-    temp = temp / io.cfg.Bounds(i._2 + 1)
-  }
-
-  // Calculate the current base address: the first stride need to be left-shifted
-  val currentPointer =
-    io.cfg.Ptr + currentLoop
-      .zip(io.cfg.Strides.tail)
-      .map { case (a, b) => a * b }
-      .reduce(_ + _)
-
-  // Calculate all calculated address together
-  val currentAddress = Wire(Vec(io.addr.length, UInt(param.addressWidth.W)))
-  currentAddress.zipWithIndex.foreach { case (address, index) =>
-    address := currentPointer + io.cfg.Strides.head * index.U
-  }
-
-  // Connect it to the input of outputBuffer
-  outputBuffer.io.in.head.bits := currentAddress.reduce((a, b) => Cat(b, a))
-
-  // Connect the outputs of the buffer out
-  outputBuffer.io.out.zip(io.addr).foreach { case (a, b) => a <> b }
-
-  // Connect io.bufferEmpty signal: If all output is 0, then all addresses are empty, which means io.bufferEmpty should be high
-  io.bufferEmpty := ~(outputBuffer.io.out.map(i => i.valid).reduce(_ | _))
+  val Strides = Vec(param.dimension, UInt(param.addressWidth.W))
+  val Bounds = Vec(param.dimension, UInt(param.addressWidth.W))
 }
 
 /** AGU is the module to automatically generate the address for all ports.
@@ -231,13 +128,13 @@ class AddressGenUnit(
   *   to totally remove multiplication and division in temporal address
   *   generation
   */
-class AddressGenUnitNoMulDiv(
-    param: AddressGenUnitNoMulDivParam,
+class AddressGenUnit(
+    param: AddressGenUnitParam,
     module_name_prefix: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
   val io = IO(new Bundle {
-    val cfg = Input(new AddressGenUnitCfgIO(param.toAddressGenUnitParam))
+    val cfg = Input(new AddressGenUnitCfgIO(param))
     // Take in the new cfg file and reset all the counters
     val start = Input(Bool())
     // If the address is all generated and pushed into FIFO, busy is false
@@ -246,8 +143,8 @@ class AddressGenUnitNoMulDiv(
     val bufferEmpty = Output(Bool())
     // The calculated address. This equals to # of output channels (64-bit narrow TCDM)
     val addr =
-      Vec(param.channels, Decoupled(UInt(param.addressWidth.W)))
-    val enabled_channels = Vec(param.channels, Output(Bool()))
+      Vec(param.numChannel, Decoupled(UInt(param.addressWidth.W)))
+    val enabled_channels = Vec(param.numChannel, Output(Bool()))
   })
 
   override val desiredName = s"${module_name_prefix}_AddressGenUnitNoMulDiv"
@@ -256,7 +153,7 @@ class AddressGenUnitNoMulDiv(
   // Be aware that counter is not needed for the first dimension, because it is the spatial bound
   val counters = for (i <- 1 until param.dimension) yield {
     val counter = Module(
-      new ProgrammableCounter(log2Up(param.memorySize << 10)) {
+      new ProgrammableCounter(param.addressWidth, hasCeil = true) {
         override val desiredName =
           s"${module_name_prefix}_AddressGenUnitNoMulDiv_Counter_${i}"
       }
@@ -271,7 +168,7 @@ class AddressGenUnitNoMulDiv(
   // Create the outputBuffer to store the generated address: one input + spatialUnrollingFactor outputs
   val outputBuffer = Module(
     new ComplexQueueConcat(
-      inputWidth = io.addr.head.bits.getWidth * param.channels,
+      inputWidth = io.addr.head.bits.getWidth * param.numChannel,
       outputWidth = io.addr.head.bits.getWidth,
       depth = param.outputBufferDepth
     ) {
@@ -281,9 +178,8 @@ class AddressGenUnitNoMulDiv(
 
   // Calculate the current base address: the first stride need to be left-shifted
   val temporalOffset = VecInit(counters.map(_.io.value)).reduceTree(_ + _)
-  val spatialOffsets = for (i <- 0 until param.channels) yield {
-    val spatialOffset = temporalOffset + io.cfg.Strides
-      .head(log2Up(param.memorySize << 10) - 1, 0) * i.U
+  val spatialOffsets = for (i <- 0 until param.numChannel) yield {
+    val spatialOffset = temporalOffset + io.cfg.Strides.head * i.U
     spatialOffset
   }
 
@@ -326,7 +222,7 @@ class AddressGenUnitNoMulDiv(
     a := io.cfg.Bounds.head > b.U
   }
   assert(
-    io.cfg.Bounds.head <= param.channels.U,
+    io.cfg.Bounds.head <= param.numChannel.U,
     "[AddressGenUnit] The innermost bound is spatial bound, so it should be less than or equal to the number of channels"
   )
 

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
@@ -46,11 +46,8 @@ class Reader(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
 
   // New Address Generator
   val addressgen = Module(
-    new AddressGenUnitNoMulDiv(
-      AddressGenUnitNoMulDivParam(
-        param.agu_param,
-        memorySize = param.tcdm_param.tcdmSize
-      ),
+    new AddressGenUnit(
+      param.agu_param,
       module_name_prefix = s"${clusterName}_xdma_Reader"
     )
   )

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
@@ -42,12 +42,9 @@ class Writer(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
 
   // New Address Generator
   val addressgen = Module(
-    new AddressGenUnitNoMulDiv(
-      AddressGenUnitNoMulDivParam(
-        param.agu_param,
-        memorySize = param.tcdm_param.tcdmSize
-      ),
-      module_name_prefix = s"${clusterName}_xdma_Reader"
+    new AddressGenUnit(
+      param.agu_param,
+      module_name_prefix = s"${clusterName}_xdma_Writer"
     )
   )
 

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -138,22 +138,6 @@ class xdmaTop(
 
 }
 
-object xdmaTopEmitter extends App {
-  _root_.circt.stage.ChiselStage.emitSystemVerilogFile(
-    new xdmaTop(
-      clusterName = "test_cluster",
-      readerparam =
-        new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq()),
-      writerparam = new DMADataPathParam(
-        new AXIParam,
-        new ReaderWriterParam,
-        Seq(HasMaxPool, HasVerilogMemset, HasTransposer)
-      )
-    ),
-    args = Array("--split-verilog", "--target-dir", "generated/xdma")
-  )
-}
-
 object xdmaTopGen extends App {
   val parsed_args = snax.utils.ArgParser.parse(args)
 
@@ -174,7 +158,7 @@ object xdmaTopGen extends App {
    */
   val axiParam = new AXIParam(
     dataWidth = parsed_args("axiDataWidth").toInt,
-    addrWidth = parsed_args("axiAddressWidth").toInt
+    addrWidth = parsed_args("axiAddrWidth").toInt
   )
 
   val readerparam = new ReaderWriterParam(

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -20,7 +20,7 @@ class xdmaTopIO(
     writerparam: DMADataPathParam
 ) extends Bundle {
   val clusterBaseAddress = Input(
-    UInt(readerparam.rwParam.agu_param.addressWidth.W)
+    UInt(writerparam.axiParam.addrWidth.W)
   )
   val csrIO = new SnaxCsrIO(32)
 

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -17,19 +17,18 @@ import scala.reflect.runtime.universe._
 
 class xdmaTopIO(
     readerparam: DMADataPathParam,
-    writerparam: DMADataPathParam,
-    axiWidth: Int = 512,
-    csrAddrWidth: Int = 32
+    writerparam: DMADataPathParam
 ) extends Bundle {
   val clusterBaseAddress = Input(
     UInt(readerparam.rwParam.agu_param.addressWidth.W)
   )
-  val csrIO = new SnaxCsrIO(csrAddrWidth)
+  val csrIO = new SnaxCsrIO(32)
 
   val remoteDMADataPathCfg = new Bundle {
-    val fromRemote = Flipped(Decoupled(UInt(axiWidth.W)))
-    val toRemote = Decoupled(UInt(axiWidth.W))
+    val fromRemote = Flipped(Decoupled(UInt(writerparam.axiParam.dataWidth.W)))
+    val toRemote = Decoupled(UInt(writerparam.axiParam.dataWidth.W))
   }
+
   val tcdm_reader = new Bundle {
     val req = Vec(
       readerparam.rwParam.tcdm_param.numChannel,
@@ -80,8 +79,6 @@ class xdmaTopIO(
 class xdmaTop(
     readerparam: DMADataPathParam,
     writerparam: DMADataPathParam,
-    axiWidth: Int = 512,
-    csrAddrWidth: Int = 32,
     clusterName: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
@@ -89,27 +86,23 @@ class xdmaTop(
   val io = IO(
     new xdmaTopIO(
       readerparam = readerparam,
-      writerparam = writerparam,
-      axiWidth = axiWidth,
-      csrAddrWidth = csrAddrWidth
+      writerparam = writerparam
     )
   )
 
   val i_dmactrl = Module(
     new DMACtrl(
-      clusterName = clusterName,
       readerparam = readerparam,
       writerparam = writerparam,
-      axiWidth = axiWidth,
-      csrAddrWidth = csrAddrWidth
+      clusterName = clusterName
     )
   )
 
   val i_dmadatapath = Module(
     new DMADataPath(
-      clusterName = clusterName,
       readerparam = readerparam,
-      writerparam = writerparam
+      writerparam = writerparam,
+      clusterName = clusterName
     )
   )
 
@@ -149,8 +142,10 @@ object xdmaTopEmitter extends App {
   _root_.circt.stage.ChiselStage.emitSystemVerilogFile(
     new xdmaTop(
       clusterName = "test_cluster",
-      readerparam = new DMADataPathParam(new ReaderWriterParam, Seq()),
+      readerparam =
+        new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq()),
       writerparam = new DMADataPathParam(
+        new AXIParam,
         new ReaderWriterParam,
         Seq(HasMaxPool, HasVerilogMemset, HasTransposer)
       )
@@ -177,12 +172,15 @@ object xdmaTopGen extends App {
     HasMaxPool
     HasTranspopser
    */
+  val axiParam = new AXIParam(
+    dataWidth = parsed_args("axiDataWidth").toInt,
+    addrWidth = parsed_args("axiAddressWidth").toInt
+  )
 
   val readerparam = new ReaderWriterParam(
     dimension = parsed_args("readerDimension").toInt,
     tcdmDataWidth = parsed_args("tcdmDataWidth").toInt,
     tcdmSize = parsed_args("tcdmSize").toInt,
-    tcdmAddressWidth = parsed_args("addressWidth").toInt,
     numChannel =
       parsed_args("axiDataWidth").toInt / parsed_args("tcdmDataWidth").toInt,
     addressBufferDepth = parsed_args("readerBufferDepth").toInt
@@ -192,7 +190,6 @@ object xdmaTopGen extends App {
     dimension = parsed_args("writerDimension").toInt,
     tcdmDataWidth = parsed_args("tcdmDataWidth").toInt,
     tcdmSize = parsed_args("tcdmSize").toInt,
-    tcdmAddressWidth = parsed_args("addressWidth").toInt,
     numChannel =
       parsed_args("axiDataWidth").toInt / parsed_args("tcdmDataWidth").toInt,
     addressBufferDepth = parsed_args("writerBufferDepth").toInt
@@ -226,8 +223,10 @@ return ${i._1}
   var sv_string = getVerilogString(
     new xdmaTop(
       clusterName = parsed_args.getOrElse("clusterName", ""),
-      readerparam = new DMADataPathParam(readerparam, readerextensionparam),
-      writerparam = new DMADataPathParam(writerparam, writerextensionparam)
+      readerparam =
+        new DMADataPathParam(axiParam, readerparam, readerextensionparam),
+      writerparam =
+        new DMADataPathParam(axiParam, writerparam, writerextensionparam)
     )
   )
 

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMACtrlTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMACtrlTester.scala
@@ -44,8 +44,10 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
   "The DMACtrl" should " pass" in {
     test(
       new DMACtrl(
-        readerparam = new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq()),
-        writerparam = new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq())
+        readerparam =
+          new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq()),
+        writerparam =
+          new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq())
       )
     ).withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
       dut =>
@@ -145,7 +147,7 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
               // Writer: strobe / mask
               write_csr(dut, dut.io.csrIO, addr = currentCSR, data = 0)
               currentCSR += 1
-              
+
               // Commit the config
               write_csr(dut, dut.io.csrIO, addr = currentCSR, data = 1)
               println(
@@ -162,8 +164,8 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
                 (Reader_PointerAddress + 0x0000_1000 + i).toInt
               )
               val remoteConfig: BigInt =
-                BigInt(0x2000_0000) +
-                  ((Reader_PointerAddress + 0x0000_1000 + i) << 48) +
+                (Reader_PointerAddress + 0x0000_1000 + i) +
+                  (BigInt(0x2000_0000) << 48) +
                   (BigInt(Reader_Strides(0)) << 96) +
                   (BigInt(Reader_Strides(1)) << 128) +
                   (BigInt(Reader_Strides(2)) << 160) +
@@ -202,20 +204,20 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
               dut.clock.step(Random.between(1, 16) + 32)
               dut.io.localDMADataPath.reader_busy_i.poke(true)
               println(
-                "[Local Reader Checker] " + dut.io.localDMADataPath.reader_cfg_o.agu_cfg.Ptr
+                "[Local Reader Checker] " + dut.io.localDMADataPath.reader_cfg_o.readerPtr
                   .peekInt()
                   .toInt
                   .toHexString
               )
               if (
                 !unreceived_reader_cfg.remove(
-                  dut.io.localDMADataPath.reader_cfg_o.agu_cfg.Ptr
+                  dut.io.localDMADataPath.reader_cfg_o.readerPtr
                     .peekInt()
                     .toInt
                 )
               )
                 throw new Exception(
-                  "[Local Reader Checker] The received pointer " + dut.io.localDMADataPath.reader_cfg_o.agu_cfg.Ptr
+                  "[Local Reader Checker] The received pointer " + dut.io.localDMADataPath.reader_cfg_o.readerPtr
                     .peekInt()
                     .toInt
                     .toHexString + " is not in the buffer"
@@ -236,20 +238,20 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
                 if (testTerminated) break()
               }
               println(
-                "[Local Writer Checker] " + dut.io.localDMADataPath.writer_cfg_o.agu_cfg.Ptr
+                "[Local Writer Checker] " + dut.io.localDMADataPath.writer_cfg_o.writerPtr
                   .peekInt()
                   .toInt
                   .toHexString
               )
               if (
                 !unreceived_writer_cfg.remove(
-                  dut.io.localDMADataPath.writer_cfg_o.agu_cfg.Ptr
+                  dut.io.localDMADataPath.writer_cfg_o.writerPtr
                     .peekInt()
                     .toInt
                 )
               )
                 throw new Exception(
-                  "[Local Writer Checker] The received pointer " + dut.io.localDMADataPath.writer_cfg_o.agu_cfg.Ptr
+                  "[Local Writer Checker] The received pointer " + dut.io.localDMADataPath.writer_cfg_o.writerPtr
                     .peekInt()
                     .toInt
                     .toHexString + " is not in the buffer"
@@ -281,16 +283,16 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
                   !unreceived_reader_cfg.remove(
                     extractBits(
                       dut.io.remoteDMADataPathCfg.toRemote.bits.peekInt(),
-                      95,
-                      48
+                      47,
+                      0
                     ).toInt
                   )
                 )
                   throw new Exception(
                     "[Remote Reader Checker] The received pointer " + extractBits(
                       dut.io.remoteDMADataPathCfg.toRemote.bits.peekInt(),
-                      95,
-                      48
+                      47,
+                      0
                     ).toInt.toHexString + " is not in the buffer"
                   )
                 dut.clock.step(Random.between(1, 16) + 32)

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMACtrlTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMACtrlTester.scala
@@ -44,8 +44,8 @@ class DMACtrlTester extends AnyFlatSpec with ChiselScalatestTester {
   "The DMACtrl" should " pass" in {
     test(
       new DMACtrl(
-        readerparam = new DMADataPathParam(new ReaderWriterParam, Seq()),
-        writerparam = new DMADataPathParam(new ReaderWriterParam, Seq())
+        readerparam = new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq()),
+        writerparam = new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq())
       )
     ).withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
       dut =>

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
@@ -11,7 +11,8 @@ import scala.util.Random
 // Import break support for loops
 import scala.util.control.Breaks.{break, breakable}
 import snax.xdma.xdmaFrontend.DMADataPath
-import snax.xdma.DesignParams.{DMADataPathParam, ReaderWriterParam}
+import snax.xdma.DesignParams.{DMADataPathParam, ReaderWriterParam, AXIParam}
+import snax.xdma.xdmaTop.xdmaTopGen.axiParam
 
 class ReaderWriterTesterParam(
     val address: Int,
@@ -26,9 +27,11 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
   "DMA Data Path behavior is as expected" in test(
     new DMADataPath(
       readerparam = new DMADataPathParam(
+        axiParam = new AXIParam,
         rwParam = new ReaderWriterParam
       ),
       writerparam = new DMADataPathParam(
+        axiParam = new AXIParam,
         rwParam = new ReaderWriterParam
       )
     )
@@ -267,11 +270,11 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
   }
 }
 
-object DMADataPathTester extends App {
+object DMADataPathEmitter extends App {
   emitVerilog(
     new DMADataPath(
-      readerparam = new DMADataPathParam(new ReaderWriterParam, Seq()),
-      writerparam = new DMADataPathParam(new ReaderWriterParam, Seq())
+      readerparam = new DMADataPathParam(new AXIParam, new ReaderWriterParam),
+      writerparam = new DMADataPathParam(new AXIParam, new ReaderWriterParam)
     ),
     Array("--target-dir", "generated")
   )

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
@@ -41,7 +41,7 @@ class AddressGenUnitTester
   )
     .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
       dut =>
-        dut.io.cfg.Ptr.poke(0x100000.U)
+        dut.io.cfg.Ptr.poke(0x1000.U)
         dut.io.cfg.Bounds(0).poke(8)
         dut.io.cfg.Bounds(1).poke(1)
         dut.io.cfg.Bounds(2).poke(16)
@@ -74,7 +74,7 @@ class AddressGenUnitTester
   )
     .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
       dut =>
-        dut.io.cfg.Ptr.poke(0x100000.U)
+        dut.io.cfg.Ptr.poke(0x1000.U)
         dut.io.cfg.Bounds(0).poke(8)
         dut.io.cfg.Bounds(1).poke(4)
         dut.io.cfg.Bounds(2).poke(4)

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
@@ -21,74 +21,21 @@ class basicCounterTester extends AnyFlatSpec with ChiselScalatestTester {
   }
 }
 
-class AddressGenUnitTester extends AnyFlatSpec with ChiselScalatestTester {
-
-  println(getVerilogString(new AddressGenUnit(AddressGenUnitParam())))
-
-  "AddressGenUnit: spatial stride = 8 (continuous fetch)" should " pass" in test(
-    new AddressGenUnit(AddressGenUnitParam())
-  )
-    .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
-      dut =>
-        dut.io.cfg.Ptr.poke(100000.U)
-        dut.io.cfg.Bounds(0).poke(8)
-        dut.io.cfg.Bounds(1).poke(16)
-        dut.io.cfg.Strides(0).poke(8)
-        dut.io.cfg.Strides(1).poke(512)
-        dut.io.start.poke(true)
-        dut.clock.step()
-        dut.io.start.poke(false)
-        for (i <- 0 until 16) {
-          dut.clock.step()
-        }
-
-        dut.io.addr.foreach(_.ready.poke(true.B))
-        for (i <- 0 until 48) {
-          dut.clock.step()
-        }
-
-    }
-
-  "AddressGenUnit: spatial stride = 64 (strided fetch)" should " pass" in test(
-    new AddressGenUnit(AddressGenUnitParam())
-  )
-    .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
-      dut =>
-        dut.io.cfg.Ptr.poke(100000.U)
-        dut.io.cfg.Bounds(0).poke(8)
-        dut.io.cfg.Bounds(1).poke(16)
-        dut.io.cfg.Strides(0).poke(64)
-        dut.io.cfg.Strides(1).poke(512)
-        dut.io.start.poke(true)
-        dut.clock.step()
-        dut.io.start.poke(false)
-        for (i <- 0 until 16) {
-          dut.clock.step()
-        }
-
-        dut.io.addr.foreach(_.ready.poke(true.B))
-        for (i <- 0 until 48) {
-          dut.clock.step()
-        }
-    }
-}
-
-class AddressGenUnitNoMulDivTester
+class AddressGenUnitTester
     extends AnyFlatSpec
     with ChiselScalatestTester {
 
   println(
-    getVerilogString(new AddressGenUnitNoMulDiv(AddressGenUnitNoMulDivParam()))
+    getVerilogString(new AddressGenUnit(AddressGenUnitParam()))
   )
 
-  "AddressGenUnitNoMulDiv: continuous fetch with first temporal loop disabled" should " pass" in test(
-    new AddressGenUnitNoMulDiv(
-      AddressGenUnitNoMulDivParam(
+  "AddressGenUnit: continuous fetch with first temporal loop disabled" should " pass" in test(
+    new AddressGenUnit(
+      AddressGenUnitParam(
         dimension = 3,
-        addressWidth = 48,
-        channels = 8,
+        numChannel = 8,
         outputBufferDepth = 2,
-        memorySize = 128
+        tcdmSize = 128
       )
     )
   )
@@ -115,14 +62,13 @@ class AddressGenUnitNoMulDivTester
 
     }
 
-  "AddressGenUnitNoMulDiv: continuous fetch with first temporal loop enabled" should " pass" in test(
-    new AddressGenUnitNoMulDiv(
-      AddressGenUnitNoMulDivParam(
+  "AddressGenUnit: continuous fetch with first temporal loop enabled" should " pass" in test(
+    new AddressGenUnit(
+      AddressGenUnitParam(
         dimension = 3,
-        addressWidth = 48,
-        channels = 8,
+        numChannel = 8,
         outputBufferDepth = 2,
-        memorySize = 128
+        tcdmSize = 128
       )
     )
   )

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaTop/xdmaTopTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaTop/xdmaTopTester.scala
@@ -100,9 +100,11 @@ class xDMATopTester extends AnyFreeSpec with ChiselScalatestTester {
   "The bahavior of XDMA is as expected" in test(
     new xdmaTop(
       readerparam = new DMADataPathParam(
+        axiParam = new AXIParam,
         rwParam = new ReaderWriterParam
       ),
       writerparam = new DMADataPathParam(
+        axiParam = new AXIParam,
         rwParam = new ReaderWriterParam,
         extParam = Seq(HasVerilogMemset, HasMaxPool, HasTransposer)
       )

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaTop/xdmaTopTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaTop/xdmaTopTester.scala
@@ -890,3 +890,19 @@ class xDMATopTester extends AnyFreeSpec with ChiselScalatestTester {
       concurrent_threads.joinAndStep()
   }
 }
+
+object xdmaTopEmitter extends App {
+  _root_.circt.stage.ChiselStage.emitSystemVerilogFile(
+    new xdmaTop(
+      clusterName = "test_cluster",
+      readerparam =
+        new DMADataPathParam(new AXIParam, new ReaderWriterParam, Seq()),
+      writerparam = new DMADataPathParam(
+        new AXIParam,
+        new ReaderWriterParam,
+        Seq(HasMaxPool, HasVerilogMemset, HasTransposer)
+      )
+    ),
+    args = Array("--target-dir", "generated/xdma")
+  )
+}

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -390,7 +390,7 @@ def main():
             gen_path=" --clusterName " + str(cfg["cluster"]["name"]) +
             " --tcdmDataWidth " + str(cfg["cluster"]["data_width"]) +
             " --axiDataWidth " + str(cfg["cluster"]["dma_data_width"]) +
-            " --addressWidth " + str(cfg["cluster"]["addr_width"]) +
+            " --axiAddrWidth " + str(cfg["cluster"]["addr_width"]) +
             " --tcdmSize " + str(cfg["cluster"]["tcdm"]["size"]) +
             " --readerDimension " +
             str(snax_xdma_cfg["reader_agu_dimension"]) +


### PR DESCRIPTION
This PR is based on the discussion result with @xiaoling-yi , modifying XDMA's streamer so that it can be used by other accelerators. 

Key changes: 
- The address is trimmed down to the bitwidth that can just reside TCDM memory space, to save the area consumption
- Many optimizations on the generation cfg encapsulation
- The ComplexQueue utilizes flow FIFO instead of normal FIFO
- The ComplexQueue can tackle the condition of input port equals output port