### PR TITLE
Make dependency order only

### DIFF
--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -331,13 +331,13 @@ $(TARGET_C_HDRS_DIR)/snitch_cluster_peripheral.h: $(ROOT)/hw/snitch_cluster/src/
 $(GENERATED_DIR):
 	mkdir -p $(GENERATED_DIR)
 
-$(GENERATED_DIR)/link.ld: | ${CFG} ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
+$(GENERATED_DIR)/link.ld: ${CFG} |  ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --linker
 
-$(GENERATED_DIR)/memories.json: | ${CFG} ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
+$(GENERATED_DIR)/memories.json: ${CFG} |  ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --memories
 
-$(GENERATED_DIR)/bootdata.cc: | ${CFG} ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
+$(GENERATED_DIR)/bootdata.cc: ${CFG} |  ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --bootdata
 
 #############

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -331,13 +331,13 @@ $(TARGET_C_HDRS_DIR)/snitch_cluster_peripheral.h: $(ROOT)/hw/snitch_cluster/src/
 $(GENERATED_DIR):
 	mkdir -p $(GENERATED_DIR)
 
-$(GENERATED_DIR)/link.ld: ${CFG} ${CLUSTER_GEN_PREREQ} | $(GENERATED_DIR)
+$(GENERATED_DIR)/link.ld: | ${CFG} ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --linker
 
-$(GENERATED_DIR)/memories.json: ${CFG} ${CLUSTER_GEN_PREREQ} | $(GENERATED_DIR)
+$(GENERATED_DIR)/memories.json: | ${CFG} ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --memories
 
-$(GENERATED_DIR)/bootdata.cc: ${CFG} ${CLUSTER_GEN_PREREQ} | $(GENERATED_DIR)
+$(GENERATED_DIR)/bootdata.cc: | ${CFG} ${CLUSTER_GEN_PREREQ} $(GENERATED_DIR)
 	$(CLUSTER_GEN) -c $< -o $(GENERATED_DIR) --bootdata
 
 #############


### PR DESCRIPTION
This PR is a minor fix to make the dependency of the cluster generation python script as an order only. Since it is always there and any modifications appear always, then it being an order only is fine.

This circumvents the problem in our private server for tapeout. Since the file is new, it needs to regenerate the bootdata.cc which we have to pre-generate outside of the private server. 