### PR TITLE
Fix the streamer bug

### DIFF
--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -243,7 +243,7 @@ class AddressGenUnit(
   // The FSM to record if the AddressGenUnit is busy
   val sIDLE :: sBUSY :: Nil = Enum(2)
   val currentState = RegInit(sIDLE)
-  when(io.start && io.cfg.temporalBounds.map(_ =/= 0.U).reduce(_ && _)) {  // The cfg is valid, and the start signal is high
+  when(io.start && io.cfg.temporalBounds.map(_ =/= 0.U).reduce(_ && _)) { // The cfg is valid, and the start signal is high
     currentState := sBUSY
   }.elsewhen(
     counters.map(_.io.lastVal).reduce(_ & _) && outputBuffer.io.in.head.fire

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/AddressGenUnit.scala
@@ -243,7 +243,7 @@ class AddressGenUnit(
   // The FSM to record if the AddressGenUnit is busy
   val sIDLE :: sBUSY :: Nil = Enum(2)
   val currentState = RegInit(sIDLE)
-  when(io.start) {
+  when(io.start && io.cfg.temporalBounds.map(_ =/= 0.U).reduce(_ && _)) {  // The cfg is valid, and the start signal is high
     currentState := sBUSY
   }.elsewhen(
     counters.map(_.io.lastVal).reduce(_ & _) && outputBuffer.io.in.head.fire

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/ReaderWriter.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaStreamer/ReaderWriter.scala
@@ -84,7 +84,14 @@ class ReaderWriter(
   readerwriterMux.foreach(_.io.sel := sel)
 
   // Connect the response from TCDM to the reader
-  io.readerInterface.tcdmRsp <> reader.io.tcdmRsp
+  reader.io.tcdmRsp.zip(io.readerInterface.tcdmRsp).foreach {
+    case (reader, interface) => {
+      // Bits is connected directly
+      reader.bits := interface.bits
+      // Valid is connected with the interface valid, under the condition that the last request is from the reader
+      reader.valid := interface.valid && RegNext(sel === 1.U)
+    }
+  }
 }
 
 object ReaderWriterEmitter extends App {

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaStreamer/AddressGenUnitTester.scala
@@ -44,7 +44,7 @@ class AddressGenUnitTester extends AnyFlatSpec with ChiselScalatestTester {
         dut.io.cfg.spatialStrides(0).poke(8)
         dut.io.cfg.temporalStrides(0).poke(64)
         dut.io.cfg.temporalStrides(1).poke(64)
-        dut.io.cfg.temporalBounds(0).poke(1)
+        dut.io.cfg.temporalBounds(0).poke(0)
         dut.io.cfg.temporalBounds(1).poke(16)
 
         dut.io.start.poke(true)


### PR DESCRIPTION
This PR: 
- Avoid starting AGU when some ***loopBound*** is zero. 
- Avoid written result loopback to reader's channel in ***ReaderWriter*** module. 