### PR TITLE
Add custom TCDM assignment feature

### DIFF
--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -154,6 +154,58 @@
             "propertyNames": { "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
             "additionalProperties": { "type": "number", "minimum": 1 }
         },
+        "snax_custom_tcdm_assign":{
+            "type": "object",
+            "title": "SNAX Custom TCDM Assignments",
+            "properties": {
+                "snax_enable_assign_tcdm_idx": {
+                    "type": "boolean",
+                    "title": "Use index assignment for TCDM",
+                    "description": "This enables the custom use of index assignment for TCDM ports. WARNING! Use this only when needed.",
+                    "default": false
+                },
+                "snax_narrow_assign_start_idx": {
+                    "type": "array",
+                    "title": "Narrow TCDM Start Index Assignments",
+                    "description": "Start indices for the custom narrow TCDM assignments.",
+                    "minItems": 1,
+                    "default": [0],
+                      "items": {
+                        "type": "number"
+                      }
+                },
+                "snax_narrow_assign_end_idx": {
+                    "type": "array",
+                    "title": "Narrow TCDM End Index Assignments",
+                    "description": "End indices for the custom narrow TCDM assignments.",
+                    "minItems": 1,
+                    "default": [0],
+                      "items": {
+                        "type": "number"
+                      }
+                },
+                "snax_wide_assign_start_idx": {
+                    "type": "array",
+                    "title": "Wide TCDM Start Index Assignments",
+                    "description": "Start indices for the custom wide TCDM assignments.",
+                    "minItems": 1,
+                    "default": [0],
+                      "items": {
+                        "type": "number"
+                      }
+                },
+                "snax_wide_assign_end_idx": {
+                    "type": "array",
+                    "title": "Wide TCDM End Index Assignments",
+                    "description": "End indices for the custom wide TCDM assignments.",
+                    "minItems": 1,
+                    "default": [0],
+                      "items": {
+                        "type": "number"
+                      }
+                }
+            }
+        },
         "timing": {
             "type": "object",
             "title": "Timing and Latency Tuning Parameter",

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -105,7 +105,18 @@ module snitch_cluster
   parameter int unsigned TotalSnaxWideTcdmPorts = 0,
   /// Total Number of SNAX TCDM ports
   parameter int unsigned TotalSnaxTcdmPorts = TotalSnaxNarrowTcdmPorts + TotalSnaxWideTcdmPorts,
-  /// SNAX Acc Narrow Wide Selection
+  /// SNAX TCDM Custom Index Assignment
+  parameter bit          SnaxUseIdxTcdmAssign = 1'b0,
+  /// SNAX Number of Narrow Index Assignments
+  parameter int unsigned SnaxNumNarrowAssignIdx = 0,
+  /// SNAX Number of Wide Index Assignments
+  parameter int unsigned SnaxNumWideAssignIdx = 0,
+  /// SNAX Narrow Custom Index Assignment
+  parameter int unsigned SnaxNarrowStartIdx [SnaxNumNarrowAssignIdx] = '{default: 0},
+  parameter int unsigned SnaxNarrowEndIdx [SnaxNumNarrowAssignIdx] = '{default: 0},
+  /// SNAX Wide Custom Index Assignment
+  parameter int unsigned SnaxWideStartIdx [SnaxNumWideAssignIdx] = '{default: 0},
+  parameter int unsigned SnaxWideEndIdx [SnaxNumWideAssignIdx] = '{default: 0},
   /// SNAX Use Custom Instruction Ports
   parameter bit [NrCores-1:0] SnaxUseCustomPorts = 0,
   /// Physical Memory Attribute Configuration
@@ -705,34 +716,87 @@ module snitch_cluster
     // That is the technique used in the procedural block below
     //------------------------
 
-    always_comb begin
+    if (SnaxUseIdxTcdmAssign) begin: gen_custom_tcdm_assign
 
-      total_offset = 0;
-      wide_offset = 0;
-      narrow_offset = 0;
+      integer start_wide_idx, end_wide_idx, wide_len;
+      integer start_narrow_idx, end_narrow_idx, narrow_len;
 
-      for (int i = 0; i < NrCores; i++) begin
+      always_comb begin
 
-        curr_wide = SnaxWideTcdmPorts[i];
-        curr_narrow = SnaxNarrowTcdmPorts[i];
+        wide_offset = 0;
+        narrow_offset = 0;
 
-        // Wide re-mapping
-        for(int j = 0; j < curr_wide; j++) begin
-          snax_tcdm_req_wide[j+wide_offset] = snax_tcdm_req_i[j+total_offset];
-          snax_tcdm_rsp_o[j+total_offset] = snax_tcdm_rsp_wide[j+wide_offset];
+        // Re-map the custom wide ports
+        // We make the assumption that the number of narrow
+        // per wide port is equal to BanksPerSuperBank
+
+        // For this part we cycle through the starting
+        // and end points for the TCDM slices
+        for (int i = 0; i < SnaxNumWideAssignIdx; i++) begin
+
+          // Note that indices are indexed starting from 0
+          start_wide_idx = SnaxWideStartIdx[i];
+          end_wide_idx = SnaxWideEndIdx[i];
+          wide_len = end_wide_idx - start_wide_idx + 1;
+  
+          for (int j =0; j < wide_len; j++) begin
+            snax_tcdm_req_wide[j+wide_offset] = snax_tcdm_req_i[j+start_wide_idx];
+            snax_tcdm_rsp_o[j+start_wide_idx] = snax_tcdm_rsp_wide[j+wide_offset];
+          end
+
+          wide_offset += wide_len;
+
         end
 
-        // Narrow re-mapping
-        for(int j = 0; j < curr_narrow; j++) begin
-          snax_tcdm_req_narrow[j+narrow_offset] = snax_tcdm_req_i[j+curr_wide+total_offset];
-          snax_tcdm_rsp_o[j+curr_wide+total_offset] = snax_tcdm_rsp_narrow[j+narrow_offset];
+        // Re-map the custom narrow ports
+        for (int i = 0; i < SnaxNumNarrowAssignIdx; i++) begin
+
+          // Note that indices are indexed starting from 0
+          start_narrow_idx = SnaxNarrowStartIdx[i];
+          end_narrow_idx = SnaxNarrowEndIdx[i];
+          narrow_len = end_narrow_idx - start_narrow_idx + 1;
+
+          for (int j =0; j < narrow_len; j++) begin
+            snax_tcdm_req_narrow[j+narrow_offset] = snax_tcdm_req_i[j+start_narrow_idx];
+            snax_tcdm_rsp_o[j+start_narrow_idx] = snax_tcdm_rsp_narrow[j+narrow_offset];
+          end
+
+          narrow_offset += narrow_len;
+
         end
 
-        wide_offset += curr_wide;
-        narrow_offset += curr_narrow;
-        total_offset += (curr_wide + curr_narrow);
       end
+    end else begin: gen_non_custom_tcdm_assign
 
+      always_comb begin
+
+        total_offset = 0;
+        wide_offset = 0;
+        narrow_offset = 0;
+
+        for (int i = 0; i < NrCores; i++) begin
+
+          curr_wide = SnaxWideTcdmPorts[i];
+          curr_narrow = SnaxNarrowTcdmPorts[i];
+
+          // Wide re-mapping
+          for(int j = 0; j < curr_wide; j++) begin
+            snax_tcdm_req_wide[j+wide_offset] = snax_tcdm_req_i[j+total_offset];
+            snax_tcdm_rsp_o[j+total_offset] = snax_tcdm_rsp_wide[j+wide_offset];
+          end
+
+          // Narrow re-mapping
+          for(int j = 0; j < curr_narrow; j++) begin
+            snax_tcdm_req_narrow[j+narrow_offset] = snax_tcdm_req_i[j+curr_wide+total_offset];
+            snax_tcdm_rsp_o[j+curr_wide+total_offset] = snax_tcdm_rsp_narrow[j+narrow_offset];
+          end
+
+          wide_offset += curr_wide;
+          narrow_offset += curr_narrow;
+          total_offset += (curr_wide + curr_narrow);
+        end
+
+      end
     end
 
   end else if (NumSnaxWideTcdmPorts > 0) begin: gen_wide_only_map

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -738,7 +738,7 @@ module snitch_cluster
           start_wide_idx = SnaxWideStartIdx[i];
           end_wide_idx = SnaxWideEndIdx[i];
           wide_len = end_wide_idx - start_wide_idx + 1;
-  
+
           for (int j =0; j < wide_len; j++) begin
             snax_tcdm_req_wide[j+wide_offset] = snax_tcdm_req_i[j+start_wide_idx];
             snax_tcdm_rsp_o[j+start_wide_idx] = snax_tcdm_rsp_wide[j+wide_offset];

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -467,11 +467,13 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
   localparam int unsigned SsrMuxRespDepth         [${cfg['nr_cores']}] = '{${core_cfg('ssr_mux_resp_depth')}};
   localparam int unsigned SnaxNarrowTcdmPorts     [${cfg['nr_cores']}] = '{${acc_cfg(snax_narrow_tcdm_ports_list)}};
   localparam int unsigned SnaxWideTcdmPorts       [${cfg['nr_cores']}] = '{${acc_cfg(snax_wide_tcdm_ports_list)}};
+% if 'snax_custom_tcdm_assign' in cfg:
 % if cfg['snax_custom_tcdm_assign']['snax_enable_assign_tcdm_idx']:
   localparam int unsigned SnaxNarrowStartIdx      [${len(cfg['snax_custom_tcdm_assign']['snax_narrow_assign_start_idx'])}] = '{${snax_custom_tcdm_idx('snax_narrow_assign_start_idx')}};
   localparam int unsigned SnaxNarrowEndIdx        [${len(cfg['snax_custom_tcdm_assign']['snax_narrow_assign_end_idx'])}] = '{${snax_custom_tcdm_idx('snax_narrow_assign_end_idx')}};
   localparam int unsigned SnaxWideStartIdx        [${len(cfg['snax_custom_tcdm_assign']['snax_wide_assign_start_idx'])}] = '{${snax_custom_tcdm_idx('snax_wide_assign_start_idx')}};
   localparam int unsigned SnaxWideEndIdx          [${len(cfg['snax_custom_tcdm_assign']['snax_wide_assign_end_idx'])}] = '{${snax_custom_tcdm_idx('snax_wide_assign_end_idx')}};
+% endif
 % endif
 
   //-----------------------------
@@ -558,7 +560,8 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .TotalSnaxNarrowTcdmPorts(${total_snax_narrow_ports}),
     .TotalSnaxWideTcdmPorts(${total_snax_wide_ports}),
     .SnaxUseCustomPorts (${core_cfg_flat('snax_use_custom_ports')}),
-% if cfg['snax_custom_tcdm_assign']['snax_enable_assign_tcdm_idx']:
+% if 'snax_custom_tcdm_assign' in cfg:
+  % if cfg['snax_custom_tcdm_assign']['snax_enable_assign_tcdm_idx']:
     .SnaxUseIdxTcdmAssign(1'b1),
     .SnaxNumNarrowAssignIdx(${len(cfg['snax_custom_tcdm_assign']['snax_narrow_assign_start_idx'])}),
     .SnaxNumWideAssignIdx(${len(cfg['snax_custom_tcdm_assign']['snax_wide_assign_start_idx'])}),
@@ -566,6 +569,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .SnaxNarrowEndIdx(SnaxNarrowEndIdx),
     .SnaxWideStartIdx(SnaxWideStartIdx),
     .SnaxWideEndIdx(SnaxWideEndIdx),
+  % endif
 % endif
     .FPUImplementation (${cfg['pkg_name']}::FPUImplementation),
     .SnitchPMACfg (${cfg['pkg_name']}::SnitchPMACfg),

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -16,6 +16,12 @@ ${c[prop]}${', ' if not loop.last else ''}\
   % endfor
 </%def>\
 
+<%def name="snax_custom_tcdm_idx(prop)">\
+  % for idx in range(len(cfg['snax_custom_tcdm_assign'][prop])):
+${cfg['snax_custom_tcdm_assign'][prop][idx]}${', ' if not loop.last else ''}\
+  % endfor
+</%def>\
+
 <%def name="acc_cfg(prop)">\
   % for idx in range(len(prop)):
 ${prop[idx]}${', ' if not loop.last else ''}\
@@ -461,6 +467,12 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
   localparam int unsigned SsrMuxRespDepth         [${cfg['nr_cores']}] = '{${core_cfg('ssr_mux_resp_depth')}};
   localparam int unsigned SnaxNarrowTcdmPorts     [${cfg['nr_cores']}] = '{${acc_cfg(snax_narrow_tcdm_ports_list)}};
   localparam int unsigned SnaxWideTcdmPorts       [${cfg['nr_cores']}] = '{${acc_cfg(snax_wide_tcdm_ports_list)}};
+% if cfg['snax_custom_tcdm_assign']['snax_enable_assign_tcdm_idx']:
+  localparam int unsigned SnaxNarrowStartIdx      [${len(cfg['snax_custom_tcdm_assign']['snax_narrow_assign_start_idx'])}] = '{${snax_custom_tcdm_idx('snax_narrow_assign_start_idx')}};
+  localparam int unsigned SnaxNarrowEndIdx        [${len(cfg['snax_custom_tcdm_assign']['snax_narrow_assign_end_idx'])}] = '{${snax_custom_tcdm_idx('snax_narrow_assign_end_idx')}};
+  localparam int unsigned SnaxWideStartIdx        [${len(cfg['snax_custom_tcdm_assign']['snax_wide_assign_start_idx'])}] = '{${snax_custom_tcdm_idx('snax_wide_assign_start_idx')}};
+  localparam int unsigned SnaxWideEndIdx          [${len(cfg['snax_custom_tcdm_assign']['snax_wide_assign_end_idx'])}] = '{${snax_custom_tcdm_idx('snax_wide_assign_end_idx')}};
+% endif
 
   //-----------------------------
   // SNAX Custom Instruction Ports
@@ -546,6 +558,15 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .TotalSnaxNarrowTcdmPorts(${total_snax_narrow_ports}),
     .TotalSnaxWideTcdmPorts(${total_snax_wide_ports}),
     .SnaxUseCustomPorts (${core_cfg_flat('snax_use_custom_ports')}),
+% if cfg['snax_custom_tcdm_assign']['snax_enable_assign_tcdm_idx']:
+    .SnaxUseIdxTcdmAssign(1'b1),
+    .SnaxNumNarrowAssignIdx(${len(cfg['snax_custom_tcdm_assign']['snax_narrow_assign_start_idx'])}),
+    .SnaxNumWideAssignIdx(${len(cfg['snax_custom_tcdm_assign']['snax_wide_assign_start_idx'])}),
+    .SnaxNarrowStartIdx(SnaxNarrowStartIdx),
+    .SnaxNarrowEndIdx(SnaxNarrowEndIdx),
+    .SnaxWideStartIdx(SnaxWideStartIdx),
+    .SnaxWideEndIdx(SnaxWideEndIdx),
+% endif
     .FPUImplementation (${cfg['pkg_name']}::FPUImplementation),
     .SnitchPMACfg (${cfg['pkg_name']}::SnitchPMACfg),
     .NumIntOutstandingLoads (NumIntOutstandingLoads),

--- a/target/snitch_cluster/cfg/snax-hypercorex.hjson
+++ b/target/snitch_cluster/cfg/snax-hypercorex.hjson
@@ -26,6 +26,14 @@
         dma_data_width: 512,
         dma_axi_req_fifo_depth: 3,
         dma_req_fifo_depth: 3,
+        // SNAX custom cluster TCDM assignment
+        snax_custom_tcdm_assign: {
+            snax_enable_assign_tcdm_idx: true,
+            snax_narrow_assign_start_idx: [0,26],
+            snax_narrow_assign_end_idx: [1,26],
+            snax_wide_assign_start_idx: [2,27],
+            snax_wide_assign_end_idx: [25,34],
+        },
         // Timing parameters
         timing: {
             lat_comp_fp32: 3,


### PR DESCRIPTION
This PR adds an advanced feature where you manually assign the narrow and wide TCDM assignments.
We discovered that we needed this because of @xiaoling-yi's GeMM-CONV core and the Hypercorex.

The old assignment from the narrow and wide TCDM always assumes that all wide ports should be collated together (grouped together) from the LSB TCDM ports to whatever size they need. Then all narrow TCDM ports come after. Moreover, all reads come first then all writes come after too causing a limitation in TCDM assignment. Visually...

`[ all narrow ports, all wide ports]`

However the the streamers produce an arrangement such that:

`[narrow read ports, wide read ports, narrow write ports, wide write ports]`

Our previous accelerators complied with these and there were no problems. For example, in the case of Gemm + Data reshuffle, our GeMM has 2 wide read ports, and 4 wide write ports, and the data reshuffle can use 8 narrow read ports and 1 wide write port which we can re-arrange as:

`[8 narrow read ports of DR, 1 wide write port of DR, 2 wide read ports of GeMM, 4 wide write ports of GeMM]`

However, having more complex accelerators necessitates a flexible port assignment. This becomes a limitation when the arrangement of narrow and wide ports can be mixed. For example, in Hypercorex we need the arrangement (in order):

`[2 narrow read, 1 narrow write, 3 wide reads, 1 wide write]`

All of which cannot be mapped accordingly with the current setup.

This PR fixes it.

**How to configure then?**

A sample of the configuration file is shown below:

```
// SNAX custom cluster TCDM assignment
snax_custom_tcdm_assign: {
    snax_enable_assign_tcdm_idx: true,
    snax_narrow_assign_start_idx: [0,26],
    snax_narrow_assign_end_idx: [1,26],
    snax_wide_assign_start_idx: [2,27],
    snax_wide_assign_end_idx: [25,34],
},
```

**NOTE**: You need to declare this outside of the accelerator file. This custom TCDM re-assignment is a cluster-level configuration. So any user who uses this needs to know the specific mapping to TCDMs.

Major TODO:
- [x] Modify schema for default values
- [x] Modify cluster template
- [x] Modify main cluster for switches
- [x] Modify configuration files