### PR TITLE
Fix ReaderWriter Bug

### DIFF
--- a/hw/chisel/src/main/scala/snax/xdma/CommonCells/MuxDemuxDecoupled.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/CommonCells/MuxDemuxDecoupled.scala
@@ -40,7 +40,7 @@ class MuxDecoupled[T <: Data](dataType: T, numInput: Int)
   })
   // Default assigns
   io.out.valid := false.B
-  io.out.bits := 0.U
+  io.out.bits := 0.U.asTypeOf(dataType)
   // Mux logic
   for (i <- 0 until numInput) {
     when(io.sel === i.U) {

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/DataRequestor.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/DataRequestor.scala
@@ -5,9 +5,11 @@ import chisel3.util._
 
 import snax.utils._
 
-// When the requestor is reader, it has to consider the received fifo is full or not
-// When the reqeustor is writer, it only has req_valid and ignore the Responsor ready
-
+/** DataRequestor's IO definition: io.in.address: Decoupled(UInt) io.in.data:
+  * Some(Decoupled(UInt)) or None io.in.ResponsorReady: Some(Bool()) or None
+  * io.out: Toward TCDM, see Xiaoling's definition to compatible with her
+  * wrapper: TypeDefine.scala
+  */
 class DataRequestorIO(
     tcdmDataWidth: Int,
     tcdmAddressWidth: Int,
@@ -28,53 +30,11 @@ class DataRequestorIO(
     val rspReady = if (isReader) Some(Input(Bool())) else None
     val reqSubmit = if (isReader) Some(Output(Bool())) else None
   }
-
 }
 
-// class DataRequestorsIO(
-//     tcdmDataWidth: Int,
-//     tcdmAddressWidth: Int,
-//     isReader: Boolean,
-//     numChannel: Int
-// ) extends Bundle {
-//   val dataReq
-// }
+// When the requestor is reader, it has to consider the received fifo is full or not
+// When the reqeustor is writer, it only has req_valid and ignore the Responsor ready
 
-// class DataRequestorsIO(
-//     tcdmDataWidth: Int,
-//     tcdmAddressWidth: Int,
-//     isReader: Boolean,
-//     numChannel: Int
-// ) extends Bundle {
-//   val in = new Bundle {
-//     val addr = Vec(numChannel, Flipped(Decoupled(UInt(tcdmAddressWidth.W))))
-//     val data =
-//       if (!isReader)
-//         Some(Vec(numChannel, Flipped(Decoupled(UInt(tcdmDataWidth.W)))))
-//       else None
-//     val strb = Input(UInt((tcdmDataWidth / 8).W))
-//   }
-//   val out = new Bundle {
-//     val tcdmReq =
-//       Vec(numChannel, Decoupled(new TcdmReq(tcdmAddressWidth, tcdmDataWidth)))
-//   }
-
-//   val enable = Vec(numChannel, Input(Bool()))
-
-//   val RequestorResponserLink = new Bundle {
-//     val ResponsorReady =
-//       if (isReader) Some(Vec(numChannel, Input(Bool()))) else None
-//     val RequestorSubmit =
-//       if (isReader) Some(Vec(numChannel, Output(Bool()))) else None
-//   }
-
-// }
-
-/** DataRequestor's IO definition: io.in.address: Decoupled(UInt) io.in.data:
-  * Some(Decoupled(UInt)) or None io.in.ResponsorReady: Some(Bool()) or None
-  * io.out: Toward TCDM, see Xiaoling's definition to compatible with her
-  * wrapper: TypeDefine.scala
-  */
 class DataRequestor(
     tcdmDataWidth: Int,
     tcdmAddressWidth: Int,
@@ -86,16 +46,9 @@ class DataRequestor(
   // Or this channel is disabled
   // Because if enable is 0, Reader will always write 0 to databuffer and writer does nothing at all, so the address is popped out if there is place to write 0 (reader case) or unconditionally (writer case)
   when(io.enable) {
-    io.in.addr.ready := {
-      if (isReader)
-        io.reqrspLink.rspReady.get && io.out.tcdmReq.fire
-      else io.out.tcdmReq.fire
-    }
+    io.in.addr.ready := io.out.tcdmReq.fire
   }.otherwise {
-    io.in.addr.ready := {
-      if (isReader) io.reqrspLink.rspReady.get
-      else true.B
-    }
+    io.in.addr.ready := true.B
   }
 
   if (isReader) {
@@ -110,11 +63,6 @@ class DataRequestor(
   // If is reader, the mask is always 1 because tcdm ignore it;
   // Else, the mask is connected to the tcdm requestor to indicate which byte is valid
   io.out.tcdmReq.bits.strb := io.in.strb
-
-  // If is writer, the data port is ready to receive data when there is a valid address
-  if (!isReader) {
-    io.in.data.get.ready := io.in.addr.ready
-  }
 
   io.out.tcdmReq.bits.addr := io.in.addr.bits
   io.out.tcdmReq.bits.write := { if (isReader) 0.U else 1.U }
@@ -132,11 +80,6 @@ class DataRequestor(
   }
 }
 
-/** DataRequestors' IO definition: io.in.address: Vec(Decoupled(UInt))
-  * io.in.data: Some(Vec(Decoupled(UInt))) or None io.in.ResponsorReady:
-  * Some(Vec(Bool())) or None io.out: Toward TCDM, see Xiaoling's definition to
-  * compatible with her wrapper
-  */
 // In this module is the multiple instantiation of DataRequestor. No Buffer is required from the data requestor's side, as it will be done at the outside.
 class DataRequestors(
     tcdmDataWidth: Int,

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/DataResponser.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/DataResponser.scala
@@ -40,33 +40,7 @@ class DataResponser(tcdmDataWidth: Int) extends Module with RequireAsyncReset {
   io.reqrspLink.rspReady := ~io.out.dataFifoNearlyFull // If dataBuffer is not full, then the Responsor is ready to intake more data
 }
 
-/** DataResponsers' IO definition: io.in: From TCDM, see Xiaoling's definition
-  * to compatible with her wrapper io.out.data: Vec(Decoupled(UInt)), to store
-  * the data to FIFO at the outside io.out.ResponsorReady: Vec(Bool()), to
-  * determine whether the Requestor can intake more data (dpending on whether
-  * the output FIFO is full)
-  */
 // In this module is the multiple instantiation of DataRequestor. No Buffer is required from the data requestor's side, as it will be done at the outside.
-
-// class DataResponsersIO(tcdmDataWidth: Int = 64, numChannel: Int = 8)
-//     extends Bundle {
-//   val in = new Bundle {
-//     val tcdmRsp = Vec(
-//       numChannel,
-//       Flipped(Valid(new TcdmRsp(tcdmDataWidth = tcdmDataWidth)))
-//     )
-//   }
-//   val out = new Bundle {
-//     val data = Vec(numChannel, Decoupled(UInt(tcdmDataWidth.W)))
-//     val dataFifoNearlyFull = Input(Vec(numChannel, Bool()))
-//   }
-//   val enable = Vec(numChannel, Input(Bool()))
-//   val RequestorResponserLink = new Bundle {
-//     val ResponsorReady = Vec(numChannel, Output(Bool()))
-//     val RequestorSubmit = Vec(numChannel, Input(Bool()))
-//   }
-
-// }
 
 class DataResponsers(
     tcdmDataWidth: Int = 64,

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/Reader.scala
@@ -91,10 +91,8 @@ class Reader(param: ReaderWriterParam, clusterName: String = "unnamed_cluster")
   if (param.configurableByteMask)
     requestors.io.foreach(_.in.strb := io.readerwriterCfg.enabledByte)
   else
-    requestors.io.zipWithIndex.foreach {
-      case (requestor, i) => {
-        requestor.in.strb := Fill(requestor.in.strb.getWidth, 1.U)
-      }
+    requestors.io.foreach { case requestor =>
+      requestor.in.strb := Fill(requestor.in.strb.getWidth, 1.U)
     }
 
   // ReqRsp Link to exchange necessary data


### PR DESCRIPTION
This PR: 
- Removes the redundant code in **DataRequestor** and **DataResponser**. 
- Comment Improvement
- Do the check of compliance with TCDM timing. 
- ReaderWriter now shares one **sel** logic, instead of having its own **sel** logic per channel. 