### PR TITLE
Add function switch to turn on / off Byte Mask and Spatial Bound

### DIFF
--- a/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
@@ -36,7 +36,8 @@ class AddressGenUnitParam(
     val addressWidth: Int,
     val numChannel: Int,
     val outputBufferDepth: Int,
-    val tcdmSize: Int
+    val tcdmSize: Int,
+    val configurableSpatialBound: Boolean
 )
 
 object AddressGenUnitParam {
@@ -46,19 +47,22 @@ object AddressGenUnitParam {
     addressWidth = 17, // For the address of 128kB tcdm size
     numChannel = 8,
     outputBufferDepth = 8,
-    tcdmSize = 128
+    tcdmSize = 128,
+    configurableSpatialBound = true
   )
   def apply(
       dimension: Int,
       numChannel: Int,
       outputBufferDepth: Int,
-      tcdmSize: Int
+      tcdmSize: Int,
+      configurableSpatialBound: Boolean
   ) = new AddressGenUnitParam(
     dimension = dimension,
     addressWidth = log2Ceil(tcdmSize) + 10,
     numChannel = numChannel,
     outputBufferDepth = outputBufferDepth,
-    tcdmSize = tcdmSize
+    tcdmSize = tcdmSize,
+    configurableSpatialBound = configurableSpatialBound
   )
 }
 
@@ -68,13 +72,16 @@ class ReaderWriterParam(
     tcdmSize: Int = 128,
     numChannel: Int = 8,
     addressBufferDepth: Int = 8,
-    dataBufferDepth: Int = 8
+    dataBufferDepth: Int = 8,
+    configurableSpatialBound: Boolean = true,
+    val configurableByteMask: Boolean = true
 ) {
   val aguParam = AddressGenUnitParam(
     dimension = dimension,
     numChannel = numChannel,
     outputBufferDepth = addressBufferDepth,
-    tcdmSize = tcdmSize
+    tcdmSize = tcdmSize,
+    configurableSpatialBound = configurableSpatialBound
   )
 
   val tcdmParam = TCDMParam(

--- a/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/DesignParams/DesignParams.scala
@@ -55,7 +55,7 @@ object AddressGenUnitParam {
       numChannel: Int,
       outputBufferDepth: Int,
       tcdmSize: Int,
-      configurableSpatialBound: Boolean
+      configurableSpatialBound: Boolean = true
   ) = new AddressGenUnitParam(
     dimension = dimension,
     addressWidth = log2Ceil(tcdmSize) + 10,

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -217,14 +217,19 @@ class AddressGenUnit(
   io.busy := currentState === sBUSY
 
   // Spatial bound
-  // The innermost one is the spatial bound, so it should not be multiplied with other bounds. It should be used to generate enabled_channels signal
-  io.enabled_channels.zipWithIndex.foreach { case (a, b) =>
-    a := io.cfg.bounds.head > b.U
+  // The innermost one is the spatial bound, so it should not be multiplied with other bounds.
+  // If param.configurableSpatialBound is true, then the spatial bound is configurable
+  if (param.configurableSpatialBound) {
+    io.enabled_channels.zipWithIndex.foreach { case (a, b) =>
+      a := io.cfg.bounds.head > b.U
+    }
+    assert(
+      io.cfg.bounds.head <= param.numChannel.U,
+      "[AddressGenUnit] The innermost bound is spatial bound, so it should be less than or equal to the number of channels"
+    )
+  } else {
+    io.enabled_channels.foreach(_ := true.B)
   }
-  assert(
-    io.cfg.bounds.head <= param.numChannel.U,
-    "[AddressGenUnit] The innermost bound is spatial bound, so it should be less than or equal to the number of channels"
-  )
 
   // Temporal bounds' tick signal (enable signal)
   val counters_tick =

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
@@ -61,7 +61,10 @@ class Reader(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
   requestors.io.in.addr <> addressgen.io.addr
   requestors.io.enable := addressgen.io.enabled_channels
   responsers.io.enable := addressgen.io.enabled_channels
-  requestors.io.in.strb := io.strb
+
+  if (param.configurableByteMask) requestors.io.in.strb := io.strb
+  else requestors.io.in.strb.asBools.foreach(_ := true.B)
+
   requestors.io.RequestorResponserLink.ResponsorReady.get := responsers.io.RequestorResponserLink.ResponsorReady
   responsers.io.RequestorResponserLink.RequestorSubmit := requestors.io.RequestorResponserLink.RequestorSubmit.get
   requestors.io.out.tcdmReq <> io.tcdmReq

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/ReaderWriterIO.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/ReaderWriterIO.scala
@@ -11,7 +11,11 @@ abstract class ReaderWriterCommomIO(val param: ReaderWriterParam)
   // The signal to control address generator
   val cfg = Input(new AddressGenUnitCfgIO(param.aguParam))
   // The signal to control which byte is written to TCDM
-  val strb = Input(UInt((param.tcdmParam.dataWidth / 8).W))
+  val strb =
+    if (param.configurableByteMask)
+      Input(UInt((param.tcdmParam.dataWidth / 8).W))
+    else Input(UInt(0.W))
+
   // The signal trigger the start of Address Generator. The non-empty of address generator will cause data requestor to read the data
   val start = Input(Bool())
   // The module is busy if addressgen is busy or fifo in addressgen is not empty

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Writer.scala
@@ -53,7 +53,9 @@ class Writer(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
   requestors.io.in.addr <> addressgen.io.addr
   requestors.io.in.data.get <> dataBuffer.io.out
   requestors.io.out.tcdmReq <> io.tcdmReq
-  requestors.io.in.strb := io.strb
+
+  if (param.configurableByteMask) requestors.io.in.strb := io.strb
+  else requestors.io.in.strb.asBools.foreach(_ := true.B)
 
   dataBuffer.io.in.head <> io.data
   io.busy := addressgen.io.busy | (~addressgen.io.bufferEmpty)


### PR DESCRIPTION
This PR is a stacked PR that relies on PR #244 . 

This PR adds the ability to turn off Byte Enable and Spatial Bound by setting ***configurableSpatialBound*** and ***configurableByteMask*** to false in ***ReaderWriterParam*** Class. 

Be cautious that setting these value does not mean the corresponding IOs in Chisel view disappear (although it will not show up in the final SystemVerilog RTL). To suppress errors in Chisel, ***strobe*** and ***bounds(0)*** should be connected to any value or DontCare. 