### PR TITLE
Improve snrt to calculate the correct cluster index

### DIFF
--- a/sw/snRuntime/src/team.h
+++ b/sw/snRuntime/src/team.h
@@ -61,7 +61,7 @@ inline uint32_t __attribute__((const)) snrt_global_compute_core_idx() {
 
 inline uint32_t __attribute__((const)) snrt_cluster_idx() {
     // return snrt_global_core_idx() / snrt_cluster_core_num();
-    return (snrt_cluster_base_addrl() & 0xfc0000) >> (CLUSTER_TCDM_ADDRWIDTH + 1);
+    return (snrt_cluster_base_addrl() & 0xfc0000) >> CLUSTER_ADDRWIDTH;
 }
 
 inline uint32_t __attribute__((const)) snrt_cluster_core_idx() {

--- a/sw/snRuntime/src/team.h
+++ b/sw/snRuntime/src/team.h
@@ -61,7 +61,7 @@ inline uint32_t __attribute__((const)) snrt_global_compute_core_idx() {
 
 inline uint32_t __attribute__((const)) snrt_cluster_idx() {
     // return snrt_global_core_idx() / snrt_cluster_core_num();
-    return (snrt_cluster_base_addrl() & 0xfc0000) >> 18;
+    return (snrt_cluster_base_addrl() & 0xfc0000) >> (CLUSTER_TCDM_ADDRWIDTH + 1);
 }
 
 inline uint32_t __attribute__((const)) snrt_cluster_core_idx() {

--- a/target/snitch_cluster/cfg/default.hjson
+++ b/target/snitch_cluster/cfg/default.hjson
@@ -13,7 +13,7 @@
         name: "snitch_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -13,7 +13,7 @@
         name: "snax_alu_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-hypercorex.hjson
+++ b/target/snitch_cluster/cfg/snax-hypercorex.hjson
@@ -13,7 +13,7 @@
         name: "snax_hypercorex_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
@@ -13,7 +13,7 @@
         name: "snax_KUL_xdma_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
@@ -13,7 +13,7 @@
         name: "snax_KUL_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-mac-mult.hjson
+++ b/target/snitch_cluster/cfg/snax-mac-mult.hjson
@@ -13,7 +13,7 @@
         name: "snax_mac_mult_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-mac.hjson
+++ b/target/snitch_cluster/cfg/snax-mac.hjson
@@ -13,7 +13,7 @@
         name: "snax_mac_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-streamer-gemm-add-c.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm-add-c.hjson
@@ -14,7 +14,7 @@
         name: "snax_streamer_gemm_add_c_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
@@ -13,7 +13,7 @@
         name: "snax_streamer_gemm_cluster",
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
-        cluster_base_offset: 0, // 0x0
+        cluster_base_offset: 262144,  // 256KB
         cluster_base_hartid: 0,
         addr_width: 48,
         data_width: 64,

--- a/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
+++ b/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
@@ -13,6 +13,6 @@
 %>
 #define CLUSTER_ADDRWIDTH ${cluster_addrwidth}
 #define CLUSTER_PERIPH_BASE_ADDR (CLUSTER_TCDM_BASE_ADDR + CLUSTER_TCDM_SIZE)
-#define CLUSTER_ZERO_MEM_START_ADDR (CLUSTER_PERIPH_BASE_ADDR + CLUSTER_TCDM_SIZE)
+#define CLUSTER_ZERO_MEM_START_ADDR (CLUSTER_PERIPH_BASE_ADDR + ${hex(cfg['cluster']['cluster_periph_size'] * 1024)})
 #define CLUSTER_ZERO_MEM_END_ADDR (CLUSTER_ZERO_MEM_START_ADDR + ${hex(cfg['cluster']['zero_mem_size'] * 1024)})
 #define CLINT_BASE_ADDR ${hex(cfg['peripherals']['clint']['address'])}

--- a/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
+++ b/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
@@ -2,8 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+
+
 #define CLUSTER_TCDM_BASE_ADDR ${hex(cfg['cluster']['cluster_base_addr'])}
-#define CLUSTER_PERIPH_BASE_ADDR (CLUSTER_TCDM_BASE_ADDR + ${hex(cfg['cluster']['tcdm']['size'] * 1024)})
-#define CLUSTER_ZERO_MEM_START_ADDR (CLUSTER_PERIPH_BASE_ADDR + ${hex(cfg['cluster']['cluster_periph_size'] * 1024)})
+#define CLUSTER_TCDM_SIZE ${hex(cfg['cluster']['tcdm']['size'] * 1024)}
+<%
+    import math
+    cluster_tcdm_addrwidth = int(math.log2(cfg['cluster']['tcdm']['size'] * 1024))
+%>
+#define CLUSTER_TCDM_ADDRWIDTH ${cluster_tcdm_addrwidth}
+#define CLUSTER_PERIPH_BASE_ADDR (CLUSTER_TCDM_BASE_ADDR + CLUSTER_TCDM_SIZE)
+#define CLUSTER_ZERO_MEM_START_ADDR (CLUSTER_PERIPH_BASE_ADDR + CLUSTER_TCDM_SIZE)
 #define CLUSTER_ZERO_MEM_END_ADDR (CLUSTER_ZERO_MEM_START_ADDR + ${hex(cfg['cluster']['zero_mem_size'] * 1024)})
 #define CLINT_BASE_ADDR ${hex(cfg['peripherals']['clint']['address'])}

--- a/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
+++ b/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
@@ -6,11 +6,12 @@
 
 #define CLUSTER_TCDM_BASE_ADDR ${hex(cfg['cluster']['cluster_base_addr'])}
 #define CLUSTER_TCDM_SIZE ${hex(cfg['cluster']['tcdm']['size'] * 1024)}
+#define CLUSTER_SIZE ${hex(cfg['cluster']['cluster_base_offset'])}
 <%
     import math
-    cluster_tcdm_addrwidth = int(math.log2(cfg['cluster']['tcdm']['size'] * 1024))
+    cluster_addrwidth = int(math.log2(cfg['cluster']['cluster_base_offset']))
 %>
-#define CLUSTER_TCDM_ADDRWIDTH ${cluster_tcdm_addrwidth}
+#define CLUSTER_ADDRWIDTH ${cluster_addrwidth}
 #define CLUSTER_PERIPH_BASE_ADDR (CLUSTER_TCDM_BASE_ADDR + CLUSTER_TCDM_SIZE)
 #define CLUSTER_ZERO_MEM_START_ADDR (CLUSTER_PERIPH_BASE_ADDR + CLUSTER_TCDM_SIZE)
 #define CLUSTER_ZERO_MEM_END_ADDR (CLUSTER_ZERO_MEM_START_ADDR + ${hex(cfg['cluster']['zero_mem_size'] * 1024)})


### PR DESCRIPTION
This PR fixes the wrong snitch cluster index when TCDM is not set to 128KB. This is needed when multiple clusters are integrated into one chip with non-default TCDM size. 