### PR TITLE
Systematic approach to fix transposer critical path

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtensionHost.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtensionHost.scala
@@ -120,7 +120,7 @@ class DataPathExtensionHost(
     } else {
       extensions.last.io.data_o <> io.data.out
     }
-    
+
     extensions.head.io.data_i <> io.data.in
     extensions.last.io.data_o <> io.data.out
     extensions.zip(extensions.tail).foreach {

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtensionHost.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtensionHost.scala
@@ -44,6 +44,9 @@ class DataPathExtensionHostIO(
 class DataPathExtensionHost(
     extensionList: Seq[HasDataPathExtension],
     dataWidth: Int = 512,
+    headCut: Boolean = false,
+    tailCut: Boolean = false,
+    halfCut: Boolean = false,
     moduleNamePrefix: String = "unnamed_cluster"
 ) extends Module {
   override def desiredName = s"${moduleNamePrefix}_DataPathExtensionHost"
@@ -98,11 +101,35 @@ class DataPathExtensionHost(
       )
 
     // Connect the data path
+    if (headCut) {
+      if (halfCut) {
+        io.data.in -/> extensions.head.io.data_i
+      } else {
+        io.data.in -||> extensions.head.io.data_i
+      }
+    } else {
+      io.data.in <> extensions.head.io.data_i
+    }
+
+    if (tailCut) {
+      if (halfCut) {
+        extensions.last.io.data_o -/> io.data.out
+      } else {
+        extensions.last.io.data_o -||> io.data.out
+      }
+    } else {
+      extensions.last.io.data_o <> io.data.out
+    }
+    
     extensions.head.io.data_i <> io.data.in
     extensions.last.io.data_o <> io.data.out
     extensions.zip(extensions.tail).foreach {
       case (a, b) => {
-        a.io.data_o -||> b.io.data_i
+        if (halfCut) {
+          a.io.data_o -/> b.io.data_i
+        } else {
+          a.io.data_o -||> b.io.data_i
+        }
       }
     }
   }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/Transposer.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/Transposer.scala
@@ -38,14 +38,10 @@ class Transposer()(implicit extensionParam: DataPathExtensionParam)
     }
   }
 
-  val outBuffered = Wire(chiselTypeOf(ext_data_o))
-  outBuffered -||> ext_data_o
-
-  ext_data_i.ready := outBuffered.ready
-  outBuffered.valid := ext_data_i.valid
-  outBuffered.bits := out_data_array.asUInt
-
-  ext_busy_o := ext_data_o.valid
+  ext_data_i.ready := ext_data_o.ready
+  ext_data_o.valid := ext_data_i.valid
+  ext_busy_o := false.B
+  ext_data_o.bits := out_data_array.asUInt
 
 }
 

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -161,6 +161,9 @@ class Streamer(
       new DataPathExtensionHost(
         extensionList = param.dataPathExtensionParam,
         dataWidth = param.fifoWidthReader(i),
+        headCut = false,
+        tailCut = true,
+        halfCut = true,
         moduleNamePrefix = param.tagName
       )
     )

--- a/hw/chisel/src/main/scala/snax/utils/CustomOperators.scala
+++ b/hw/chisel/src/main/scala/snax/utils/CustomOperators.scala
@@ -21,7 +21,7 @@ object DecoupledCut {
       val buffer = Module(
         new Queue(chiselTypeOf(left.bits), entries = 1, pipe = false)
       )
-      buffer.suggestName("cut1")
+      buffer.suggestName("fullCut1")
 
       left <> buffer.io.enq
       buffer.io.deq <> right
@@ -33,7 +33,7 @@ object DecoupledCut {
       val buffer = Module(
         new Queue(chiselTypeOf(left.bits), entries = 2, pipe = false)
       )
-      buffer.suggestName("cut2")
+      buffer.suggestName("fullCut2")
       left <> buffer.io.enq
       buffer.io.deq <> right
     }
@@ -44,7 +44,18 @@ object DecoupledCut {
       val buffer = Module(
         new Queue(chiselTypeOf(left.bits), entries = 3, pipe = false)
       )
-      buffer.suggestName("cut3")
+      buffer.suggestName("fullCut3")
+      left <> buffer.io.enq
+      buffer.io.deq <> right
+    }
+
+    def -/>(
+        right: DecoupledIO[T]
+    )(implicit sourceInfo: chisel3.experimental.SourceInfo): Unit = {
+      val buffer = Module(
+        new Queue(chiselTypeOf(left.bits), entries = 1, pipe = true)
+      )
+      buffer.suggestName("halfCut1")
       left <> buffer.io.enq
       buffer.io.deq <> right
     }

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
@@ -225,6 +225,9 @@ class DMADataPath(
       readerparam.extParam,
       dataWidth =
         readerparam.rwParam.tcdmParam.dataWidth * readerparam.rwParam.tcdmParam.numChannel,
+      headCut = false,
+      tailCut = false,
+      halfCut = false,
       moduleNamePrefix = clusterName
     )
   )
@@ -242,6 +245,9 @@ class DMADataPath(
       writerparam.extParam,
       dataWidth =
         writerparam.rwParam.tcdmParam.dataWidth * writerparam.rwParam.tcdmParam.numChannel,
+      headCut = false,
+      tailCut = false,
+      halfCut = false,
       moduleNamePrefix = clusterName
     )
   )


### PR DESCRIPTION
This PR modifies the previous updates on cut after the transpose unit to cut the critical path in a more systematic and generic way. 