### PR TITLE
Take out `snax-gemm` from Docker build

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -131,23 +131,6 @@ RUN git clone https://github.com/kuleuven-micas/snax_cluster /src && \
     make -C target/snitch_cluster bin/snitch_cluster.vlt \
     CFG_OVERRIDE=cfg/snax-mac.hjson -j $(nproc)
 
-FROM base as snax-gemm
-
-RUN git clone https://github.com/kuleuven-micas/snax_cluster /src && \
-    cd /src && git submodule update --init && \
-    cd /src && sbt package && \
-    cd /src && \
-    make DEBUG=ON sw -j$(nproc) \
-    -C target/snitch_cluster \
-    SELECT_TOOLCHAIN=llvm-generic \
-    SELECT_RUNTIME=rtl-generic \
-    CFG_OVERRIDE=cfg/snax-gemm.hjson && \
-    cd /src && \
-    make -C target/snitch_cluster rtl-gen \
-    CFG_OVERRIDE=cfg/snax-gemm.hjson && \
-    make -C target/snitch_cluster bin/snitch_cluster.vlt \
-    CFG_OVERRIDE=cfg/snax-gemm.hjson -j $(nproc)
-
 FROM base as snax-alu
 
 RUN git clone https://github.com/kuleuven-micas/snax_cluster /src && \
@@ -195,16 +178,6 @@ COPY --from=snax-mac /src/sw/math/ /opt/snax-mac/sw/math/
 COPY --from=snax-mac /src/sw/deps/riscv-opcodes /opt/snax-mac/sw/deps/riscv-opcodes
 COPY --from=snax-mac /src/sw/deps/printf /opt/snax-mac/sw/deps/printf
 COPY --from=snax-mac /src/util/trace/gen_trace.py /opt/gen_trace.py
-
-COPY --from=snax-gemm /src/target/snitch_cluster/bin/snitch_cluster.vlt /opt/snax-gemm-rtl/bin/snitch_cluster.vlt
-COPY --from=snax-gemm /src/sw/snRuntime /opt/snax-gemm/sw/snRuntime
-COPY --from=snax-gemm /src/target/snitch_cluster/sw/runtime/rtl /opt/snax-gemm/target/snitch_cluster/sw/runtime/rtl
-COPY --from=snax-gemm /src/target/snitch_cluster/sw/runtime/rtl-generic /opt/snax-gemm/target/snitch_cluster/sw/runtime/rtl-generic
-COPY --from=snax-gemm /src/target/snitch_cluster/sw/runtime/common /opt/snax-gemm/target/snitch_cluster/sw/runtime/common
-COPY --from=snax-gemm /src/target/snitch_cluster/sw/snax/ /opt/snax-gemm/target/snitch_cluster/sw/snax
-COPY --from=snax-gemm /src/sw/math/ /opt/snax-gemm/sw/math/
-COPY --from=snax-gemm /src/sw/deps/riscv-opcodes /opt/snax-gemm/sw/deps/riscv-opcodes
-COPY --from=snax-gemm /src/sw/deps/printf /opt/snax-gemm/sw/deps/printf
 
 COPY --from=snax-alu /src/target/snitch_cluster/bin/snitch_cluster.vlt /opt/snax-alu-rtl/bin/snitch_cluster.vlt
 COPY --from=snax-alu /src/sw/snRuntime /opt/snax-alu/sw/snRuntime


### PR DESCRIPTION
This PR takes out the `snax-gemm` from the Docker build. It's currently not part of `main` any more.
Hence the CI for docker build in main fails. 

