### PR TITLE
Set default AXI user widths to 2

### DIFF
--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -104,12 +104,12 @@
         "user_width": {
             "type": "number",
             "description": "User width of the narrower AXI plug into the cluster.",
-            "default": 1
+            "default": 2
         },
         "dma_user_width": {
             "type": "number",
             "description": "User width of the wide AXI plug into the cluster.",
-            "default": 1
+            "default": 2
         },
         "hart_base_id": {
             "type": "number",


### PR DESCRIPTION
This PR is a request for the CONVOLVE project to set the default AXI user width values to 2.
By default, in the schema, this is 1. Now we set it to 2.

