### PR TITLE
Add make file targets for synthesis generation

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -50,6 +50,15 @@ VCS_BENDER   += -t test -t rtl -t simulation -t vcs
 VCS_SOURCES   = $(shell ${BENDER} script flist ${VCS_BENDER} | ${SED_SRCS})
 VCS_BUILDDIR := work-vcs
 
+# For synthesis with DC compiler
+SYN_FLIST ?= flist.tcl
+SYN_BENDER += -t test -t synthesis -t simulation
+ifeq ($(MEM_TYPE), exclude_tcsram)
+	SYN_BENDER += -t tech_cells_generic_exclude_tc_sram
+endif 
+SYN_SOURCES = $(shell ${BENDER} script synopsys ${SYN_BENDER})
+SYN_BUILDDIR := work-syn
+
 # fesvr is being installed here
 FESVR         ?= ${MKFILE_DIR}work
 FESVR_VERSION ?= 98d2c29e431f3b14feefbda48c5f70c2f451acf2

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -19,7 +19,7 @@ SELECT_TOOLCHAIN ?=      # Select Toolchain: "llvm-generic" = llvm17 generic or 
 .DEFAULT_GOAL := help
 .PHONY: all clean
 all: sw
-clean: clean-sw clean-work clean-vsim clean-vlt clean-vcs clean-logs clean-bender clean-generated
+clean: clean-sw clean-work clean-vsim clean-vlt clean-vcs clean-syn clean-logs clean-bender clean-generated
 
 ##########
 # Common #
@@ -29,6 +29,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
 ROOT        := ${MKFILE_DIR}../..
 SNITCH_ROOT := $(ROOT)
+SYN_ROOT    := $(ROOT)
 SNAX_CFG_PATH := $(ROOT)/target/snitch_cluster/cfg/
 SNAX_TPL_PATH := $(ROOT)/hw/templates/
 SNAX_TEST_PATH := $(ROOT)/target/snitch_cluster/test/
@@ -67,6 +68,16 @@ STREAM_PARAM_SCALA_PATH = $(ROOT)/hw/chisel/src/main/scala/snax/streamer/StreamP
 # SNAX Generations #
 ####################
 
+# This "function" simply adds
+# the tags necessary for each tool
+
+define add_tags
+	$(eval VSIM_BENDER += -t $1)
+	$(eval VLT_BENDER  += -t $1)
+	$(eval VCS_BENDER  += -t $1)
+	$(eval SYN_BENDER  += -t $1)
+endef
+
 # List manual conditions for different configurations
 
 # TODO: This config should be removed in the future, as the accelerator is in the seperate repo
@@ -75,69 +86,63 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
-	VSIM_BENDER += -t snax_streamer_gemm -t snax_streamer_gemm_cluster
-	VLT_BENDER  += -t snax_streamer_gemm -t snax_streamer_gemm_cluster
-	VCS_BENDER  += -t snax_streamer_gemm -t snax_streamer_gemm_cluster
+$(call add_tags,snax_streamer_gemm)
+$(call add_tags,snax_streamer_gemm_cluster)
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-alu.hjson)
 
-	VSIM_BENDER += -t snax_alu -t snax_alu_cluster
-	VLT_BENDER  += -t snax_alu -t snax_alu_cluster
-	VCS_BENDER  += -t snax_alu -t snax_alu_cluster
+$(call add_tags,snax_alu)
+$(call add_tags,snax_alu_cluster)
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-hypercorex.hjson)
 
-	VSIM_BENDER += -t hypercorex -t snax_hypercorex_cluster
-	VLT_BENDER  += -t hypercorex -t snax_hypercorex_cluster
-	VCS_BENDER  += -t hypercorex -t snax_hypercorex_cluster
+$(call add_tags,hypercorex)
+$(call add_tags,snax_hypercorex_cluster)
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm-add-c.hjson)
 
-    VSIM_BENDER += -t snax_streamer_gemm_add_c -t snax_streamer_gemm_add_c_cluster
-    VLT_BENDER  += -t snax_streamer_gemm_add_c -t snax_streamer_gemm_add_c_cluster
-    VCS_BENDER  += -t snax_streamer_gemm_add_c -t snax_streamer_gemm_add_c_cluster
+$(call add_tags,snax_streamer_gemm_add_c)
+$(call add_tags,snax_streamer_gemm_add_c_cluster)
  
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson)
 
