### PR TITLE
Fanchen/add support floating cluster addr

### DIFF
--- a/sw/snRuntime/src/start.S
+++ b/sw/snRuntime/src/start.S
@@ -95,14 +95,39 @@ snrt.crt0.init_core_info:
     # Initialize information needed by the following routines
 
     # Calculate cluster idx
-    csrr a0, mhartid
-    li   t0, SNRT_BASE_HARTID
-    sub  a0, a0, t0
-    li   a1, SNRT_CLUSTER_CORE_NUM
-    div  t0, a0, a1
+    #csrr a0, mhartid
+    #li   t0, SNRT_BASE_HARTID
+    #sub  a0, a0, t0
+    #li   a1, SNRT_CLUSTER_CORE_NUM
+    #div  t0, a0, a1
+
+    # The cluster idx is calculated as snrt_cluster_idx()
+    # we use the lower 24bits as cluster base_address
+    # 0000 0000 1111 1111 1111 1111 1111 1111
+    # a0 holds the cluster start addr
+    csrr a0, 0xbc1
+    # a1 holds the cluster addr width
+    li a1, CLUSTER_ADDRWIDTH
+    addi a1, a1, 8
+    # first we left shift a0 by 8 bits
+    slli a0, a0, 8
+    # then we shift right a0 by a1 (8 + cluster_addrwidth) bits
+    srl t0, a0, a1
 
     # Calculate cluster-local core ID
-    remu a0, a0, a1
+    # remu a0, a0, a1
+
+    # The cluster-local core id is calculated as snrt_cluster_core_idx()
+    # we read the lower 16bits of register 0xbc3
+    csrr a0, 0xbc3
+    slli a0, a0, 16
+    srli a0, a0, 16
+
+    # The cluster core number is previosly stored in a1
+    # now we need to do the same as snrt_cluster_core_num()
+    # we shift the a1 by 16bits
+    csrr a1, 0xbc3
+    srli a1, a1, 16
 
     # Calculate cluster's TCDM start address
     li   a2, SNRT_TCDM_START_ADDR

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -8,9 +8,10 @@ static inline uint32_t snrt_cls_base_addr() {
     extern volatile uint32_t __cbss_start, __cbss_end;
     uint32_t cdata_size = ((uint32_t)&__cdata_end) - ((uint32_t)&__cdata_start);
     uint32_t cbss_size = ((uint32_t)&__cbss_end) - ((uint32_t)&__cbss_start);
-    uint32_t l1_end_addr = SNRT_TCDM_START_ADDR +
-                           snrt_cluster_idx() * SNRT_CLUSTER_OFFSET +
-                           SNRT_TCDM_SIZE;
+    // uint32_t l1_end_addr = SNRT_TCDM_START_ADDR +
+    //                        snrt_cluster_idx() * SNRT_CLUSTER_OFFSET +
+    //                        SNRT_TCDM_SIZE;
+    uint32_t l1_end_addr = snrt_cluster_base_addrl() + SNRT_TCDM_SIZE;
     return l1_end_addr - cdata_size - cbss_size;
 }
 #endif

--- a/sw/snRuntime/src/team.h
+++ b/sw/snRuntime/src/team.h
@@ -64,7 +64,7 @@ inline uint32_t __attribute__((const)) snrt_cluster_idx() {
     // occamy assign 16MB cluster memory
     // Hence we need the lower 22bit for cluster address
     // We add 2 bits for future use
-    // Hence we mask the lower 24bits for cluster address 
+    // Hence we mask the lower 24bits for cluster address
     return (snrt_cluster_base_addrl() & 0x00FFFFFF) >> CLUSTER_ADDRWIDTH;
 }
 

--- a/sw/snRuntime/src/team.h
+++ b/sw/snRuntime/src/team.h
@@ -61,7 +61,11 @@ inline uint32_t __attribute__((const)) snrt_global_compute_core_idx() {
 
 inline uint32_t __attribute__((const)) snrt_cluster_idx() {
     // return snrt_global_core_idx() / snrt_cluster_core_num();
-    return (snrt_cluster_base_addrl() & 0xfc0000) >> CLUSTER_ADDRWIDTH;
+    // occamy assign 16MB cluster memory
+    // Hence we need the lower 22bit for cluster address
+    // We add 2 bits for future use
+    // Hence we mask the lower 24bits for cluster address 
+    return (snrt_cluster_base_addrl() & 0x00FFFFFF) >> CLUSTER_ADDRWIDTH;
 }
 
 inline uint32_t __attribute__((const)) snrt_cluster_core_idx() {


### PR DESCRIPTION
This change adds support for different clusters with different numbers of cores, which will be used in the Hemaia system.
1. Change the start.S
The computation of cluster_idx, cluster_local_core_id, and cluster_core_num follows the snrt.h
2. Change the snrt_cls_base_addr()
This function is related to the behavior of `snrt_l1_next()`. The start_addr should be computed from the snrt_cluster_base_addrl() instead of the old `SNRT_TCDM_START_ADDR + snrt_cluster_idx() * SNRT_CLUSTER_OFFSET`, which the SNRT_CLUSTER_OFFSET is hardcoded in snitch_cluster_defs.h. This is not a problem in snax but will be a problem in occamy.
