### PR TITLE
Change the default toolchain and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
         run: |
           bender vendor init
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/default.hjson
+          CFG_OVERRIDE=cfg/default.hjson \
+          SELECT_RUNTIME=rtl \
+          SELECT_TOOLCHAIN=llvm-snitch
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
@@ -76,9 +78,7 @@ jobs:
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax-mac.hjson \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          CFG_OVERRIDE=cfg/snax-mac.hjson
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
@@ -141,9 +141,7 @@ jobs:
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax-mac-mult.hjson \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          CFG_OVERRIDE=cfg/snax-mac-mult.hjson
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
@@ -171,9 +169,7 @@ jobs:
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax-alu.hjson \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          CFG_OVERRIDE=cfg/snax-alu.hjson
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
@@ -205,9 +201,7 @@ jobs:
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax-hypercorex.hjson \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          CFG_OVERRIDE=cfg/snax-hypercorex.hjson
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
@@ -243,9 +237,7 @@ jobs:
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax-kul-cluster-mixed-narrow-wide.hjson \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          CFG_OVERRIDE=cfg/snax-kul-cluster-mixed-narrow-wide.hjson
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -270,9 +262,7 @@ jobs:
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          CFG_OVERRIDE=cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson \

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -11,8 +11,8 @@
 
 DEBUG            ?= OFF  # ON to turn on debugging symbols
 CFG_OVERRIDE     ?=      # Override default config file
-SELECT_RUNTIME   ?=      # Select snRuntime implementation: "banshee", "rtl-generic" or "rtl" (default)
-SELECT_TOOLCHAIN ?=      # Select Toolchain: "llvm-generic" = llvm17 generic or "llvm-snitch" llvm 12 snitch_specific (default)
+SELECT_RUNTIME   ?=      # Select snRuntime implementation: "banshee", "rtl-generic(default)" or "rtl" 
+SELECT_TOOLCHAIN ?=      # Select Toolchain: "llvm-generic" = llvm17 generic (default) or "llvm-snitch" llvm 12 snitch_specific
  					     # Note that the default toolchain only works with some applications 
 						 # since it requires the rtl-generic runtime
 

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -5,7 +5,7 @@
 # Luca Colagrande <colluca@iis.ee.ethz.ch>
 
 TARGET ?= all
-SELECT_RUNTIME ?= rtl
+SELECT_RUNTIME ?= rtl-generic
 
 ifeq ($(SELECT_RUNTIME), banshee)
 RUNTIME = runtime/banshee

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -9,10 +9,10 @@ SELECT_RUNTIME ?= rtl
 
 ifeq ($(SELECT_RUNTIME), banshee)
 RUNTIME = runtime/banshee
-else ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME = runtime/rtl-generic
-else
+else ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME = runtime/rtl
+else
+RUNTIME = runtime/rtl-generic
 endif
 
 SUBDIRS += math $(RUNTIME) snax/mac snax/data-reshuffler snax/streamer-gemm-conv-simd snax/xdma snax/hypercorex apps tests

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -7,7 +7,7 @@
 SUBDIRS  = lto
 SUBDIRS += nop
 # Tests below don't work with the generic runtime
-ifneq ($(SELECT_RUNTIME), rtl-generic)
+ifneq ($(filter $(SELECT_RUNTIME),rtl banshee),)
 SUBDIRS += blas/axpy
 SUBDIRS += blas/gemm
 SUBDIRS += dnn/batchnorm

--- a/target/snitch_cluster/sw/apps/common.mk
+++ b/target/snitch_cluster/sw/apps/common.mk
@@ -19,10 +19,10 @@ SNRT_DIR := $(ROOT)/sw/snRuntime
 ifeq ($(SELECT_RUNTIME), banshee)
 RUNTIME_DIR  := $(ROOT)/target/snitch_cluster/sw/runtime/banshee
 RISCV_CFLAGS += -DBIST
