### PR TITLE
Add `snax_mac` target to bender

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -287,6 +287,7 @@ sources:
       - hw/snax_util/src/snax_csr_mux_demux.sv
       - hw/snax_util/src/snax_acc_mux_demux.sv
       - hw/snax_util/src/snax_intf_translator.sv
+
   #---------------------------
   # SNAX Accelerators
   #---------------------------
@@ -298,6 +299,7 @@ sources:
       - hw/snax_hwpe_mac/src/snax_hwpe_to_reqrsp.sv
       # Level 1
       - hw/snax_hwpe_mac/src/snax_mac_wrapper.sv
+
   # SNAX ALU
   - target: snax_alu
     files:

--- a/Bender.yml
+++ b/Bender.yml
@@ -291,7 +291,8 @@ sources:
   # SNAX Accelerators
   #---------------------------
   # SNAX HWPE MAC
-  - files:
+  - target: snax_mac
+    files:
       # Level 0
       - hw/snax_hwpe_mac/src/snax_hwpe_ctrl.sv
       - hw/snax_hwpe_mac/src/snax_hwpe_to_reqrsp.sv

--- a/hw/snax_util/src/snax_intf_translator.sv
+++ b/hw/snax_util/src/snax_intf_translator.sv
@@ -9,10 +9,9 @@
 // Snitch accelerator ports to
 // CSR ports
 //-------------------------------
-`ifndef TARGET_VERILATOR
+
 import riscv_instr::*;
 import reqrsp_pkg::*;
-`endif
 
 module snax_intf_translator #(
   parameter type                        acc_req_t = logic,


### PR DESCRIPTION
This PR cleans-up the bender to avoid adding the HWPE MAC to the filelist. It's a minor clean-up because it needed the `-target snax_mac` which was forgotten to be added.