-	VSIM_BENDER += -t snax_gemmX -t snax_KUL_xdma_cluster_xdma -t snax_KUL_xdma_cluster
-	VLT_BENDER  += -t snax_gemmX -t snax_KUL_xdma_cluster_xdma -t snax_KUL_xdma_cluster
-	VCS_BENDER  += -t snax_gemmX -t snax_KUL_xdma_cluster_xdma -t snax_KUL_xdma_cluster
+$(call add_tags,snax_gemmX)
+$(call add_tags,snax_KUL_xdma_cluster_xdma)
+$(call add_tags,snax_KUL_xdma_cluster)
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-kul-cluster-mixed-narrow-wide.hjson)
 
-	VSIM_BENDER += -t snax_gemmX -t snax_data_reshuffler -t snax_KUL_cluster
-	VLT_BENDER  += -t snax_gemmX -t snax_data_reshuffler -t snax_KUL_cluster
-	VCS_BENDER  += -t snax_gemmX -t snax_data_reshuffler -t snax_KUL_cluster
+$(call add_tags,snax_gemmX)
+$(call add_tags,snax_data_reshuffler)
+$(call add_tags,snax_KUL_cluster)
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-mac.hjson)
 
 	BYPASS_ACCGEN = true
-	
-	VSIM_BENDER += -t snax_mac -t snax_mac_cluster
-	VLT_BENDER  += -t snax_mac -t snax_mac_cluster
-	VCS_BENDER  += -t snax_mac -t snax_mac_cluster
+
+$(call add_tags,snax_mac)
+$(call add_tags,snax_mac_cluster)
 
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-mac-mult.hjson)
 
 	BYPASS_ACCGEN = true
-	
-	VSIM_BENDER += -t snax_mac -t snax_mac_mult_cluster
-	VLT_BENDER  += -t snax_mac -t snax_mac_mult_cluster
-	VCS_BENDER  += -t snax_mac -t snax_mac_mult_cluster
+
+$(call add_tags,snax_mac)
+$(call add_tags,snax_mac_mult_cluster)
 
 endif
 
@@ -145,9 +150,7 @@ ifeq (${CFG_OVERRIDE}, cfg/default.hjson)
 
 	BYPASS_ACCGEN = true
 
-	VSIM_BENDER += -t snitch_cluster
-	VLT_BENDER  += -t snitch_cluster
-	VCS_BENDER  += -t snitch_cluster
+$(call add_tags,snitch_cluster)
 
 endif
 
@@ -404,6 +407,21 @@ bin/snitch_cluster.vcs: ${VCS_SOURCES} ${TB_SRCS} $(TB_CC_SOURCES) $(TB_ASM_SOUR
 	$(VCS) -Mlib=$(VCS_BUILDDIR) -Mdir=$(VCS_BUILDDIR) -o bin/snitch_cluster.vcs -cc $(CC) -cpp $(CXX) \
 		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin $(TB_CC_SOURCES) $(TB_ASM_SOURCES) \
 		-CFLAGS "$(TB_CC_FLAGS)" -LDFLAGS "-L${FESVR}/lib" -lfesvr
+
+###############
+# DC Compiler #
+###############
+
+.PHONY: gen-syn clean-syn
+
+gen-syn:
+	mkdir -p $(SYN_BUILDDIR)
+	${BENDER} script synopsys ${SYN_BENDER} > $(SYN_BUILDDIR)/$(SYN_FLIST)
+	sed -i '2c\set ROOT "$(SYN_ROOT)"' $(SYN_BUILDDIR)/$(SYN_FLIST)
+	chmod +x $(SYN_BUILDDIR)/$(SYN_FLIST)
+
+clean-syn: clean-work
+	rm -rf $(SYN_BUILDDIR)
 
 ########
 # Util #


### PR DESCRIPTION
This PR adds a `syn-gen` target to help our Synthesis flow for generating the correct filelist with bender.

We need this so that we can:
- Automate the file list generation while **including bender targets**
- Add path hooks to the Makefile target

To make a sample synthesis filelist generation (assuming you have bender installed):

```bash
make CFG_OVERRIDE=cfg/snax-alu.hjson MEM_TYPE=exclude_tcsram SYN_ROOT=/repo/target/snitch_cluster SYN_FLIST=ddi.tcl gen-syn
```

Where:
- `CFG_OVERRIDE=cfg/snax-alu.hjson` is the configuration file. By default it is `cfg/default.hjson`.
- `MEM_TYPE=exclude_tcsram` if this is defined it excludes the `tcsram` model of the PULP platform. By default it is undefined.
- `SYN_ROOT=/repo/target/snitch_cluster` sets the `set ROOT` line in the generated DC filelist line. By default it is the Git root directory.
- `SYN_FLIST=ddi.tcl` specifies the name of the file list. By default it is `flist.tcl`
- (Optional) We can also modify `SYN_BUILDDIR` to point to the directory path where you want the `tcl` script to be stored.

Major TODO:
- [x] Modify common.ml
- [x] Modify target Makefile