### PR TITLE
add kul-cluster-all-narrow hw bender and cfg

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -357,7 +357,7 @@ sources:
       # Level 2
       - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_wrapper.sv
 
-  - target: any(snax_data_reshuffler, snax_wide_gemm_data_reshuffler)
+  - target: any(snax_data_reshuffler, snax_wide_gemm_data_reshuffler, snax_KUL_cluster)
     files:
       # Level 0
       - hw/chisel_acc/generated/reshuffle/Reshuffler.sv
@@ -370,7 +370,7 @@ sources:
       - hw/chisel_acc/src/snax_data_reshuffler_shell_wrapper.sv
       - target/snitch_cluster/generated/snax_data_reshuffler/snax_data_reshuffler_wrapper.sv
 
-  - target: snax_streamer_gemmX
+  - target: any(snax_streamer_gemmX, snax_KUL_cluster)
     files:
       # Level 0
       - hw/chisel_acc/generated/gemmx/BlockGemmRescaleSIMD.sv
@@ -463,6 +463,9 @@ sources:
   - target: snax_streamer_gemm_add_c_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_add_c_cluster_wrapper.sv
+  - target: snax_KUL_cluster
+    files:
+      - target/snitch_cluster/generated/snax_KUL_cluster_wrapper.sv
 
   #---------------------------
   # Test harness declaration

--- a/target/snitch_cluster/cfg/snax-kul-cluster-all-narrow.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-all-narrow.hjson
@@ -1,0 +1,245 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Cluster configuration for a simple testbench system.
+{
+    nr_s1_quadrant: 1,
+    s1_quadrant: {
+        nr_clusters: 1,
+    },
+
+    cluster: {
+        name: "snax_KUL_cluster",
+        boot_addr: 4096, // 0x1000
+        cluster_base_addr: 268435456, // 0x1000_0000
+        cluster_base_offset: 0, // 0x0
+        cluster_base_hartid: 0,
+        addr_width: 48,
+        data_width: 64,
+        tcdm: {
+            size: 128,
+            banks: 32,
+        },
+        cluster_periph_size: 64, // kB
+        zero_mem_size: 64, // kB
+        dma_data_width: 512,
+        dma_axi_req_fifo_depth: 3,
+        dma_req_fifo_depth: 3,
+        // AXI bandwidth switcher
+        use_ax_bw_converter: true,
+        converted_axi_bandwidth: 256,
+        // Timing parameters
+        timing: {
+            lat_comp_fp32: 3,
+            lat_comp_fp64: 3,
+            lat_comp_fp16: 2,
+            lat_comp_fp16_alt: 2,
+            lat_comp_fp8: 1,
+            lat_comp_fp8_alt: 1,
+            lat_noncomp: 1,
+            lat_conv: 1,
+            lat_sdotp: 2,
+            fpu_pipe_config: "BEFORE"
+            narrow_xbar_latency: "CUT_ALL_PORTS",
+            wide_xbar_latency: "CUT_ALL_PORTS",
+            // Isolate the core.
+            register_core_req: true,
+            register_core_rsp: true,
+            register_offload_req: true,
+            register_offload_rsp: true
+        },
+        hives: [
+            // Hive 0
+            {
+                icache: {
+                    size: 8, // total instruction cache size in kByte
+                    sets: 2, // number of ways
+                    cacheline: 256 // word size in bits
+                },
+                cores: [
+                    { $ref: "#/snax_streamer_gemmX_core_template" },
+                    { $ref: "#/snax_data_reshuffler_core_template" },
+                    { $ref: "#/dma_core_template" },
+                ]
+            }
+        ]
+    },
+    dram: {
+        // 0x8000_0000
+        address: 2147483648,
+        // 0x8000_0000
+        length: 2147483648
+    },
+    peripherals: {
+        clint: {
+            // 0xffff_0000
+            address: 4294901760,
+            // 0x0000_1000
+            length: 4096
+        },
+    },
+    // Templates.
+    snax_streamer_gemmX_core_template: {
+        isa: "rv32ima",
+        xssr: false,
+        xfrep: false,
+        xdma: false,
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        snax_acc_cfg: {
+            snax_acc_name: "snax_streamer_gemmX",
+            // add a checker here?
+            // some of the tcdm ports specificed here?
+            snax_narrow_tcdm_ports: 56,
+            snax_num_rw_csr: 10,
+            snax_num_ro_csr: 2,
+            snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
+        },
+        snax_use_custom_ports: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+        // Enable division/square root unit
+        // Xdiv_sqrt: true,
+    },
+    // Templates.
+    snax_data_reshuffler_core_template: {
+        isa: "rv32ima",
+        xssr: false,
+        xfrep: false,
+        xdma: false,
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        snax_acc_cfg: {
+            snax_acc_name: "snax_data_reshuffler",
+            snax_narrow_tcdm_ports: 16,
+            snax_num_rw_csr: 2,
+            snax_num_ro_csr: 2,
+            snax_streamer_cfg: {$ref: "#/snax_data_reshuffler_streamer_template" }
+        },
+        snax_use_custom_ports: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+        // Enable division/square root unit
+        // Xdiv_sqrt: true,
+    },
+    dma_core_template: {
+        isa: "rv32ima",
+        // Xdiv_sqrt: true,
+        # isa: "rv32ema",
+        xdma: true
+        xssr: false
+        xfrep: false
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+    },
+    // SNAX Streamer Templates
+    snax_streamer_gemmX_streamer_template :{
+
+        temporal_addrgen_unit_params: {
+            loop_dim: [6, 3, 3, 3, 3],
+            share_temp_addr_gen_loop_bounds: false,
+        }
+
+        fifo_reader_params: {
+            fifo_width: [512, 512],
+            fifo_depth: [2, 2],
+        }
+
+        fifo_writer_params: {
+            fifo_width: [512],
+            fifo_depth: [2],
+        }
+
+        fifo_reader_writer_params: {
+            fifo_width: [2048],
+            fifo_depth: [2],
+        }
+
+        data_reader_params:{
+            tcdm_ports_num: [8, 8],
+            spatial_bounds: [[8, 8], [8, 8]],
+            spatial_dim: [2, 2],
+            element_width: [8, 8],
+        }
+
+        data_writer_params:{
+            tcdm_ports_num: [8],
+            spatial_bounds: [[8, 8]],
+            spatial_dim: [2],
+            element_width: [8],
+        }
+
+        data_reader_writer_params:{
+            tcdm_ports_num: [32],
+            spatial_bounds: [[8, 8]],
+            spatial_dim: [2],
+            element_width: [32],
+        }
+
+        stationarity: [0,0,0,0,0]
+    },
+    // SNAX Streamer Templates
+    snax_data_reshuffler_streamer_template :{
+
+        temporal_addrgen_unit_params: {
+            loop_dim: [5, 3],
+            share_temp_addr_gen_loop_bounds: false,
+        }
+
+        fifo_reader_params: {
+            fifo_width: [512],
+            fifo_depth: [2],
+        }
+
+        fifo_writer_params: {
+            fifo_width: [512],
+            fifo_depth: [2],
+        }
+
+        data_reader_params:{
+            tcdm_ports_num: [8],
+            spatial_bounds: [[8]],
+            spatial_dim: [1],
+            element_width: [64],
+        }
+
+        data_writer_params:{
+            tcdm_ports_num: [8],
+            spatial_bounds: [[8]],
+            spatial_dim: [1],
+            element_width: [64],
+        }
+
+        stationarity: [0,0]
+    }
+}


### PR DESCRIPTION
In this PR, we add the latest cluster cfg for the FPGA prototype.