### PR TITLE
inc bit width for maxpool kernel size

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/Reshuffle.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/Reshuffle.scala
@@ -6,8 +6,8 @@ import chisel3.util._
 class ReshufflerCtrl(params: ReshufflerParams) extends Bundle {
 
   // packed CRS configuration
-  val reduceLen_i = UInt(5.W)
-  val tloop2Len_i = UInt(25.W)
+  val reduceLen_i = UInt(6.W)
+  val tloop2Len_i = UInt(24.W)
   val opcode_i = UInt(2.W)
 
   require(params.sizeConfigWidth == 32, "sizeConfigWidth must be 32")
@@ -119,8 +119,8 @@ class Reshuffler(params: ReshufflerParams)
   // when config valid, store the configuration for later computation
   when(config_valid) {
     ctrl_csr.opcode_i := io.ctrl.bits(0)(1, 0)
-    ctrl_csr.reduceLen_i := io.ctrl.bits(0)(6, 2)
-    ctrl_csr.tloop2Len_i := io.ctrl.bits(0)(31, 7)
+    ctrl_csr.reduceLen_i := io.ctrl.bits(0)(7, 2)
+    ctrl_csr.tloop2Len_i := io.ctrl.bits(0)(31, 8)
   }
 
   // when opcode is 2, do MAXPool

--- a/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-data-reshuffler/data/datagen.py
@@ -208,8 +208,8 @@ def emit_gemm_data(**kwargs):
             padded_output_tensor_w * padded_output_tensor_h * kwargs["Cin"]
         )
 
-        assert padded_output_tensor_w == kwargs["W"]
-        assert padded_output_tensor_h == kwargs["H"]
+        assert padded_output_tensor_w % 8 == 0
+        assert kwargs["Cin"] % 8 == 0
 
         data_str += [
             # input data reshuffler loop bounds settings
@@ -246,9 +246,9 @@ def emit_gemm_data(**kwargs):
         assert padded_output_tensor_w * 8 == 8 * 8 * (padded_output_tensor_w // 8)
         data_str += [
             # data reshuffler input strides
-            format_scalar_definition("int32_t", "spatialStride1_in", 8),
+            format_scalar_definition("int32_t", "spatialStride1_in", kwargs["stride_w"] * 8),
             format_scalar_definition(
-                "int32_t", "tempStride0_in", kwargs["stride_w"] * 8
+                "int32_t", "tempStride0_in", 8
             ),
             format_scalar_definition(
                 "int32_t", "tempStride1_in", padded_input_tensor_w * 8

--- a/target/snitch_cluster/sw/snax/data-reshuffler/src/snax-data-reshuffler-lib.c
+++ b/target/snitch_cluster/sw/snax/data-reshuffler/src/snax-data-reshuffler-lib.c
@@ -61,7 +61,7 @@ void wait_streamer() { write_csr(980, 0); }
 
 void set_data_reshuffler(int T2Len, int reduceLen, int opcode) {
     // set transpose or not
-    uint32_t csr0 = ((uint32_t)T2Len << 7) | ((uint32_t)reduceLen << 2) |
+    uint32_t csr0 = ((uint32_t)T2Len << 8) | ((uint32_t)reduceLen << 2) |
                     ((uint32_t)opcode);
     write_csr(983, csr0);
 }
@@ -80,10 +80,10 @@ uint32_t test_a_chrunk_of_data(int8_t* base_ptr_local, int8_t* base_ptr_l2,
     uint32_t error = 0;
     for (int i = 0; i < len; i++) {
         if ((int8_t)base_ptr_local[i] != (int8_t)base_ptr_l2[i]) {
-            printf(
-                "Error: after reshuffle base_ptr_local[%d] = %d, golden "
-                "base_ptr_l2[%d] = %d \n",
-                i, (int8_t)base_ptr_local[i], i, (int8_t)base_ptr_l2[i]);
+            // printf(
+            //     "Error: after reshuffle base_ptr_local[%d] = %d, golden "
+            //     "base_ptr_l2[%d] = %d \n",
+            //     i, (int8_t)base_ptr_local[i], i, (int8_t)base_ptr_l2[i]);
             error++;
         }
     }


### PR DESCRIPTION
* increase bit width for maxpool kernel size cfg from 5 to 6 bits for supporting max pool kernel size 7*7.
* fix a sw test bug
