### PR TITLE
Add scale factor for each channel

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
@@ -112,7 +112,9 @@ class BlockGemm(params: GemmParams) extends Module with RequireAsyncReset {
   val b_split_out = Wire(Decoupled(UInt(b_bits_len.W)))
 
   val a_b_cat = Module(new DecoupledCat2to1(a_bits_len, b_bits_len))
-  val a_b_split = Module(new DecoupledSplit1to2(a_b_bits_len, a_bits_len, b_bits_len))
+  val a_b_split = Module(
+    new DecoupledSplit1to2(a_b_bits_len, a_bits_len, b_bits_len)
+  )
 
   a_b_cat.io.in1 <> io.data.a_i
   a_b_cat.io.in2 <> io.data.b_i

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
@@ -174,7 +174,7 @@ object BlockGemmRescaleSIMDGen {
           (if (withPipeline == true)
              snax_acc.simd.PipelinedConfig.rescaleSIMDConfig
            else snax_acc.simd.DefaultConfig.rescaleSIMDConfig),
-          false
+          withPipeline
         )
       ),
       Array("--target-dir", "generated/gemmx")

--- a/hw/chisel_acc/src/main/scala/snax_acc/simd/Parameter.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/simd/Parameter.scala
@@ -31,7 +31,7 @@ object RescaleSIMDConstant {
   def readWriteCsrNum: Int = 13
 
   // sharedScaleFactorPerGroupSize
-  def sharedScaleFactorPerGroupSize = 1
+  def sharedScaleFactorPerGroupSize = 8
 
 }
 
@@ -58,6 +58,6 @@ object PipelinedConfig {
     dataLen = RescaleSIMDConstant.dataLen,
     laneLen = 8,
     readWriteCsrNum = RescaleSIMDConstant.readWriteCsrNum,
-    sharedScaleFactorPerGroupSize = 8
+    sharedScaleFactorPerGroupSize = 1
   )
 }

--- a/hw/chisel_acc/src/main/scala/snax_acc/simd/Parameter.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/simd/Parameter.scala
@@ -10,7 +10,8 @@ case class RescaleSIMDParams(
     constantMulType: Int,
     dataLen: Int,
     laneLen: Int,
-    readWriteCsrNum: Int
+    readWriteCsrNum: Int,
+    sharedScaleFactorPerGroupSize: Int
 )
 
 // parameters for Rescale SIMD accelerator
@@ -26,9 +27,11 @@ object RescaleSIMDConstant {
   def dataLen = 64
   def laneLen = 64
 
-  // csrManager parameters, we use 3 CSR for Post-processing SIMD configuration,
-  // CSR 4 for the vector length,
-  def readWriteCsrNum: Int = 4
+  // csrManager parameters, refer to the SIMD spec for more details
+  def readWriteCsrNum: Int = 13
+
+  // sharedScaleFactorPerGroupSize
+  def sharedScaleFactorPerGroupSize = 1
 
 }
 
@@ -40,7 +43,9 @@ object DefaultConfig {
     constantMulType = RescaleSIMDConstant.constantMulType,
     dataLen = RescaleSIMDConstant.dataLen,
     laneLen = RescaleSIMDConstant.laneLen,
-    readWriteCsrNum = RescaleSIMDConstant.readWriteCsrNum
+    readWriteCsrNum = RescaleSIMDConstant.readWriteCsrNum,
+    sharedScaleFactorPerGroupSize =
+      RescaleSIMDConstant.sharedScaleFactorPerGroupSize
   )
 }
 
@@ -52,6 +57,7 @@ object PipelinedConfig {
     constantMulType = RescaleSIMDConstant.constantMulType,
     dataLen = RescaleSIMDConstant.dataLen,
     laneLen = 8,
-    readWriteCsrNum = RescaleSIMDConstant.readWriteCsrNum
+    readWriteCsrNum = RescaleSIMDConstant.readWriteCsrNum,
+    sharedScaleFactorPerGroupSize = 8
   )
 }

--- a/hw/chisel_acc/src/main/scala/snax_acc/simd/PipelinedRescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/simd/PipelinedRescaleSIMD.scala
@@ -88,8 +88,6 @@ class PipelinedRescaleSIMD(params: RescaleSIMDParams)
       lane(i).io.input_i := 0.S
       lane(i).io.valid_i := false.B
     }
