### PR TITLE
Fix DataRequestor Errors

### DIFF
--- a/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
@@ -48,7 +48,7 @@ class DataRequestor(
   when(io.enable) {
     io.in.addr.ready := io.out.tcdmReq.fire
   }.otherwise {
-    io.in.addr.ready := true.B
+    io.in.addr.ready := { if (isReader) io.reqrspLink.rspReady.get else true.B }
   }
 
   if (isReader) {


### PR DESCRIPTION
This PR fixes an error in readerWriter: When some channels in reader are turned off under the case that output of reader is highly congested, some padded zeros is not stored into the FIFO as expected. 