### PR TITLE
Change bender target generation to come from the configuration files

### DIFF
--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -68,15 +68,11 @@ STREAM_PARAM_SCALA_PATH = $(ROOT)/hw/chisel/src/main/scala/snax/streamer/StreamP
 # SNAX Generations #
 ####################
 
-# This "function" simply adds
-# the tags necessary for each tool
-
-define add_tags
-	$(eval VSIM_BENDER += -t $1)
-	$(eval VLT_BENDER  += -t $1)
-	$(eval VCS_BENDER  += -t $1)
-	$(eval SYN_BENDER  += -t $1)
-endef
+# Adds targets from the generated bender target file
+VSIM_BENDER := $(VSIM_BENDER) $(shell cat $(GENERATED_DIR)/bender_targets.tmp)
+VLT_BENDER  := $(VLT_BENDER)  $(shell cat $(GENERATED_DIR)/bender_targets.tmp)
+VCS_BENDER  := $(VCS_BENDER)  $(shell cat $(GENERATED_DIR)/bender_targets.tmp)
+SYN_BENDER  := $(SYN_BENDER)  $(shell cat $(GENERATED_DIR)/bender_targets.tmp)
 
 # List manual conditions for different configurations
 
@@ -86,54 +82,12 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm.hjson)
 	SNAX_GEMM_ROOT ?= $(shell $(BENDER) path snax-gemm)
 	include $(SNAX_GEMM_ROOT)/Makefile
 
-$(call add_tags,snax_streamer_gemm)
-$(call add_tags,snax_streamer_gemm_cluster)
-
 endif
 
-ifeq (${CFG_OVERRIDE}, cfg/snax-alu.hjson)
-
-$(call add_tags,snax_alu)
-$(call add_tags,snax_alu_cluster)
-
-endif
-
-ifeq (${CFG_OVERRIDE}, cfg/snax-hypercorex.hjson)
-
-$(call add_tags,hypercorex)
-$(call add_tags,snax_hypercorex_cluster)
-
-endif
-
-ifeq (${CFG_OVERRIDE}, cfg/snax-streamer-gemm-add-c.hjson)
-
-$(call add_tags,snax_streamer_gemm_add_c)
-$(call add_tags,snax_streamer_gemm_add_c_cluster)
- 
-endif
-
-ifeq (${CFG_OVERRIDE}, cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson)
-
-$(call add_tags,snax_gemmX)
-$(call add_tags,snax_KUL_xdma_cluster_xdma)
-$(call add_tags,snax_KUL_xdma_cluster)
-
-endif
-
-ifeq (${CFG_OVERRIDE}, cfg/snax-kul-cluster-mixed-narrow-wide.hjson)
-
-$(call add_tags,snax_gemmX)
-$(call add_tags,snax_data_reshuffler)
-$(call add_tags,snax_KUL_cluster)
-
-endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax-mac.hjson)
 
 	BYPASS_ACCGEN = true
-
-$(call add_tags,snax_mac)
-$(call add_tags,snax_mac_cluster)
 
 endif
 
@@ -141,25 +95,17 @@ ifeq (${CFG_OVERRIDE}, cfg/snax-mac-mult.hjson)
 
 	BYPASS_ACCGEN = true
 
-$(call add_tags,snax_mac)
-$(call add_tags,snax_mac_mult_cluster)
-
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/default.hjson)
 
 	BYPASS_ACCGEN = true
 
-$(call add_tags,snitch_cluster)
-
 endif
 
 .PHONY: rtl-snax-gen rtl-gen
 
-rtl-snax-gen:
-
-	mkdir -p $(GENERATED_DIR)
-
+rtl-snax-gen: | $(GENERATED_DIR)
 	@echo "-------------------------------------------------------------"
 	@echo "Generating streamers, CSR managers, wrappers, and testharness"
 	@echo "-------------------------------------------------------------"
@@ -172,14 +118,17 @@ rtl-snax-gen:
 		--gen_path="${GENERATED_DIR}/"
 
 
-rtl-cluster-gen:
+rtl-cluster-gen: | $(GENERATED_DIR)
 	@echo "-------------------------------------------------------------"
 	@echo "Generating Cluster Wrapper"
 	@echo "-------------------------------------------------------------"
 
 	$(CLUSTER_GEN) -c ${CFG_OVERRIDE} -o $(GENERATED_DIR) --wrapper
 
-rtl-gen: rtl-snax-gen rtl-cluster-gen
+$(GENERATED_DIR)/bender_targets.tmp: | $(GENERATED_DIR)
+	${WRAPPER_GEN} --cfg_path="$(CFG_FILE)" --get_bender_targets > $(GENERATED_DIR)/bender_targets.tmp
+
+rtl-gen: $(GENERATED_DIR)/bender_targets.tmp rtl-snax-gen rtl-cluster-gen
 
 VSIM_BENDER += -t QUESTA_SIM
 

