### PR TITLE
Add random delay for rst_ni at tb_bin.sv

### DIFF
--- a/target/common/test/tb_bin.sv
+++ b/target/common/test/tb_bin.sv
@@ -32,6 +32,8 @@ module tb_bin;
 
   // Generate clock
   initial begin
+    clk_i = 0;
+    #100ns;
     forever begin
       clk_i = 1;
       #(TCK/2);

--- a/target/common/test/tb_bin.sv
+++ b/target/common/test/tb_bin.sv
@@ -19,21 +19,38 @@ module tb_bin;
     .rst_ni
   );
 
+  // Function to generate a random delay between min and max
+  function int random_delay(int min, int max);
+    automatic int range;
+    begin
+      if (min > max) begin
+        // Swap if min is greater than max
+        automatic int temp = min;
+        min = max;
+        max = temp;
+      end
+      range = max - min + 1;
+      return min + ($urandom % range);
+    end
+  endfunction
+
   // Generate reset
   initial begin
+    automatic real rst_delay;
     rst_ni = 0;
-    #10ns;
+    rst_delay = random_delay(10,20);
+    #rst_delay;
     rst_ni = 1;
-    #10ns;
+    rst_delay = random_delay(10,20);
+    #rst_delay;
     rst_ni = 0;
-    #10ns;
+    rst_delay = random_delay(10,20);
+    #rst_delay;
     rst_ni = 1;
   end
 
   // Generate clock
   initial begin
-    clk_i = 0;
-    #100ns;
     forever begin
       clk_i = 1;
       #(TCK/2);


### PR DESCRIPTION
1. Add initial delay for clk_i at tb_bin.sv
This change will help to modify the boot address when the system is powered up. 
Previously the clk_i starts at t=0, now adding an extra 100ns delay in the beginning. So after the rst_ni, the `boot_addr` will be reset according to the external IO `boot_mode_i` pin.