### PR TITLE
fix-conv-mapping-data-granularity for wide ports

### DIFF
--- a/target/snitch_cluster/sw/apps/snax-streamer-gemm-conv-simd/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-streamer-gemm-conv-simd/data/datagen.py
@@ -97,11 +97,14 @@ def emit_conv_data(**kwargs):
     out_height = (H + 2 * pad_h - Kh) // stride_h + 1
     out_width = (W + 2 * pad_w - Kw) // stride_w + 1
 
+    assert out_width % 8 == 0, "out_width must be multiple of 8"
+
     M = out_height * out_width // 8
     K = Cin // 8 * Kh * Kw
     N = Cout // 8
 
     length_c = M * N * 8 * 8
+    # bias = np.random.randint(MIN, MAX, length_c)
     bias = np.random.randint(-(2**30), 2**30 - 1, length_c)
 
     data_str = []
@@ -131,9 +134,24 @@ def emit_conv_data(**kwargs):
 
     # Generating base pointer settings
     delta_local_a = 0
+
     delta_local_b = input_padding.size
-    delta_local_c = input_padding.size + kernel.size
-    delta_local_d8 = input_padding.size + kernel.size + length_c * 4
+    assert input_padding.size == (Nbatch * Cin8 * (H + 2 * pad_h) * (W + 2 * pad_w) * 8)
+    if delta_local_b % 64 != 0:
+        delta_local_b = ((delta_local_b // 64) + 1) * 64
+    assert delta_local_b % 64 == 0
+
+    delta_local_c = delta_local_b + kernel.size
+    assert kernel.size == (Cout8 * Cin8 * Kh * Kw * 8 * 8)
+    if delta_local_c % 64 != 0:
+        delta_local_c = ((delta_local_c // 64) + 1) * 64
+    assert delta_local_c % 64 == 0
+
+    delta_local_d8 = delta_local_c + length_c * 4
+    if delta_local_d8 % 64 != 0:
+        delta_local_d8 = ((delta_local_d8 // 64) + 1) * 64
+    assert delta_local_d8 % 64 == 0
+
     delta_local_d32 = delta_local_d8
     data_str += [
         format_scalar_definition("int32_t", "delta_local_a", delta_local_a),
@@ -148,11 +166,11 @@ def emit_conv_data(**kwargs):
     if kwargs["ifC8HW8datalayout"] is True:
         # NC8HW8
         Aslstride0 = 1
-        Aslstride1 = 8
+        Aslstride1 = 8 * stride_w
 
         # K dim
         Atlbound0 = Kw
-        Atlstride0 = 8 * stride_w
+        Atlstride0 = 8
 
         Atlbound1 = Kh
         Atlstride1 = 8 * (W + 2 * pad_w)
@@ -166,7 +184,7 @@ def emit_conv_data(**kwargs):
 
         # M dim
         Atlbound4 = out_width // 8
-        Atlstride4 = 8 * 8
+        Atlstride4 = 8 * 8 * stride_w
 
         Atlbound5 = out_height
         Atlstride5 = 8 * (W + 2 * pad_w) * stride_h
@@ -178,14 +196,14 @@ def emit_conv_data(**kwargs):
     else:
         # NHWC
         Aslstride0 = 1
-        Aslstride1 = Cin
+        Aslstride1 = Cin * stride_w
 
         # K dim
         Atlbound0 = Cin // 8
         Atlstride0 = 8
 
         Atlbound1 = Kw
-        Atlstride1 = Cin * stride_w
+        Atlstride1 = Cin
 
         Atlbound2 = Kh
         Atlstride2 = Cin * (W + 2 * pad_w)
@@ -204,6 +222,8 @@ def emit_conv_data(**kwargs):
         # Batch dim
         Atlbound6 = Nbatch
         Atlstride6 = Cin * (H + 2 * pad_h) * (W + 2 * pad_w)
+
+    assert Atlstride0 % 8 == 0 and Atlstride1 % 8 == 0 and Atlstride2 % 8 == 0 and Atlstride3 % 8 == 0 and Atlstride4 % 8 == 0 and Atlstride5 % 8 == 0 and Atlstride6 % 8 == 0
 
     assert (
         M * K * N
@@ -278,6 +298,8 @@ def emit_conv_data(**kwargs):
         Btlbound3 = Nbatch
         Btlstride3 = 0
 
+    assert Btlstride0 % 64 == 0 and Btlstride1 % 64 == 0 and Btlstride2 % 64 == 0 and Btlstride3 % 64 == 0
+
     assert K * N * M == Btlbound0 * Btlbound1 * Btlbound2 * Btlbound3, (
         "K * N * M",
         K * N * M,
@@ -341,6 +363,7 @@ def emit_conv_data(**kwargs):
         Ctlbound3 = Nbatch
         Ctlstride3 = Cout * H * W * 4
 
+    assert Ctlstride0 % 64 == 0 and Ctlstride1 % 64 == 0 and Ctlstride2 % 64 == 0 and Ctlstride3 % 64 == 0
     assert M * N == Ctlbound0 * Ctlbound1 * Ctlbound2 * Ctlbound3
 
     data_str += [
@@ -397,6 +420,8 @@ def emit_conv_data(**kwargs):
         D32tlbound3 = Nbatch
         D32tlstride3 = D32out * out_height * out_width * 4
 
+    assert D32tlstride0 % 64 == 0 and D32tlstride1 % 64 == 0 and D32tlstride2 % 64 == 0 and D32tlstride3 % 64 == 0
+
     data_str += [
         format_scalar_definition("int32_t", "D32slstride0", D32slstride0),
         format_scalar_definition("int32_t", "D32slstride1", D32slstride1),
@@ -451,6 +476,7 @@ def emit_conv_data(**kwargs):
         D8tlbound3 = Nbatch
         D8tlstride3 = D8out * out_height * out_width
 
+    assert D8tlstride0 % 64 == 0 and D8tlstride1 % 64 == 0 and D8tlstride2 % 64 == 0 and D8tlstride3 % 64 == 0
     data_str += [
         format_scalar_definition("int32_t", "D8slstride0", D8slstride0),
         format_scalar_definition("int32_t", "D8slstride1", D8slstride1),

--- a/target/snitch_cluster/sw/apps/snax-streamer-gemm-conv-simd/src/snax-streamer-gemm-conv-simd.c
+++ b/target/snitch_cluster/sw/apps/snax-streamer-gemm-conv-simd/src/snax-streamer-gemm-conv-simd.c
@@ -43,14 +43,15 @@ int main() {
             Nbatch * (H + 2 * pad_h) * (W + 2 * pad_w) * Cin * sizeof(int8_t));
         snrt_dma_start_1d(local_b, B, Cout * Kh * Kw * Cin * sizeof(int8_t));
 #endif
+        snrt_dma_wait_all();
     }
 
     // Wait for DMA to finish
     snrt_cluster_hw_barrier();
-
     if (snrt_is_dm_core()) {
         snrt_dma_start_1d(local_c, C,
                           M * N * meshRow * meshCol * sizeof(int32_t));
+        snrt_dma_wait_all();
     }
 
     snrt_cluster_hw_barrier();
@@ -105,10 +106,10 @@ int main() {
             err += check_gemmx_result_D32(local_d32, D32, Batch, M, N);
         }
 #ifdef TEST_MATMUL
-        printf("SNAX GEMM Matmul: %s, err = %d . bypassSIMD = %d .\n",
+        printf("SNAX GEMM Matmul: %s, Error: %d . bypassSIMD = %d .\n",
                err ? "FAIL" : "PASS", err, bypassSIMD);
 #else
-        printf("SNAX GEMM Conv2d: %s, err = %d . bypassSIMD = %d .\n",
+        printf("SNAX GEMM Conv2d: %s, Error: %d . bypassSIMD = %d .\n",
                err ? "FAIL" : "PASS", err, bypassSIMD);
 #endif
     };

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -270,7 +270,7 @@ def tiled_block_gemm_golden_model(
                     * m
                     * row
                     * n
-                    * col: (mm2 * n2 + nn2 + 1)
+                    * col : (mm2 * n2 + nn2 + 1)
                     * m
                     * row
                     * n
@@ -429,6 +429,6 @@ def max_pooling(
 
 
 def align_wide_addr(addr, alignment=64):
-    if(addr % alignment):
+    if addr % alignment:
         addr = ((addr // alignment) + 1) * alignment
     return addr

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -426,3 +426,9 @@ def max_pooling(
                     )
 
     return pooled_tensor
+
+
+def align_wide_addr(addr, alignment=64):
+    if(addr % alignment):
+        addr = ((addr // alignment) + 1) * alignment
+    return addr

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -270,7 +270,7 @@ def tiled_block_gemm_golden_model(
                     * m
                     * row
                     * n
-                    * col : (mm2 * n2 + nn2 + 1)
+                    * col: (mm2 * n2 + nn2 + 1)
                     * m
                     * row
                     * n

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -67,6 +67,7 @@ def conv2d(input_data, kernel, stride=(1, 1), padding=(0, 0), mode="NHWC"):
         # Calculate the output feature map dimensions
         out_height = (in_height - kernel_height + 2 * pad_h) // stride_h + 1
         out_width = (in_width - kernel_width + 2 * pad_w) // stride_w + 1
+        assert out_width % 8 == 0
 
         # Add padding
         input_data_padded = np.pad(


### PR DESCRIPTION
If using wide ports, the pointer, and temporal strides must be aligned with 512 bits, which is 64 in bytes!!!