--- a/target/snitch_cluster/cfg/default.hjson
+++ b/target/snitch_cluster/cfg/default.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snitch_cluster",
+        bender_target: ["snitch_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_alu_cluster",
+        bender_target: ["snax_alu_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -88,7 +89,8 @@
         xfdotp: false,
         xfvec: false,
         snax_acc_cfg: {
-            snax_acc_name: "snax_alu"
+            snax_acc_name: "snax_alu",
+            bender_target: ["snax_alu"],
             snax_narrow_tcdm_ports: 12,
             snax_num_rw_csr: 3,
             snax_num_ro_csr: 2,

--- a/target/snitch_cluster/cfg/snax-hypercorex.hjson
+++ b/target/snitch_cluster/cfg/snax-hypercorex.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_hypercorex_cluster",
+        bender_target: ["snax_hypercorex_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -96,7 +97,8 @@
         xfdotp: false,
         xfvec: false,
         snax_acc_cfg: {
-            snax_acc_name: "snax_hypercorex"
+            snax_acc_name: "snax_hypercorex",
+            bender_target: ["hypercorex"],
             snax_narrow_tcdm_ports: 3,
             snax_wide_tcdm_ports: 32,
             snax_disable_csr_manager: true,

--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_KUL_xdma_cluster",
+        bender_target: ["snax_KUL_xdma_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -99,6 +100,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemmX",
+            bender_target: ["snax_gemmX","snax_KUL_xdma_cluster_xdma"],
             // add a checker here?
             // some of the tcdm ports specificed here?
             snax_narrow_tcdm_ports: 8,

--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_KUL_cluster",
+        bender_target: ["snax_KUL_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -100,6 +101,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemmX",
+            bender_target: ["snax_gemmX","snax_data_reshuffler"],
             // add a checker here?
             // some of the tcdm ports specificed here?
             snax_narrow_tcdm_ports: 8,

--- a/target/snitch_cluster/cfg/snax-mac-mult.hjson
+++ b/target/snitch_cluster/cfg/snax-mac-mult.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_mac_mult_cluster",
+        bender_target: ["snax_mac_mult_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -89,6 +90,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_mac",
+            bender_target: ["snax_mac"],
             snax_narrow_tcdm_ports: 4,
             snax_num_rw_csr: 24,
             snax_num_acc: 4,

--- a/target/snitch_cluster/cfg/snax-mac.hjson
+++ b/target/snitch_cluster/cfg/snax-mac.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_mac_cluster",
+        bender_target: ["snax_mac_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -88,7 +89,8 @@
         xfdotp: false,
         xfvec: false,
         snax_acc_cfg: {
-            snax_acc_name: "snax_mac"
+            snax_acc_name: "snax_mac",
+            bender_target: ["snax_mac"],
             snax_narrow_tcdm_ports: 4,
         },
         snax_use_custom_ports: true,

--- a/target/snitch_cluster/cfg/snax-streamer-gemm-add-c.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm-add-c.hjson
@@ -12,6 +12,7 @@
 
     cluster: {
         name: "snax_streamer_gemm_add_c_cluster",
+        bender_target: ["snax_streamer_gemm_add_c_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -90,6 +91,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemm_add_c",
+            bender_target: ["snax_streamer_gemm_add_c"],
             snax_narrow_tcdm_ports: 48,
             snax_num_rw_csr: 5,
             snax_num_ro_csr: 2,

--- a/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
@@ -11,6 +11,7 @@
 
     cluster: {
         name: "snax_streamer_gemm_cluster",
+        bender_target: ["snax_streamer_gemm_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 262144,  // 256KB
@@ -89,6 +90,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemm",
+            bender_target: ["snax_streamer_gemm"],
             snax_narrow_tcdm_ports: 48,
             snax_num_rw_csr: 5,
             snax_num_ro_csr: 2,

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -196,6 +196,11 @@ def main():
         "--gen_path", type=str, default="./",
         help="Points to the output directory"
     )
+    parser.add_argument(
+        "--get_bender_targets",
+        action="store_true",
+        help="Get the bender targets for the whole system",
+    )
 
     # Get the list of parsing
     args = parser.parse_args()
@@ -211,6 +216,30 @@ def main():
     # Then dump them into a dictionary set
     num_core_w_acc = 0
     acc_cfgs = []
+
+    # For generating all bender targets
+    if args.get_bender_targets:
+        def get_bender_targets(cfg):
+            targets = []
+            # If cfg is dictionary, then first check if it has bender_target, then iterate over the rest
+            if isinstance(cfg, dict):
+                for name,content in cfg.items():
+                    if name == "bender_target":
+                        targets.extend(content)
+                    else:
+                        targets.extend(get_bender_targets(content))
+            # If cfg is a list, then iterate over the list
+            elif isinstance(cfg, list):
+                for item in cfg:
+                    targets.extend(get_bender_targets(item))
+            # Return the list of targets with removing duplicates
+            return list(set(targets))
+        
+        bender_targets = get_bender_targets(cfg)
+        for i in bender_targets:
+            print(" -t "+ i,end="")
+        print()
+        return
 
     # ---------------------------------------
     # Generate the accelerator specific wrappers

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -221,9 +221,10 @@ def main():
     if args.get_bender_targets:
         def get_bender_targets(cfg):
             targets = []
-            # If cfg is dictionary, then first check if it has bender_target, then iterate over the rest
+            # If cfg is dictionary, then first check if it has
+            # bender_target, then iterate over the rest
             if isinstance(cfg, dict):
-                for name,content in cfg.items():
+                for name, content in cfg.items():
                     if name == "bender_target":
                         targets.extend(content)
                     else:
@@ -234,10 +235,10 @@ def main():
                     targets.extend(get_bender_targets(item))
             # Return the list of targets with removing duplicates
             return list(set(targets))
-        
+
         bender_targets = get_bender_targets(cfg)
         for i in bender_targets:
-            print(" -t "+ i,end="")
+            print(" -t " + i, end="")
         print()
         return
 


### PR DESCRIPTION
This PR changes how to get bender targets and instead of declaring in Makefiles, we declare them in configuration files. This achieves the single source of truth.

This PR solves issue #294 as requested by @IveanEx 

This matches with the [Hemaia ](https://github.com/KULeuven-MICAS/HeMAiA) setup.

Major TODO:
- [x] Modify `snaxgen.py` by adding the bender targets utility.
- [x] Add bender targets on the configuration files.
- [x] Modify main Makefile to use this method.