### PR TITLE
Modify memories to default `tc_sram_impl`

### DIFF
--- a/hw/snitch_cluster/src/snitch_data_mem.sv
+++ b/hw/snitch_cluster/src/snitch_data_mem.sv
@@ -33,9 +33,6 @@ module snitch_data_mem #(
 );
 
   for (genvar i = 0; i < NumTotalBanks; i++) begin: gen_banks
-
-`ifndef TARGET_TAPEOUT
-
     tc_sram_impl #(
       .NumWords   ( TCDMDepth         ),
       .DataWidth  ( NarrowDataWidth   ),
@@ -55,37 +52,6 @@ module snitch_data_mem #(
       .wdata_i    ( mem_wdata_i[i]    ),
       .rdata_o    ( mem_rdata_o[i]    )
     );
-
-`else
-
-    //----------------------------------------------------
-    // This is just a place holder for the synthesis tool
-    // The cache memory is wide hence we break it into two
-    //----------------------------------------------------
-
-    // Memory implementation for synthesis
-    // Converting the byte enable to bit enable
-    logic [NarrowDataWidth - 1 : 0] bit_en;
-
-    always_comb begin
-      for (int j = 0; j < NarrowDataWidth / 8; j = j + 1) begin
-        bit_en[j*8+:8] = {8{mem_be_i[i][j]}};
-      end
-    end
-
-    syn_data_mem i_data_mem(
-              .CLK    ( clk_i                               ),
-              .CEB    ( ~mem_cs_i[i]                        ),
-              .WEB    ( ~mem_wen_i[i]                       ),
-              .A      ( mem_add_i[i][$clog2(TCDMDepth)-1:0] ),
-              .D      ( mem_wdata_i[i]                      ),
-              .BWEB   ( ~bit_en                             ),
-              .RTSEL  ( 2'b01                               ),
-              .WTSEL  ( 2'b01                               ),
-              .Q      ( mem_rdata_o[i]                      )
-    );
-
-`endif
   end
 
 endmodule

--- a/hw/snitch_icache/src/snitch_icache_data.sv
+++ b/hw/snitch_icache/src/snitch_icache_data.sv
@@ -26,61 +26,25 @@ module snitch_icache_data #(
 );
 
   for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_data_sets
-
-`ifndef TARGET_TAPEOUT
-
-      tc_sram_impl #(
-        .NumWords   ( CFG.LINE_COUNT  ),
-        .DataWidth  ( CFG.LINE_WIDTH  ),
-        .ByteWidth  ( 8               ),
-        .NumPorts   ( 1               ),
-        .Latency    ( 1               ),
-        .impl_in_t  ( sram_cfg_data_t )
-      ) i_data (
-        .clk_i      ( clk_i           ),
-        .rst_ni     ( rst_ni          ),
-        .impl_i     ( sram_cfg_data_i ),
-        .impl_o     ( /*Unused*/      ),
-        .req_i      ( ram_enable_i[i] ),
-        .we_i       ( ram_write_i     ),
-        .addr_i     ( ram_addr_i      ),
-        .wdata_i    ( ram_wdata_i     ),
-        .be_i       ( '1              ),
-        .rdata_o    ( ram_rdata_o[i]  )
-      );
-
-`else
-
-      //----------------------------------------------------
-      // This is just a place holder for the synthesis tool
-      // The cache memory is wide hence we break it into two
-      //----------------------------------------------------
-      syn_cache_data_mem i_cache_mem_0(
-                  .CLK    ( clk_i                                                 ),
-                  .CEB    ( ~ram_enable_i[i]                                      ),
-                  .WEB    ( ~ram_write_i                                          ),
-                  .A      ( ram_addr_i                                            ),
-                  .D      ( ram_wdata_i   [(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] ),
-                  .BWEB   ( '0                                                    ),
-                  .RTSEL  ( 2'b01                                                 ),
-                  .WTSEL  ( 2'b01                                                 ),
-                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)-1:(CFG.LINE_WIDTH)/2] )
-      );
-
-      syn_cache_data_mem i_cache_mem_1(
-                  .CLK    ( clk_i                                  ),
-                  .CEB    ( ~ram_enable_i[i]                       ),
-                  .WEB    ( ~ram_write_i                           ),
-                  .A      ( ram_addr_i                             ),
-                  .D      ( ram_wdata_i   [(CFG.LINE_WIDTH)/2-1:0] ),
-                  .BWEB   ( '0                                     ),
-                  .RTSEL  ( 2'b01                                  ),
-                  .WTSEL  ( 2'b01                                  ),
-                  .Q      ( ram_rdata_o[i][(CFG.LINE_WIDTH)/2-1:0] )
-      );
-
-`endif
-
+    tc_sram_impl #(
+      .NumWords   ( CFG.LINE_COUNT  ),
+      .DataWidth  ( CFG.LINE_WIDTH  ),
+      .ByteWidth  ( 8               ),
+      .NumPorts   ( 1               ),
+      .Latency    ( 1               ),
+      .impl_in_t  ( sram_cfg_data_t )
+    ) i_data (
+      .clk_i      ( clk_i           ),
+      .rst_ni     ( rst_ni          ),
+      .impl_i     ( sram_cfg_data_i ),
+      .impl_o     ( /*Unused*/      ),
+      .req_i      ( ram_enable_i[i] ),
+      .we_i       ( ram_write_i     ),
+      .addr_i     ( ram_addr_i      ),
+      .wdata_i    ( ram_wdata_i     ),
+      .be_i       ( '1              ),
+      .rdata_o    ( ram_rdata_o[i]  )
+    );
   end
 
 endmodule

--- a/hw/snitch_icache/src/snitch_icache_tag.sv
+++ b/hw/snitch_icache/src/snitch_icache_tag.sv
@@ -26,48 +26,25 @@ module snitch_icache_tag #(
 );
 
   for (genvar i = 0; i < CFG.SET_COUNT; i++) begin: g_cache_tag_sets
-
-`ifndef TARGET_TAPEOUT
-
-      tc_sram_impl #(
-        .NumWords   ( CFG.LINE_COUNT  ),
-        .DataWidth  ( CFG.TAG_WIDTH+2 ),
-        .ByteWidth  ( 8               ),
-        .NumPorts   ( 1               ),
-        .Latency    ( 1               ),
-        .impl_in_t  ( sram_cfg_tag_t  )
-      ) i_tag (
-        .clk_i      ( clk_i           ),
-        .rst_ni     ( rst_ni          ),
-        .impl_i     ( sram_cfg_tag_i  ),
-        .impl_o     ( /*Unused*/      ),
-        .req_i      ( ram_enable_i[i] ),
-        .we_i       ( ram_write_i     ),
-        .addr_i     ( ram_addr_i      ),
-        .wdata_i    ( ram_wtag_i      ),
-        .be_i       ( '1              ),
-        .rdata_o    ( ram_rtag_o[i]   )
-      );
-
-`else
-
-    //----------------------------------------------------
-    // This is just a place holder for the synthesis tool
-    //----------------------------------------------------
-    syn_cache_tag_mem i_tag_mem(
-                .CLK   ( clk_i            ),
-                .CEB   ( ~ram_enable_i[i] ),
-                .WEB   ( ~ram_write_i     ),
-                .A     ( ram_addr_i       ),
-                .D     ( ram_wtag_i       ),
-                .BWEB  ( '0               ),
-                .RTSEL ( 2'b01            ),
-                .WTSEL ( 2'b01            ),
-                .Q     ( ram_rtag_o[i]    )
-      );
-
-`endif
-
+    tc_sram_impl #(
+      .NumWords   ( CFG.LINE_COUNT  ),
+      .DataWidth  ( CFG.TAG_WIDTH+2 ),
+      .ByteWidth  ( 8               ),
+      .NumPorts   ( 1               ),
+      .Latency    ( 1               ),
+      .impl_in_t  ( sram_cfg_tag_t  )
+    ) i_tag (
+      .clk_i      ( clk_i           ),
+      .rst_ni     ( rst_ni          ),
+      .impl_i     ( sram_cfg_tag_i  ),
+      .impl_o     ( /*Unused*/      ),
+      .req_i      ( ram_enable_i[i] ),
+      .we_i       ( ram_write_i     ),
+      .addr_i     ( ram_addr_i      ),
+      .wdata_i    ( ram_wtag_i      ),
+      .be_i       ( '1              ),
+      .rdata_o    ( ram_rtag_o[i]   )
+    );
   end
 
 endmodule


### PR DESCRIPTION
This PR brings back memories of the default `tc_sram_impl`. We have an internal model for these when we need to use it for tape out. This way, it is more generalized and avoids having to modify top-level Hemaia components.

Major TODO:
- [x]  Modify, data, cache, and tag memories.