### PR TITLE
snitch multichip simulation log

### DIFF
--- a/hw/future/src/dma/axi_dma_backend.sv
+++ b/hw/future/src/dma/axi_dma_backend.sv
@@ -57,7 +57,7 @@ module axi_dma_backend #(
     /// Asynchronous reset, active low
     input  logic                        rst_ni,
     /// Cluster base address, just for correct logging
-    input  addr_t                       cluster_base_addr_i,
+    input  [7:0]                        chip_id_i,
     /// AXI4+ATOP master request
     output axi_req_t                    axi_dma_req_o,
     /// AXI4+ATOP master response
@@ -300,8 +300,8 @@ module axi_dma_backend #(
       // open file
       initial begin
         #1;
-        $sformat(fn, "logs/trace_chip_%01x%01x_dma_%05x.log", cluster_base_addr_i[47:44],
-                 cluster_base_addr_i[43:40], dma_id_i);
+        $sformat(fn, "logs/trace_chip_%01x%01x_dma_%05x.log", chip_id_i[7:4],
+                 chip_id_i[3:0], dma_id_i);
         f = $fopen(fn, "w");
         $display("[Tracer] Logging DMA %d to %s", dma_id_i, fn);
       end

--- a/hw/future/src/dma/axi_dma_backend.sv
+++ b/hw/future/src/dma/axi_dma_backend.sv
@@ -300,7 +300,8 @@ module axi_dma_backend #(
       // open file
       initial begin
         #1;
-        $sformat(fn, "logs/trace_chip_%02x%02x_dma_%05x.log", cluster_base_addr_i[47:44], cluster_base_addr_i[43:40], dma_id_i);
+        $sformat(fn, "logs/trace_chip_%02x%02x_dma_%05x.log", cluster_base_addr_i[47:44],
+                 cluster_base_addr_i[43:40], dma_id_i);
         f = $fopen(fn, "w");
         $display("[Tracer] Logging DMA %d to %s", dma_id_i, fn);
       end

--- a/hw/future/src/dma/axi_dma_backend.sv
+++ b/hw/future/src/dma/axi_dma_backend.sv
@@ -300,7 +300,7 @@ module axi_dma_backend #(
       // open file
       initial begin
         #1;