-else ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR  := $(ROOT)/target/snitch_cluster/sw/runtime/rtl-generic
-else
+else ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR := $(ROOT)/target/snitch_cluster/sw/runtime/rtl
+else
+RUNTIME_DIR  := $(ROOT)/target/snitch_cluster/sw/runtime/rtl-generic
 endif
 MATH_DIR := $(ROOT)/target/snitch_cluster/sw/math
 

--- a/target/snitch_cluster/sw/snax/data-reshuffler/Makefile
+++ b/target/snitch_cluster/sw/snax/data-reshuffler/Makefile
@@ -11,10 +11,10 @@ MK_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include $(MK_DIR)/../../toolchain.mk
 
 # Banshee runtime is not supported
-ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR := rtl-generic
-else
+ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR := rtl
+else
+RUNTIME_DIR := rtl-generic
 endif
 
 ################

--- a/target/snitch_cluster/sw/snax/hypercorex/Makefile
+++ b/target/snitch_cluster/sw/snax/hypercorex/Makefile
@@ -11,10 +11,10 @@ MK_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include $(MK_DIR)/../../toolchain.mk
 
 # Banshee runtime is not supported
-ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR := rtl-generic
-else
+ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR := rtl
+else
+RUNTIME_DIR := rtl-generic
 endif
 
 ################

--- a/target/snitch_cluster/sw/snax/mac/Makefile
+++ b/target/snitch_cluster/sw/snax/mac/Makefile
@@ -11,10 +11,10 @@ MK_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include $(MK_DIR)/../../toolchain.mk
 
 # Banshee runtime is not supported
-ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR := rtl-generic
-else
+ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR := rtl
+else
+RUNTIME_DIR := rtl-generic
 endif
 
 

--- a/target/snitch_cluster/sw/snax/streamer-gemm-conv-simd/Makefile
+++ b/target/snitch_cluster/sw/snax/streamer-gemm-conv-simd/Makefile
@@ -11,10 +11,10 @@ MK_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include $(MK_DIR)/../../toolchain.mk
 
 # Banshee runtime is not supported
-ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR := rtl-generic
-else
+ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR := rtl
+else
+RUNTIME_DIR := rtl-generic
 endif
 
 ################

--- a/target/snitch_cluster/sw/snax/xdma/Makefile
+++ b/target/snitch_cluster/sw/snax/xdma/Makefile
@@ -11,10 +11,10 @@ MK_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include $(MK_DIR)/../../toolchain.mk
 
 # Banshee runtime is not supported
-ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR := rtl-generic
-else
+ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR := rtl
+else
+RUNTIME_DIR := rtl-generic
 endif
 
 ################

--- a/target/snitch_cluster/sw/tests/Makefile
+++ b/target/snitch_cluster/sw/tests/Makefile
@@ -19,9 +19,11 @@ include $(MK_DIR)/../toolchain.mk
 APPS        = $(shell $(MK_DIR)/../../../../util/sim/list_apps.py --in-dir tests/ ../runtime.yaml)
 APPS        += $(shell $(MK_DIR)/../../../../util/sim/list_apps.py --in-dir tests/ ../standard-fp.yaml)
 # These tests only need custom riscv instructions, no custom builtins
-ifneq ($(SELECT_TOOLCHAIN), llvm-generic)
+ifneq ($(filter $(SELECT_TOOLCHAIN),llvm-snitch),)
+$(info Toolchain is llvm-snitch)
 APPS        += $(shell $(MK_DIR)/../../../../util/sim/list_apps.py --in-dir tests/ ../custom-fp.yaml)
-ifneq ($(SELECT_RUNTIME), rtl-generic)
+ifneq ($(filter $(SELECT_RUNTIME),rtl banshee),)
+$(info Runtime is either rtl or banshee)
 # These tests need custom builtins in the runtime
 APPS        += $(shell $(MK_DIR)/../../../../util/sim/list_apps.py --in-dir tests/ ../openmp.yaml)
 APPS        += $(shell $(MK_DIR)/../../../../util/sim/list_apps.py --in-dir tests/ ../snitch-cluster-openmp.yaml)
@@ -42,10 +44,10 @@ SRC_DIR     = $(ROOT)/sw/tests
 BUILDDIR    = $(ROOT)/target/snitch_cluster/sw/tests/build
 ifeq ($(SELECT_RUNTIME), banshee)
 RUNTIME_DIR = $(ROOT)/target/snitch_cluster/sw/runtime/banshee
