### PR TITLE
docker: add vcd-to-csv

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -97,6 +97,9 @@ ENV VERIBLE_VERSION 0.0-3644-g6882622d
 # Bender
 COPY --from=build-bender /root/.cargo/bin/bender /usr/bin/bender
 
+# vcd-to-csv
+RUN wget https://github.com/KULeuven-MICAS/vcd-to-csv/releases/download/v0.1.2/vcd-to-csv -P /usr/bin && chmod +x /usr/bin/vcd-to-csv
+
 # spike-dasm
 RUN wget https://github.com/pulp-platform/riscv-isa-sim/releases/download/snitch-v0.1.0/snitch-spike-dasm-0.1.0-x86_64-linux-gnu-ubuntu18.04.tar.gz && \
     tar xzf snitch-spike-dasm-0.1.0-x86_64-linux-gnu-ubuntu18.04.tar.gz && \

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -98,7 +98,7 @@ ENV VERIBLE_VERSION 0.0-3644-g6882622d
 COPY --from=build-bender /root/.cargo/bin/bender /usr/bin/bender
 
 # vcd-to-csv
-RUN wget https://github.com/KULeuven-MICAS/vcd-to-csv/releases/download/v0.1.2/vcd-to-csv -P /usr/bin && chmod +x /usr/bin/vcd-to-csv
+RUN wget https://github.com/KULeuven-MICAS/vcd-to-csv/releases/latest/download/vcd-to-csv -P /usr/bin && chmod +x /usr/bin/vcd-to-csv
 
 # spike-dasm
 RUN wget https://github.com/pulp-platform/riscv-isa-sim/releases/download/snitch-v0.1.0/snitch-spike-dasm-0.1.0-x86_64-linux-gnu-ubuntu18.04.tar.gz && \


### PR DESCRIPTION
This tool can be used to generate csv files from a clocked vcd trace. For (limited for now) documentation see https://github.com/KULeuven-MICAS/vcd-to-csv

Tool is only `0.5MB` so does not come with a large overhead