### PR TITLE
inc fifo depth in kul-cluster reader

### DIFF
--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
@@ -180,7 +180,7 @@
 
         fifo_reader_params: {
             fifo_width: [512, 512],
-            fifo_depth: [2, 2],
+            fifo_depth: [5, 5],
         }
 
         fifo_writer_params: {


### PR DESCRIPTION
Increase the pre-fetch depth from 2 to 5