### PR TITLE
Modify testharness configurations

### DIFF
--- a/hw/templates/testharness.sv.tpl
+++ b/hw/templates/testharness.sv.tpl
@@ -30,7 +30,15 @@ module testharness import ${cfg["cluster"]["name"]}_pkg::*; (
     .hart_base_id_i       ( HartBaseID      ),
     .cluster_base_addr_i  ( ClusterBaseAddr ),
     .boot_addr_i          ( BootAddr        ),
+% if cfg["cluster"]["timing"]["iso_crossings"]:
+    .clk_d2_bypass_i      ( '0              ),
+% endif
+% if cfg["cluster"]["enable_debug"]:
     .debug_req_i          ( '0              ),
+% endif
+% if cfg["cluster"]["sram_cfg_expose"]:
+    .sram_cfgs_i          ( '0'             ),
+% endif
     .meip_i               ( '0              ),
     .mtip_i               ( '0              ),
     .msip_i               ( msip            ),

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -405,7 +405,18 @@ def main():
             " --sw-target-dir " + args.gen_path + "../sw/snax/xdma"
         )
 
+    # ---------------------------------------
     # Generation of testharness
+    # ---------------------------------------
+    if ("enable_debug" not in cfg["cluster"]):
+        cfg["cluster"]["enable_debug"] = False
+
+    if ("iso_crossings" not in cfg["cluster"]["timing"]):
+        cfg["cluster"]["timing"]["iso_crossings"] = False
+
+    if ("sram_cfg_expose" not in cfg["cluster"]):
+        cfg["cluster"]["sram_cfg_expose"] = False
+
     test_target_path = args.test_path
     file_name = "testharness.sv"
     tpl_testharness_file = args.tpl_path + "testharness.sv.tpl"  # noqa: E501


### PR DESCRIPTION
This PR modifies the test harness generation. It matches the port template of the main cluster template. This is to align with the Hemaia tapeout needs.

Major TODO:
- [x] Modify template
- [x] Modify snaxgen to set default values