-    lane(i).io.ctrl_i := ctrl_csr
-    result(i) := lane(i).io.output_o
   }
 
   // lane output valid process counter

--- a/hw/chisel_acc/src/main/scala/snax_acc/simd/RescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/simd/RescaleSIMD.scala
@@ -39,8 +39,7 @@ class RescaleSIMD(params: RescaleSIMDParams)
   val lane = Seq.fill(params.laneLen)(Module(new RescalePE(params)))
 
   // control csr registers for storing the control data
-  def ctrl_csr_set_num = params.dataLen / params.sharedScaleFactorPerGroupSize
-  require(ctrl_csr_set_num == params.laneLen)
+  def ctrl_csr_set_num = params.laneLen / params.sharedScaleFactorPerGroupSize
 
   // Create a Vec of ctrl_csr_set_num instances of RescalePECtrl(params)
   val ctrl_csr = VecInit(Seq.fill(ctrl_csr_set_num) {

--- a/hw/chisel_acc/src/main/scala/snax_acc/simd/RescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/simd/RescaleSIMD.scala
@@ -39,7 +39,13 @@ class RescaleSIMD(params: RescaleSIMDParams)
   val lane = Seq.fill(params.laneLen)(Module(new RescalePE(params)))
 
   // control csr registers for storing the control data
-  val ctrl_csr = Reg(new RescalePECtrl(params))
+  def ctrl_csr_set_num = params.dataLen / params.sharedScaleFactorPerGroupSize
+  require(ctrl_csr_set_num == params.laneLen)
+
+  // Create a Vec of ctrl_csr_set_num instances of RescalePECtrl(params)
+  val ctrl_csr = VecInit(Seq.fill(ctrl_csr_set_num) {
+    Reg(new RescalePECtrl(params))
+  })
 
   // result from different RescalePEs
   val result = Wire(
@@ -103,22 +109,36 @@ class RescaleSIMD(params: RescaleSIMDParams)
   config_valid := io.ctrl.fire
 
   // when config valid, store the configuration for later computation
-  ctrl_csr.input_zp_i := io.ctrl.bits(0)(7, 0).asSInt
-  ctrl_csr.output_zp_i := io.ctrl.bits(0)(15, 8).asSInt
+  for (i <- 0 until ctrl_csr_set_num) {
+    // common control input ports
+    ctrl_csr(i).input_zp_i := io.ctrl.bits(0)(7, 0).asSInt
+    ctrl_csr(i).output_zp_i := io.ctrl.bits(0)(15, 8).asSInt
+    ctrl_csr(i).max_int_i := io.ctrl.bits(0)(23, 16).asSInt
+    ctrl_csr(i).min_int_i := io.ctrl.bits(0)(31, 24).asSInt
 
-  // this control input port is 32 bits, so it needs 1 csr
-  ctrl_csr.multiplier_i := io.ctrl.bits(2).asSInt
+    // this control input port is only 1 bit
+    ctrl_csr(i).double_round_i := io.ctrl.bits(1)(0).asBool
 
-  ctrl_csr.shift_i := io.ctrl.bits(0)(23, 16).asSInt
-  ctrl_csr.max_int_i := io.ctrl.bits(0)(31, 24).asSInt
+    // ---------------------
+    // sharedScaleFactorPerGroup
+    def packed_shift_num = 32 / params.constantType
+    ctrl_csr(i).shift_i := io.ctrl
+      .bits(2 + i / packed_shift_num)(
+        i % packed_shift_num * params.constantType + params.constantType - 1,
+        i % packed_shift_num * params.constantType
+      )
+      .asSInt
 
-  ctrl_csr.min_int_i := io.ctrl.bits(1)(7, 0).asSInt
+    // this control input port is 32 bits, so it needs 1 csr
+    ctrl_csr(i).multiplier_i := io.ctrl.bits(4 + i).asSInt
+    // ---------------------
 
-  // this control input port is only 1 bit
-  ctrl_csr.double_round_i := io.ctrl.bits(1)(8).asBool
+    // length of the data
+    ctrl_csr(i).len := io.ctrl
+      .bits(2 + ctrl_csr_set_num / 4 + ctrl_csr_set_num)
+      .asUInt
 
-  // length of the data
-  ctrl_csr.len := io.ctrl.bits(3)
+  }
 
   val simd_input_fire = WireInit(0.B)
   simd_input_fire := io.data.input_i.fire
@@ -135,7 +155,11 @@ class RescaleSIMD(params: RescaleSIMDParams)
     write_counter := 0.U
   }
 
-  computation_finish := (read_counter === ctrl_csr.len) && (write_counter === ctrl_csr.len - 1.U) && simd_output_fire && cstate === sBUSY
+  computation_finish := (read_counter === ctrl_csr(
+    0
+  ).len) && (write_counter === ctrl_csr(
+    0
+  ).len - 1.U) && simd_output_fire && cstate === sBUSY
 
   // always ready for configuration
   io.ctrl.ready := cstate === sIDLE
@@ -143,7 +167,11 @@ class RescaleSIMD(params: RescaleSIMDParams)
   // give each RescalePE right control signal and data
   // collect the result of each RescalePE
   for (i <- 0 until params.laneLen) {
-    lane(i).io.ctrl_i := ctrl_csr
+    lane(i).io.ctrl_i := ctrl_csr(i % ctrl_csr_set_num)
+    result(i) := lane(i).io.output_o
+  }
+  
+  for (i <- 0 until params.laneLen) {
     lane(i).io.input_i := io.data.input_i
       .bits(
         (i + 1) * params.inputType - 1,
@@ -151,7 +179,6 @@ class RescaleSIMD(params: RescaleSIMDParams)
       )
       .asSInt
     lane(i).io.valid_i := io.data.input_i.valid && io.data.input_i.ready
-    result(i) := lane(i).io.output_o
   }
 
   // always valid for new input on less is sending last output

--- a/hw/chisel_acc/src/main/scala/snax_acc/utils/DecoupledCat.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/utils/DecoupledCat.scala
@@ -3,10 +3,12 @@ package snax_acc.utils
 import chisel3._
 import chisel3.util._
 
-class DecoupledCat2to1[T <: Data](aWidth: Int, bWidth: Int) extends Module{
-      val io = IO(new Bundle {
-    val in1 = Flipped(Decoupled(UInt(aWidth.W)))  // First decoupled input interface
-    val in2 = Flipped(Decoupled(UInt(bWidth.W)))  // Second decoupled input interface
+class DecoupledCat2to1[T <: Data](aWidth: Int, bWidth: Int) extends Module {
+  val io = IO(new Bundle {
+    val in1 =
+      Flipped(Decoupled(UInt(aWidth.W))) // First decoupled input interface
+    val in2 =
+      Flipped(Decoupled(UInt(bWidth.W))) // Second decoupled input interface
     val out = Decoupled(UInt((aWidth + bWidth).W)) // Decoupled output interface
   })
 
@@ -23,17 +25,20 @@ class DecoupledCat2to1[T <: Data](aWidth: Int, bWidth: Int) extends Module{
 }
 
 class DecoupledSplit1to2(cWidth: Int, aWidth: Int, bWidth: Int) extends Module {
-  require(cWidth == aWidth + bWidth, "cWidth must be the sum of aWidth and bWidth")
+  require(
+    cWidth == aWidth + bWidth,
+    "cWidth must be the sum of aWidth and bWidth"
+  )
 
   val io = IO(new Bundle {
     val in = Flipped(Decoupled(UInt(cWidth.W))) // Large decoupled input (c)
-    val out1 = Decoupled(UInt(aWidth.W))        // Smaller decoupled output (a)
-    val out2 = Decoupled(UInt(bWidth.W))        // Smaller decoupled output (b)
+    val out1 = Decoupled(UInt(aWidth.W)) // Smaller decoupled output (a)
+    val out2 = Decoupled(UInt(bWidth.W)) // Smaller decoupled output (b)
   })
 
   // Split the input bits into two parts
   io.out1.bits := io.in.bits(cWidth - 1, bWidth) // Upper bits go to out1 (a)
-  io.out2.bits := io.in.bits(bWidth - 1, 0)      // Lower bits go to out2 (b)
+  io.out2.bits := io.in.bits(bWidth - 1, 0) // Lower bits go to out2 (b)
 
   // Both outputs are valid when the input is valid
   io.out1.valid := io.in.valid

--- a/hw/chisel_acc/src/snax_streamer_gemmX_shell_wrapper.sv
+++ b/hw/chisel_acc/src/snax_streamer_gemmX_shell_wrapper.sv
@@ -10,7 +10,7 @@
 module snax_streamer_gemmX_shell_wrapper #(
     // Custom parameters. As much as possible,
     // these parameters should not be taken from outside
-    parameter int unsigned RegRWCount   = 10,
+    parameter int unsigned RegRWCount   = 19,
     parameter int unsigned RegROCount   = 2,
     parameter int unsigned DataWidthA   = 512,
     parameter int unsigned DataWidthB   = 512,
@@ -84,8 +84,17 @@ module snax_streamer_gemmX_shell_wrapper #(
     .io_ctrl_simd_ctrl_bits_1(csr_reg_set_i[5]),
     .io_ctrl_simd_ctrl_bits_2(csr_reg_set_i[6]),
     .io_ctrl_simd_ctrl_bits_3(csr_reg_set_i[7]),
+    .io_ctrl_simd_ctrl_bits_4(csr_reg_set_i[8]),
+    .io_ctrl_simd_ctrl_bits_5(csr_reg_set_i[9]),
+    .io_ctrl_simd_ctrl_bits_6(csr_reg_set_i[10]),
+    .io_ctrl_simd_ctrl_bits_7(csr_reg_set_i[11]),
+    .io_ctrl_simd_ctrl_bits_8(csr_reg_set_i[12]),
+    .io_ctrl_simd_ctrl_bits_9(csr_reg_set_i[13]),
+    .io_ctrl_simd_ctrl_bits_10(csr_reg_set_i[14]),
+    .io_ctrl_simd_ctrl_bits_11(csr_reg_set_i[15]),
+    .io_ctrl_simd_ctrl_bits_12(csr_reg_set_i[16]),
 
-    .io_ctrl_bypassSIMD(csr_reg_set_i[8][0]),
+    .io_ctrl_bypassSIMD(csr_reg_set_i[17][0]),
 
     .io_ctrl_busy_o(csr_reg_ro_set_o[0][0]),
     .io_ctrl_performance_counter(csr_reg_ro_set_o[1]),

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
@@ -122,7 +122,7 @@
             bender_target: ["snax_gemmX","snax_data_reshuffler"],
             snax_narrow_tcdm_ports: 8,
             snax_wide_tcdm_ports: 48,
-            snax_num_rw_csr: 10,
+            snax_num_rw_csr: 19,
             snax_num_ro_csr: 2,
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
@@ -180,14 +180,16 @@
             spatial_bounds: [[8], [8]],
             temporal_dim: [6, 3],
             num_channel: [8, 8],
-            fifo_depth: [2, 2],
+            fifo_depth: [8, 8],
+            configurable_channel: [0, 0],
         },
 
         data_writer_params:{
             spatial_bounds: [[8]],
             temporal_dim: [3],
             num_channel: [8],
-            fifo_depth: [2],
+            fifo_depth: [8],
+            configurable_channel: [0],
         },
 
         data_reader_writer_params:{
@@ -195,8 +197,11 @@
             temporal_dim: [3, 3],
             num_channel: [32, 32],
             fifo_depth: [2, 2],
+            configurable_channel: [1, 0],
         },
-        has_transpose: true
+
+        has_transpose: true,
+
         snax_library_name: "gemmx",
     }
 }

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
@@ -121,7 +121,7 @@
             bender_target: ["snax_gemmX","snax_KUL_xdma_cluster_xdma"],
             snax_narrow_tcdm_ports: 8,
             snax_wide_tcdm_ports: 48,
-            snax_num_rw_csr: 10,
+            snax_num_rw_csr: 19,
             snax_num_ro_csr: 2,
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
@@ -794,35 +794,54 @@ def emit_gemmx_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "bypassSIMD", bypassSIMD)]
 
     # Generating random constant values
+    group_num = 8
     input_zp_i = np.random.randint(MIN, MAX)
     output_zp_i = np.random.randint(MIN, MAX)
-    shift_i = np.random.randint(0, 63)  # values between 0-63
     max_int_i = MAX
     min_int_i = MIN
     double_round_i = np.random.randint(0, 1)
-    multiplier_i = np.random.randint(-(2**31), 2**31 - 1)
+
+    shift_i = np.random.randint(0, 63, size=group_num)  # values between 0-63
+    multiplier_i = np.random.randint(-(2**31), 2**31 - 1, size=group_num)
+
 
     # Writing the constant values to data.h
     data_str += [
         format_scalar_definition("int8_t", "input_zp_i", input_zp_i),
         format_scalar_definition("int8_t", "output_zp_i", output_zp_i),
-        format_scalar_definition("int8_t", "shift_i", shift_i),
         format_scalar_definition("int8_t", "max_int_i", max_int_i),
         format_scalar_definition("int8_t", "min_int_i", min_int_i),
         format_scalar_definition("int8_t", "double_round_i", double_round_i),
-        format_scalar_definition("int32_t", "multiplier_i", multiplier_i),
     ]
 
-    D8 = postprocessing_simd_golden_model(
-        D32,
-        input_zp_i,
-        output_zp_i,
-        shift_i,
-        max_int_i,
-        min_int_i,
-        double_round_i,
-        multiplier_i,
-    )
+    shared_bitpacked_shift0 = (shift_i[3] << 24) | (shift_i[2] << 16) | (shift_i[1] << 8) | shift_i[0]
+    shared_bitpacked_shift1 = (shift_i[7] << 24) | (shift_i[6] << 16) | (shift_i[5] << 8) | shift_i[4]
+    data_str += [format_scalar_definition("int32_t", "shared_bitpacked_shift0", shared_bitpacked_shift0)]
+    data_str += [format_scalar_definition("int32_t", "shared_bitpacked_shift1", shared_bitpacked_shift1)]
+
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier0", multiplier_i[0])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier1", multiplier_i[1])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier2", multiplier_i[2])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier3", multiplier_i[3])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier4", multiplier_i[4])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier5", multiplier_i[5])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier6", multiplier_i[6])]
+    data_str += [format_scalar_definition("int32_t", "shared_multiplier7", multiplier_i[7])]
+
+    D8 = np.zeros_like(D32, dtype=np.uint8)
+    # output channel (innermost dim) has a different scale factor
+    for i in range(group_num):
+        D8[i::group_num] = postprocessing_simd_golden_model(
+                D32[i::group_num],
+                input_zp_i,
+                output_zp_i,
+                shift_i[i],
+                max_int_i,
+                min_int_i,
+                double_round_i,
+                multiplier_i[i],
+            )
+
     data_str += [format_vector_definition("int8_t", "D8", D8)]
 
     data_str = "\n\n".join(data_str)

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
@@ -804,7 +804,6 @@ def emit_gemmx_data(**kwargs):
     shift_i = np.random.randint(0, 63, size=group_num)  # values between 0-63
     multiplier_i = np.random.randint(-(2**31), 2**31 - 1, size=group_num)
 