-        $sformat(fn, "logs/trace_chip_%02x%02x_dma_%05x.log", cluster_base_addr_i[47:44],
+        $sformat(fn, "logs/trace_chip_%01x%01x_dma_%05x.log", cluster_base_addr_i[47:44],
                  cluster_base_addr_i[43:40], dma_id_i);
         f = $fopen(fn, "w");
         $display("[Tracer] Logging DMA %d to %s", dma_id_i, fn);

--- a/hw/future/src/dma/axi_dma_backend.sv
+++ b/hw/future/src/dma/axi_dma_backend.sv
@@ -48,13 +48,18 @@ module axi_dma_backend #(
     /// Give each DMA backend a unique id
     parameter int unsigned DmaIdWidth     = -1,
     /// Enable or disable tracing
-    parameter bit          DmaTracing     = 0
+    parameter bit          DmaTracing     = 0,
+
+    parameter type            addr_t      = logic [AddrWidth-1:0]
+
 
 ) (
     /// Clock
     input  logic                        clk_i,
     /// Asynchronous reset, active low
     input  logic                        rst_ni,
+    /// Cluster base address, just for correct logging
+    input  addr_t                       cluster_base_addr_i,
     /// AXI4+ATOP master request
     output axi_req_t                    axi_dma_req_o,
     /// AXI4+ATOP master response
@@ -299,7 +304,7 @@ module axi_dma_backend #(
       // open file
       initial begin
         #1;
-        $sformat(fn, "dma_trace_%05x.log", dma_id_i);
+        $sformat(fn, "logs/chip_%02x_%02x/dma_trace_%05x.log", cluster_base_addr_i[47:44], cluster_base_addr_i[43:40], dma_id_i);
         f = $fopen(fn, "w");
         $display("[Tracer] Logging DMA %d to %s", dma_id_i, fn);
       end

--- a/hw/future/src/dma/axi_dma_backend.sv
+++ b/hw/future/src/dma/axi_dma_backend.sv
@@ -49,10 +49,8 @@ module axi_dma_backend #(
     parameter int unsigned DmaIdWidth     = -1,
     /// Enable or disable tracing
     parameter bit          DmaTracing     = 0,
-
+    /// Address type
     parameter type            addr_t      = logic [AddrWidth-1:0]
-
-
 ) (
     /// Clock
     input  logic                        clk_i,
@@ -84,8 +82,6 @@ module axi_dma_backend #(
   localparam int unsigned OffsetWidth = $clog2(StrobeWidth);
   /// Offset type
   typedef logic [OffsetWidth-1:0] offset_t;
-  /// Address Type
-  typedef logic [AddrWidth-1:0] addr_t;
   /// AXI ID Type
   typedef logic [IdWidth-1:0] axi_id_t;
 
@@ -304,7 +300,7 @@ module axi_dma_backend #(
       // open file
       initial begin
         #1;
-        $sformat(fn, "logs/chip_%02x_%02x/dma_trace_%05x.log", cluster_base_addr_i[47:44], cluster_base_addr_i[43:40], dma_id_i);
+        $sformat(fn, "logs/trace_chip_%02x%02x_dma_%05x.log", cluster_base_addr_i[47:44], cluster_base_addr_i[43:40], dma_id_i);
         f = $fopen(fn, "w");
         $display("[Tracer] Logging DMA %d to %s", dma_id_i, fn);
       end

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -388,6 +388,7 @@ module snitch_cc #(
     ) i_axi_dma_tc_snitch_fe (
       .clk_i            ( clk_i                     ),
       .rst_ni           ( rst_ni                    ),
+      .cluster_base_addr_i ( tcdm_addr_base_i       ),
       .axi_dma_req_o    ( axi_dma_req_o             ),
       .axi_dma_res_i    ( axi_dma_res_i             ),
       .dma_busy_o       ( axi_dma_busy_o            ),
@@ -852,7 +853,7 @@ module snitch_cc #(
     #0;
 `endif
     $system("mkdir logs -p");
-    $sformat(fn, "logs/trace_hart_%05x.dasm", hart_id_i);
+    $sformat(fn, "logs/chip_%02x_%02x/trace_hart_%05x.dasm", tcdm_addr_base_i[47:44], tcdm_addr_base_i[43:40], hart_id_i);
     f = $fopen(fn, "w");
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
   end

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -852,8 +852,8 @@ module snitch_cc #(
 `ifndef VERILATOR
     #0;
 `endif
-    $system("mkdir logs -p");
-    $sformat(fn, "logs/chip_%02x_%02x/trace_hart_%05x.dasm", tcdm_addr_base_i[47:44], tcdm_addr_base_i[43:40], hart_id_i);
+    $system("mkdir -p logs");
+    $sformat(fn, "logs/trace_chip_%02x%02x_hart_%05x.dasm", tcdm_addr_base_i[47:44], tcdm_addr_base_i[43:40], hart_id_i);
     f = $fopen(fn, "w");
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
   end

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -853,7 +853,8 @@ module snitch_cc #(
     #0;
 `endif
     $system("mkdir -p logs");
-    $sformat(fn, "logs/trace_chip_%02x%02x_hart_%05x.dasm", tcdm_addr_base_i[47:44], tcdm_addr_base_i[43:40], hart_id_i);
+    $sformat(fn, "logs/trace_chip_%02x%02x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
+             tcdm_addr_base_i[43:40], hart_id_i);
     f = $fopen(fn, "w");
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
   end

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -853,7 +853,7 @@ module snitch_cc #(
     #0;
 `endif
     $system("mkdir -p logs");
-    $sformat(fn, "logs/trace_chip_%02x%02x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
+    $sformat(fn, "logs/trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
              tcdm_addr_base_i[43:40], hart_id_i);
     f = $fopen(fn, "w");
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -850,7 +850,7 @@ module snitch_cc #(
     // `hart_id_i` won't have a value assigned at the beginning of the first
     // delta cycle.
 `ifndef VERILATOR
-    #0;
+    #1;
 `endif
     $system("mkdir -p logs");
     $sformat(fn, "logs/trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],

--- a/hw/snitch_dma/src/axi_dma_tc_snitch_fe.sv
+++ b/hw/snitch_dma/src/axi_dma_tc_snitch_fe.sv
@@ -103,7 +103,8 @@ module axi_dma_tc_snitch_fe #(
     ) i_axi_dma_backend (
         .clk_i            ( clk_i               ),
         .rst_ni           ( rst_ni              ),
-        .cluster_base_addr_i(cluster_base_addr_i),
+        // Chip ID is retrieved from base_addr, and is hard coded here
+        .chip_id_i        (cluster_base_addr_i[47:40]),
         .axi_dma_req_o    ( axi_dma_req_o       ),
         .axi_dma_res_i    ( axi_dma_res_i       ),
         .burst_req_i      ( burst_req           ),

--- a/hw/snitch_dma/src/axi_dma_tc_snitch_fe.sv
+++ b/hw/snitch_dma/src/axi_dma_tc_snitch_fe.sv
@@ -26,6 +26,7 @@ module axi_dma_tc_snitch_fe #(
 ) (
     input  logic           clk_i,
     input  logic           rst_ni,
+    input  addr_t          cluster_base_addr_i,
     // AXI4 bus
     output axi_req_t       axi_dma_req_o,
     input  axi_res_t       axi_dma_res_i,
@@ -102,6 +103,7 @@ module axi_dma_tc_snitch_fe #(
     ) i_axi_dma_backend (
         .clk_i            ( clk_i               ),
         .rst_ni           ( rst_ni              ),
+        .cluster_base_addr_i(cluster_base_addr_i),
         .axi_dma_req_o    ( axi_dma_req_o       ),
         .axi_dma_res_i    ( axi_dma_res_i       ),
         .burst_req_i      ( burst_req           ),


### PR DESCRIPTION
This PR renames the log of cores and DMAs during the simulation to avoid the log being overridden by core at the same position of one chip, but at different chips. 