### PR TITLE
Fix Bitwidth Error for XDMA

### DIFF
--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -85,6 +85,8 @@ module ${cfg["name"]}_xdma_wrapper #(
   // Re-mapping wires for TCDM IO ports
   always_comb begin
     for ( int i = 0; i < TCDMNumPorts; i++) begin
+      // Give tcdm_req.q.addr a default value so that the mismatched bits will not be z
+      tcdm_req_o[i].q.addr         = '0;
       tcdm_req_o[i].q.addr         = tcdm_req_addr   [i];
       tcdm_req_o[i].q.write        = tcdm_req_write  [i];
       tcdm_req_o[i].q.amo          = reqrsp_pkg::AMONone;


### PR DESCRIPTION
This PR adds the default value (0) to the unused address bits instead of leaving it high impedance. 