### PR TITLE
Clean-up: Fix Hypercorex bit-width errors, initial assertion after reset, Hypercorex wide access stride

### DIFF
--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -961,8 +961,6 @@ module snitch_cc #(
   // verilog_lint: waive-stop always-ff-non-blocking
   // pragma translate_on
 
-  //`ASSERT_INIT(BootAddrAligned, boot_addr_i[1:0] == 2'b00)
-
   BootAddrAligned: assert property (
       @(posedge clk_i) disable iff (!rst_ni)
       boot_addr_i[1:0] == 2'b00

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -961,6 +961,11 @@ module snitch_cc #(
   // verilog_lint: waive-stop always-ff-non-blocking
   // pragma translate_on
 
-  `ASSERT_INIT(BootAddrAligned, boot_addr_i[1:0] == 2'b00)
+  //`ASSERT_INIT(BootAddrAligned, boot_addr_i[1:0] == 2'b00)
+
+  BootAddrAligned: assert property (
+      @(posedge clk_i) disable iff (!rst_ni)
+      boot_addr_i[1:0] == 2'b00
+  ) else $error("Boot address not aligned after reset release.");
 
 endmodule

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/char-recog/src/char-recog.c
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/char-recog/src/char-recog.c
@@ -110,7 +110,7 @@ int main() {
                                             1,            // Outer loop bound
                                             256,          // Inner loop stride
                                             0,            // Outer loop stride
-                                            1,            // Spatial stride
+                                            8,            // Spatial stride
                                             (uint32_t)qhv_start  // Base address
         );
 
@@ -178,7 +178,7 @@ int main() {
                                            num_classes,  // Outer loop bound
                                            256,          // Inner loop stride
                                            0,            // Outer loop stride
-                                           1,            // Spatial stride
+                                           8,            // Spatial stride
                                            (uint32_t)qhv_start  // Base address
         );
 


### PR DESCRIPTION
This PR fixes the following:

- [x] Bit-width warnings in the Hypercorex wrapper
- [x] Fix the initial assertion, it needs to be after a reset to avoid unnecessary error logs
- [x] Hypercorex wide access stride in software.