### PR TITLE
fix-gemm-control-critical-path

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
@@ -73,7 +73,7 @@ class BlockGemm(params: GemmParams) extends Module with RequireAsyncReset {
   // counter used to record if need to output to outside
   val d_output_ifvalid_counter = RegInit(0.U(params.sizeConfigWidth.W))
   // counter to record how many output data has been written
-  val d_output_counter = RegInit(0.U((params.sizeConfigWidth).W))
+  val d_output_counter = RegInit(0.U((2 * params.sizeConfigWidth).W))
 
   val performance_counter = RegInit(0.U(32.W))
 

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
@@ -69,11 +69,11 @@ class BlockGemm(params: GemmParams) extends Module with RequireAsyncReset {
   val subtraction_b = RegInit(0.U(params.dataWidthB.W))
 
   // useful counters
-  val compute_fire_counter = RegInit(0.U((3 * params.sizeConfigWidth).W))
+  val compute_fire_counter = RegInit(0.U((params.sizeConfigWidth).W))
   // counter used to record if need to output to outside
   val d_output_ifvalid_counter = RegInit(0.U(params.sizeConfigWidth.W))
   // counter to record how many output data has been written
-  val d_output_counter = RegInit(0.U((3 * params.sizeConfigWidth).W))
+  val d_output_counter = RegInit(0.U((params.sizeConfigWidth).W))
 
   val performance_counter = RegInit(0.U(32.W))
 


### PR DESCRIPTION
This PR remove the redundant control bits inside the gemm to fix gemm control critical path.