### PR TITLE
Fix tb_lib.hh address length

### DIFF
--- a/target/common/test/tb_lib.hh
+++ b/target/common/test/tb_lib.hh
@@ -117,17 +117,17 @@ extern GlobalMemory MEM;
 
 // The boot data generated along with the system RTL.
 struct BootData {
-    uint32_t boot_addr;
+    uint64_t boot_addr;
     uint32_t core_count;
     uint32_t hartid_base;
-    uint32_t tcdm_start;
-    uint32_t tcdm_size;
-    uint32_t tcdm_offset;
+    uint64_t tcdm_start;
+    uint64_t tcdm_size;
+    uint64_t tcdm_offset;
     uint64_t global_mem_start;
     uint64_t global_mem_end;
     uint32_t cluster_count;
     uint32_t s1_quadrant_count;
-    uint32_t clint_base;
+    uint64_t clint_base;
 };
 extern const BootData BOOTDATA;
 


### PR DESCRIPTION
A small fix on BootData struct used by fesvr to make it support 64b addressing