-
     # Writing the constant values to data.h
     data_str += [
         format_scalar_definition("int8_t", "input_zp_i", input_zp_i),
@@ -814,33 +813,61 @@ def emit_gemmx_data(**kwargs):
         format_scalar_definition("int8_t", "double_round_i", double_round_i),
     ]
 
-    shared_bitpacked_shift0 = (shift_i[3] << 24) | (shift_i[2] << 16) | (shift_i[1] << 8) | shift_i[0]
-    shared_bitpacked_shift1 = (shift_i[7] << 24) | (shift_i[6] << 16) | (shift_i[5] << 8) | shift_i[4]
-    data_str += [format_scalar_definition("int32_t", "shared_bitpacked_shift0", shared_bitpacked_shift0)]
-    data_str += [format_scalar_definition("int32_t", "shared_bitpacked_shift1", shared_bitpacked_shift1)]
+    shared_bitpacked_shift0 = (
+        (shift_i[3] << 24) | (shift_i[2] << 16) | (shift_i[1] << 8) | shift_i[0]
+    )
+    shared_bitpacked_shift1 = (
+        (shift_i[7] << 24) | (shift_i[6] << 16) | (shift_i[5] << 8) | shift_i[4]
+    )
+    data_str += [
+        format_scalar_definition(
+            "int32_t", "shared_bitpacked_shift0", shared_bitpacked_shift0
+        )
+    ]
+    data_str += [
+        format_scalar_definition(
+            "int32_t", "shared_bitpacked_shift1", shared_bitpacked_shift1
+        )
+    ]
 
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier0", multiplier_i[0])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier1", multiplier_i[1])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier2", multiplier_i[2])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier3", multiplier_i[3])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier4", multiplier_i[4])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier5", multiplier_i[5])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier6", multiplier_i[6])]
-    data_str += [format_scalar_definition("int32_t", "shared_multiplier7", multiplier_i[7])]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier0", multiplier_i[0])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier1", multiplier_i[1])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier2", multiplier_i[2])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier3", multiplier_i[3])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier4", multiplier_i[4])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier5", multiplier_i[5])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier6", multiplier_i[6])
+    ]
+    data_str += [
+        format_scalar_definition("int32_t", "shared_multiplier7", multiplier_i[7])
+    ]
 
     D8 = np.zeros_like(D32, dtype=np.uint8)
     # output channel (innermost dim) has a different scale factor
     for i in range(group_num):
         D8[i::group_num] = postprocessing_simd_golden_model(
-                D32[i::group_num],
-                input_zp_i,
-                output_zp_i,
-                shift_i[i],
-                max_int_i,
-                min_int_i,
-                double_round_i,
-                multiplier_i[i],
-            )
+            D32[i::group_num],
+            input_zp_i,
+            output_zp_i,
+            shift_i[i],
+            max_int_i,
+            min_int_i,
+            double_round_i,
+            multiplier_i[i],
+        )
 
     data_str += [format_vector_definition("int8_t", "D8", D8)]
 

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/params.hjson
@@ -22,7 +22,7 @@
   K: 18,
   N: 2,
   M: 1,
