### PR TITLE
Taking out license tag for the configuration templates.

### DIFF
--- a/hw/templates/config_impl.txt.tpl
+++ b/hw/templates/config_impl.txt.tpl
@@ -1,7 +1,3 @@
-// Copyright 2024 KU Leuven.
-// Solderpad Hardware License, Version 0.51, see LICENSE for details.
-// SPDX-License-Identifier: SHL-0.51
-
 <%def name="icache_cfg(prop)">\
   % for lw in cfg['hives']:
 ${lw['icache'][prop]}${',' if not loop.last else ''}\

--- a/hw/templates/config_spec.txt.tpl
+++ b/hw/templates/config_spec.txt.tpl
@@ -1,7 +1,3 @@
-// Copyright 2024 KU Leuven.
-// Solderpad Hardware License, Version 0.51, see LICENSE for details.
-// SPDX-License-Identifier: SHL-0.51
-
 <%def name="icache_cfg(prop)">\
   % for lw in cfg['hives']:
 ${lw['icache'][prop]}${',' if not loop.last else ''}\


### PR DESCRIPTION
This PR takes away the license tags for the configuration templates. It messes with Gui's synthesis scripts.

Major TODO:
- [x] Clean templates