### PR TITLE
[WIP] Adding pipe registers within Snitch data path

### DIFF
--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -358,6 +358,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   assign core_events_o = '0;
   `endif
 
+  // Pipe-lining some input signals
+  addr_t cluster_base_addr_reg;
+  `FFAR(cluster_base_addr_reg, cluster_base_addr_i, '0, clk_i, rst_i)
+
   logic [AddrWidth-32-1:0] mseg_q, mseg_d;
   `FFAR(mseg_q, mseg_d, cluster_base_addr_i[AddrWidth - 1 : 32], clk_i, rst_i)
 
@@ -423,7 +427,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // If trans_active is high (under VM mode), the virtual memory is replaced by translated hardware address; otherwise, the address is prepended by the chiplet base address.
   assign inst_addr_o[PPNSize+PageShift-1:PageShift] =
       ({(PPNSize){trans_active}} & itlb_pa)
-    | (~{(PPNSize){trans_active}} & {cluster_base_addr_i[AddrWidth-1:32], pc_q[31:PageShift]});
+    | (~{(PPNSize){trans_active}} & {cluster_base_addr_reg[AddrWidth-1:32], pc_q[31:PageShift]});
   assign inst_addr_o[PageShift-1:0] = pc_q[PageShift-1:0];
   assign inst_cacheable_o = snitch_pma_pkg::is_inside_cacheable_regions(SnitchPMACfg, inst_addr_o);
   assign inst_valid_o = ~wfi_q && ~csr_stall_q;
@@ -2463,10 +2467,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
             if (!exception) mseg_d = alu_result[$bits(mseg_q)-1:0];
           end
           CsrBaseAddrL: begin
-            csr_rvalue = cluster_base_addr_i[31:0];
+            csr_rvalue = cluster_base_addr_reg[31:0];
           end
           CsrBaseAddrH: begin
-            csr_rvalue = {{(64 - AddrWidth){1'b0}}, cluster_base_addr_i[AddrWidth - 1:32]};
+            csr_rvalue = {{(64 - AddrWidth){1'b0}}, cluster_base_addr_reg[AddrWidth - 1:32]};
           end
           CsrClusterCoreId: begin
             csr_rvalue = cluster_core_id_i;


### PR DESCRIPTION
This PR tries to increase operating frequency by adding pipe registers to different paths within the Snitch cores.
With these pipes we can aim to reach 1 GHz.

Major TODO:
- [x] Pipe the cluster_base_addr_i