-  bypassSIMD: 1,
+  bypassSIMD: 0,
   channel_en_C: 0,
   ifTestMatmul: 1,
 

--- a/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
@@ -87,12 +87,15 @@ int main() {
             gen_subtraction_config(subtraction_a, subtraction_b);
 
         uint32_t csr0 =
-            gen_csr0_config(input_zp_i, output_zp_i, shift_i, max_int_i);
-        uint32_t csr1 = gen_csr1_config(min_int_i, double_round_i);
-        uint32_t csr2 = gen_csr2_config(multiplier_i);
+            gen_csr0_config(input_zp_i, output_zp_i, max_int_i, min_int_i);
+        uint32_t csr1 = gen_csr1_config(double_round_i);
 
-        set_gemmx_csr(K, N, M, subtraction_setting, csr0, csr1, csr2, M * N,
-                      bypassSIMD);
+        set_gemmx_csr(
+            K, N, M, subtraction_setting, csr0, csr1, shared_bitpacked_shift0,
+            shared_bitpacked_shift1, shared_multiplier0, shared_multiplier1,
+            shared_multiplier2, shared_multiplier3, shared_multiplier4,
+            shared_multiplier5, shared_multiplier6, shared_multiplier7, M * N,
+            bypassSIMD);
 
         // Set CSR to start GEMM
         set_gemmx_start();

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -10,6 +10,35 @@
 
 #pragma once
 
+#define GEMMX_CSR_ADDR_BASE (STREAMER_PERFORMANCE_COUNTER_CSR + 1)
+#define T_BOUND_K (GEMMX_CSR_ADDR_BASE)
+#define T_BOUND_N (T_BOUND_K + 1)
+#define T_BOUND_M (T_BOUND_N + 1)
+
+#define SUBTRACTIONS (T_BOUND_M + 1)
+
+#define SIMD_CSR0 (SUBTRACTIONS + 1)
+#define SIMD_CSR1 (SIMD_CSR0 + 1)
+
+#define SIMD_SHARED_BITPACKED_SHIFT0 (SIMD_CSR1 + 1)
+#define SIMD_SHARED_BITPACKED_SHIFT1 (SIMD_SHARED_BITPACKED_SHIFT0 + 1)
+
+#define SIMD_SHARED_MULTIPLIER0 (SIMD_SHARED_BITPACKED_SHIFT1 + 1)
+#define SIMD_SHARED_MULTIPLIER1 (SIMD_SHARED_MULTIPLIER0 + 1)
+#define SIMD_SHARED_MULTIPLIER2 (SIMD_SHARED_MULTIPLIER1 + 1)
+#define SIMD_SHARED_MULTIPLIER3 (SIMD_SHARED_MULTIPLIER2 + 1)
+#define SIMD_SHARED_MULTIPLIER4 (SIMD_SHARED_MULTIPLIER3 + 1)
+#define SIMD_SHARED_MULTIPLIER5 (SIMD_SHARED_MULTIPLIER4 + 1)
+#define SIMD_SHARED_MULTIPLIER6 (SIMD_SHARED_MULTIPLIER5 + 1)
+#define SIMD_SHARED_MULTIPLIER7 (SIMD_SHARED_MULTIPLIER6 + 1)
+
+#define TEMPORAL_LOOP_BOUND (SIMD_SHARED_MULTIPLIER7 + 1)
+#define BYPASS_SIMD (TEMPORAL_LOOP_BOUND + 1)
+
+#define GEMMX_START (BYPASS_SIMD + 1)
+#define GEMMX_BUSY (GEMMX_START + 1)
+#define GEMMX_PERFORMANCE_COUNTER (GEMMX_BUSY + 1)
+
 // Pack matrix size setting to one CSR
 int32_t gen_size_config(uint8_t Batch, uint8_t M, uint8_t K, uint8_t N);
 
@@ -18,13 +47,10 @@ int32_t gen_subtraction_config(int8_t subtraction_a, int8_t subtraction_b);
 
 // generate the configuration for CSR0
 int32_t gen_csr0_config(uint8_t input_zp_i, uint8_t output_zp_i,
-                        uint8_t shift_i, uint8_t max_int_i);
+                        uint8_t max_int_i, uint8_t min_int_i);
 
 // generate the configuration for CSR1