-else ifeq ($(SELECT_RUNTIME), rtl-generic)
-RUNTIME_DIR = $(ROOT)/target/snitch_cluster/sw/runtime/rtl-generic
-else
+else ifeq ($(SELECT_RUNTIME), rtl)
 RUNTIME_DIR = $(ROOT)/target/snitch_cluster/sw/runtime/rtl
+else
+RUNTIME_DIR = $(ROOT)/target/snitch_cluster/sw/runtime/rtl-generic
 endif
 
 ###################

--- a/target/snitch_cluster/sw/toolchain.mk
+++ b/target/snitch_cluster/sw/toolchain.mk
@@ -42,7 +42,7 @@ RISCV_CFLAGS += -menable-experimental-extensions
 else
 RISCV_CFLAGS += --target=riscv32-unknown-elf
 RISCV_CFLAGS += -mcpu=generic-rv32
-RISCV_CFLAGS += -march=rv32ima
+RISCV_CFLAGS += -march=rv32imafdzfh
 RISCV_CFLAGS += -fno-builtin-memset
 # Required by printf lib such that svnprintf does not emit __udivdi3
 RISCV_CFLAGS += -DPRINTF_DISABLE_SUPPORT_LONG_LONG

--- a/target/snitch_cluster/sw/toolchain.mk
+++ b/target/snitch_cluster/sw/toolchain.mk
@@ -16,7 +16,7 @@ DEBUG ?= OFF # ON to turn on debugging symbols
 ###################
 
 # Compiler toolchain
-ifneq ($(SELECT_TOOLCHAIN), llvm-generic)
+ifeq ($(SELECT_TOOLCHAIN), llvm-snitch)
 # specialized version does not use a version specifier in the binary
 LLVM_BINROOT    = /tools/riscv-llvm/bin
 LLVM_VERSION    = 
@@ -31,16 +31,18 @@ RISCV_OBJCOPY   ?= $(LLVM_BINROOT)/llvm-objcopy$(LLVM_VERSION)
 RISCV_OBJDUMP   ?= $(LLVM_BINROOT)/llvm-objdump$(LLVM_VERSION)
 RISCV_DWARFDUMP ?= $(LLVM_BINROOT)/llvm-dwarfdump$(LLVM_VERSION)
 
+ifeq ($(SELECT_TOOLCHAIN), llvm-snitch)
 LLVM_VER        ?= $(shell /tools/riscv-llvm/bin/llvm-config --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+endif
 
 # Compiler flags
-ifneq ($(SELECT_TOOLCHAIN), llvm-generic)
+ifeq ($(SELECT_TOOLCHAIN), llvm-snitch)
 RISCV_CFLAGS += -mcpu=snitch
 RISCV_CFLAGS += -menable-experimental-extensions
 else
 RISCV_CFLAGS += --target=riscv32-unknown-elf
 RISCV_CFLAGS += -mcpu=generic-rv32
-RISCV_CFLAGS += -march=rv32imafdzfh
+RISCV_CFLAGS += -march=rv32ima
 RISCV_CFLAGS += -fno-builtin-memset
 # Required by printf lib such that svnprintf does not emit __udivdi3
 RISCV_CFLAGS += -DPRINTF_DISABLE_SUPPORT_LONG_LONG
@@ -64,7 +66,7 @@ endif
 RISCV_CFLAGS += -D__DEFINED_uint64_t
 
 # Linker flags
-ifneq ($(SELECT_TOOLCHAIN), llvm-generic)
+ifeq ($(SELECT_TOOLCHAIN), llvm-snitch)
 RISCV_LDFLAGS += -nostartfiles
 RISCV_LDFLAGS += -lclang_rt.builtins-riscv32
 RISCV_LDFLAGS += -L/tools/riscv-llvm/lib/clang/$(LLVM_VER)/lib/


### PR DESCRIPTION
This PR modified the default llvm and runtime to rtl-generic and toolchain to llvm-generic. 