### PR TITLE
Fix CI snitch cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     name: Simulate SW on Snitch Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/pulp-platform/snitch_cluster:main
+      image: ghcr.io/kuleuven-micas/snax:main
     steps:
       - uses: actions/checkout@v2
         with:
@@ -58,9 +58,8 @@ jobs:
         working-directory: target/snitch_cluster
         run: |
           ./run.py --simulator verilator \
-          sw/runtime.yaml sw/snitch-cluster-runtime.yaml sw/custom-fp.yaml \
-          sw/standard-fp.yaml sw/openmp.yaml sw/snitch-cluster-openmp.yaml \
-          sw/blas.yaml sw/dnn.yaml -j
+          sw/runtime.yaml \
+          sw/standard-fp.yaml -j
 
   ##############################################
   # Simulate SW on SNAX Cluster w/ Verilator #


### PR DESCRIPTION
This PR prunes tests that are not applicable to the build for snitch cluster

Currently, there are several changes from the original PULP snitch_cluster. One in particular actually breaks our CI:

https://github.com/pulp-platform/snitch_cluster/commit/379ae99bfbe9d7a6892cf7984fd471846bf8769f

There are actually 2 options to move forward, since our development is different now from the original Snitch cluster:

1. We use our own docker but only prune the tests that work. At least we check that it builds but we cannot test FP (note that we are not using the latest FP unit anymore. Due to not rebasing on top of their main, we cannot follow up with it).

2. We take out the snitch_cluster from our CI. It doesn't make sense to have it tested on our side anyway because (1) we're not using Snitch cluster and (2) there are several changes in the original pulp snitch that are not added here. We have totally branched out and will never be rebasing from the main again.

With the tapeout at hand, I believe no RTL person has time to check and fix the Snitch cluster. So this is just a proposed fixed to make sure CI is clean.