-int32_t gen_csr1_config(uint8_t min_int_i, bool double_round_i);
-
-// generate the configuration for CSR2
-int32_t gen_csr2_config(uint32_t multiplier_i);
+int32_t gen_csr1_config(bool double_round_i);
 
 // Set STREAMER configuration CSR
 void set_gemmx_streamer_csr(
@@ -55,8 +81,12 @@ void set_gemmx_streamer_start();
 // Set GEMM configuration CSR
 void set_gemmx_csr(int tempLoop0, int tempLoop1, int tempLoop2,
                    int subtractions, uint32_t csr0, uint32_t csr1,
-                   uint32_t csr2, uint32_t temporal_loop_bound,
-                   uint32_t bypassSIMD);
+                   int shared_bitpacked_shift0, int shared_bitpacked_shift1,
+                   int shared_multiplier0, int shared_multiplier1,
+                   int shared_multiplier2, int shared_multiplier3,
+                   int shared_multiplier4, int shared_multiplier5,
+                   int shared_multiplier6, int shared_multiplier7,
+                   uint32_t temporal_loop_bound, uint32_t bypassSIMD);
 
 // Set CSR to start GEMM
 void set_gemmx_start();


### PR DESCRIPTION
In this PR, we add scale factors for each channel, which is 8 for the GeMMX. Specifically, we add:
* supporting logic in the SIMD, mainly added more CSRs and the control signals to assign the correct CSR to correct PE
* relevant changes in hw cfg and gemmx wrapper with regard to the increased number of CSRs
* relevant software modification, mainly added more CSRs
* relevant test and golden data generation. The software test performs channel-wise rescale now
* some automatic scala file formatting

Note: This is only a functional fix of the SIMD. The critical path issue will be addressed later.
A bug fix of pipe parameter in GeMMX!