### PR TITLE
Add cluster cuts

### DIFF
--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -1599,7 +1599,7 @@ module snitch_cluster
     .DATA_WIDTH (NarrowDataWidth),
     .AXI_MAX_WRITE_TXNS (1),
     .AXI_MAX_READ_TXNS (1),
-    .DECOUPLE_W (0),
+    .DECOUPLE_W (1),
     .ID_WIDTH (NarrowIdWidthOut),
     .USER_WIDTH (NarrowUserWidth),
     .axi_req_t (axi_slv_req_t),

--- a/target/snitch_cluster/cfg/snax_alu.hjson
+++ b/target/snitch_cluster/cfg/snax_alu.hjson
@@ -62,7 +62,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_dimc.hjson
+++ b/target/snitch_cluster/cfg/snax_dimc.hjson
@@ -61,7 +61,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_hypercorex.hjson
+++ b/target/snitch_cluster/cfg/snax_hypercorex.hjson
@@ -69,7 +69,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
@@ -71,7 +71,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
@@ -19,7 +19,7 @@
         addr_width: 48,
         data_width: 64,
         tcdm: {
-            size: 4096,
+            size: 128,
             banks: 32,
         },
         cluster_periph_size: 64, // kB
@@ -71,7 +71,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_mac.hjson
+++ b/target/snitch_cluster/cfg/snax_mac.hjson
@@ -61,7 +61,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_mac_mult.hjson
+++ b/target/snitch_cluster/cfg/snax_mac_mult.hjson
@@ -61,7 +61,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_streamer_gemm.hjson
+++ b/target/snitch_cluster/cfg/snax_streamer_gemm.hjson
@@ -61,7 +61,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0

--- a/target/snitch_cluster/cfg/snax_streamer_gemm_add_c.hjson
+++ b/target/snitch_cluster/cfg/snax_streamer_gemm_add_c.hjson
@@ -62,7 +62,9 @@
             register_core_req: true,
             register_core_rsp: true,
             register_offload_req: true,
-            register_offload_rsp: true
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
         },
         hives: [
             // Hive 0


### PR DESCRIPTION
This PR enables cluster cut configs. This is an effort to increase operating frequency by cutting long AXI paths.

Major TODO:
- [x] Add cut for the AXI ports
- [x] Add cut for the axi-to-reg port