### PR TITLE
change default tcdm size

### DIFF
--- a/target/snitch_cluster/cfg/default.hjson
+++ b/target/snitch_cluster/cfg/default.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-alu.hjson
+++ b/target/snitch_cluster/cfg/snax-alu.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-dimc.hjson
+++ b/target/snitch_cluster/cfg/snax-dimc.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-hypercorex.hjson
+++ b/target/snitch_cluster/cfg/snax-hypercorex.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide-xdma.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
+++ b/target/snitch_cluster/cfg/snax-kul-cluster-mixed-narrow-wide.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-mac-mult.hjson
+++ b/target/snitch_cluster/cfg/snax-mac-mult.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-mac.hjson
+++ b/target/snitch_cluster/cfg/snax-mac.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-streamer-gemm-add-c.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm-add-c.hjson
@@ -20,7 +20,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB

--- a/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
+++ b/target/snitch_cluster/cfg/snax-streamer-gemm.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 128,
+            size: 4096,
             banks: 32,
         },
         cluster_periph_size: 64, // kB


### PR DESCRIPTION
For the neural network testing, we need some more memory :)

I suggest just increasing the default TCDM size to 4096 for all the systems? This does not have an effect on compilation/simulation time. This way we don't have to worry about running out of memory in all of our tests.

Or will this cause some problems somewhere?