### PR TITLE
New Datapath Extension: Broadcaster

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/Broadcaster.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/Broadcaster.scala
@@ -1,0 +1,33 @@
+package snax.DataPathExtension
+
+import chisel3._
+import chisel3.util._
+import snax.xdma.DesignParams._
+
+object HasBroadcaster256to2048 extends HasDataPathExtension {
+  implicit val extensionParam: DataPathExtensionParam =
+    new DataPathExtensionParam(
+      moduleName = "Broadcaster256to2048",
+      userCsrNum = 0,
+      dataWidth = 2048
+    )
+  def instantiate(clusterName: String): Broadcaster = Module(
+    new Broadcaster(256) {
+      override def desiredName = clusterName + namePostfix
+    }
+  )
+}
+
+class Broadcaster(inputUsefulDatawidth: Int)(implicit
+    extensionParam: DataPathExtensionParam
+) extends DataPathExtension {
+
+  ext_data_i.ready := ext_data_o.ready
+  ext_data_o.valid := ext_data_i.valid
+
+  val inputUsefulData = ext_data_i.bits(inputUsefulDatawidth - 1, 0)
+  ext_data_o.bits := VecInit(
+    Seq.fill(extensionParam.dataWidth / inputUsefulDatawidth)(inputUsefulData)
+  ).asUInt
+  ext_busy_o := false.B
+}

--- a/hw/chisel/src/main/scala/snax/streamer/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DesignParams.scala
@@ -22,6 +22,9 @@ class StreamerParam(
     // transpose params
     val hasTranspose: Boolean = false,
 
+    // c broadcast params
+    val hasCBroadcast: Boolean = false,
+
     // csr manager params
     val csrAddrWidth: Int,
     val tagName: String = "Test",
@@ -86,13 +89,28 @@ class StreamerParam(
     )
   }
 
-  val dataPathExtensionParam: Seq[HasDataPathExtension] =
+  val dataPathABExtensionParam: Seq[HasDataPathExtension] =
     (if (hasTranspose)
        Seq[HasDataPathExtension](
          HasTransposer
        )
      else
        Seq[HasDataPathExtension]())
+
+  val dataPathCExtensionParam: Seq[HasDataPathExtension] =
+    (if (hasCBroadcast)
+       Seq[HasDataPathExtension](
+         HasBroadcaster256to2048
+       )
+     else
+       Seq[HasDataPathExtension]())
+  if (hasCBroadcast) {
+    require(
+      fifoWidthReaderWriter.forall(_ == 2048),
+      "CBroadcast only supports for readers with the same 2048 data width"
+    )
+  }
+  
 }
 
 object StreamerParam {
@@ -121,6 +139,7 @@ object StreamerParam {
       writerParams: Seq[ReaderWriterParam],
       readerWriterParams: Seq[ReaderWriterParam],
       hasTranspose: Boolean,
+      hasCBroadcast: Boolean,
       csrAddrWidth: Int,
       tagName: String,
       headerFilepath: String
@@ -129,6 +148,7 @@ object StreamerParam {
     writerParams = writerParams,
     readerWriterParams = readerWriterParams,
     hasTranspose = hasTranspose,
+    hasCBroadcast = hasCBroadcast,
     csrAddrWidth = csrAddrWidth,
     tagName = tagName,
     headerFilepath = headerFilepath

--- a/hw/chisel/src/main/scala/snax/streamer/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DesignParams.scala
@@ -110,7 +110,7 @@ class StreamerParam(
       "CBroadcast only supports for readers with the same 2048 data width"
     )
   }
-  
+
 }
 
 object StreamerParam {

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -595,8 +595,8 @@ class StreamerHeaderFile(param: StreamerParam) {
 
   // c broadcast csr configuration
   csrBase = csrBase + (if (param.hasTranspose)
-              param.readerParams.length
-            else 0)
+                         param.readerParams.length
+                       else 0)
   if (param.hasCBroadcast) {
     csrMap = csrMap + "#define C_BROADCAST_EXTENSION_ENABLE \n"
     for (i <- 0 until param.readerWriterParams.length / 2) {

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -105,7 +105,11 @@ class Streamer(
   val csrNumReadWrite =
     reader_csr + writer_csr + reader_writer_csr + (if (param.hasTranspose)
                                                      param.readerParams.length
-                                                   else 0) + 1
+                                                   else
+                                                     0) + (if (
+                                                             param.hasCBroadcast
+                                                           ) param.readerWriterParams.length / 2
+                                                           else 0) + 1
 
   // csrManager instantiation
   val csrManager = Module(
@@ -159,7 +163,7 @@ class Streamer(
   val readerExtensions = (0 until param.readerParams.length).map { i =>
     Module(
       new DataPathExtensionHost(
-        extensionList = param.dataPathExtensionParam,
+        extensionList = param.dataPathABExtensionParam,
         dataWidth = param.fifoWidthReader(i),
         headCut = false,
         tailCut = false,
@@ -167,6 +171,21 @@ class Streamer(
         moduleNamePrefix = param.tagName
       )
     )
+  }
+
+  // c broadcast module instantiation for reader
+  val readerCExtention = (0 until param.readerWriterParams.length / 2).map {
+    i =>
+      Module(
+        new DataPathExtensionHost(
+          extensionList = param.dataPathCExtensionParam,
+          dataWidth = param.fifoWidthReaderWriter(i),
+          headCut = false,
+          tailCut = false,
+          halfCut = false,
+          moduleNamePrefix = param.tagName
+        )
+      )
   }
 
   // --------------------------------------------------------------------------------
@@ -261,6 +280,10 @@ class Streamer(
     readerExtensions(i).io.start := streamer_config_fire
   }
 
+  for (i <- 0 until param.readerWriterParams.length / 2) {
+    readerCExtention(i).io.start := streamer_config_fire
+  }
+
   // --------------------------------------------------------------------------------
   // ---------------------- csr manager connection----------------------------------------------
   // --------------------------------------------------------------------------------
@@ -342,6 +365,11 @@ class Streamer(
     remainingCSR = readerExtensions(i).io.connectCfgWithList(
       remainingCSR
     )
+  }
+
+  // c broadcast
+  for (i <- 0 until param.readerWriterParams.length / 2) {
+    remainingCSR = readerCExtention(i).io.connectCfgWithList(remainingCSR)
   }
 
   // 1 left csr for start signal
@@ -431,12 +459,19 @@ class Streamer(
           .data(i - param.readerNum)
       } else {
         // reader_writer
+        // reader C broadcast extension
         reader_writer_idx = (i - param.readerNum - param.writerNum) / 2
         reader_writer(
           reader_writer_idx
-        ).io.readerInterface.data <> io.data.streamer2accelerator.data(
+        ).io.readerInterface.data <> readerCExtention(
+          reader_writer_idx
+        ).io.data.in
+        readerCExtention(
+          reader_writer_idx
+        ).io.data.out <> io.data.streamer2accelerator.data(
           reader_writer_idx + param.readerNum
         )
+
         reader_writer(
           reader_writer_idx
         ).io.writerInterface.data <> io.data.accelerator2streamer
@@ -503,66 +538,80 @@ class StreamerHeaderFile(param: StreamerParam) {
   }
 
   var csrBase = 0
+  var csrBase_i = 0
   var csrMap = ""
 
   // reader csr configuration
+  csrBase = 960
   for (i <- 0 until param.readerNum) {
-    csrBase = 960 + param.readerParams
+    csrBase_i = csrBase + param.readerParams
       .take(i)
       .map(_.csrNum)
       .reduceLeftOption(_ + _)
       .getOrElse(0)
-    csrMap = csrMap + genCSRMap(csrBase, param.readerParams(i), "READER_" + i)
+    csrMap = csrMap + genCSRMap(csrBase_i, param.readerParams(i), "READER_" + i)
   }
 
   // writer csr configuration
+  csrBase = 960 + param.readerParams.map(_.csrNum).sum
   for (i <- 0 until param.writerNum) {
-    csrBase = 960 + param.readerParams.map(_.csrNum).sum + param.writerParams
+    csrBase_i = csrBase + param.writerParams
       .take(i)
       .map(_.csrNum)
       .reduceLeftOption(_ + _)
       .getOrElse(0)
-    csrMap = csrMap + genCSRMap(csrBase, param.writerParams(i), "WRITER_" + i)
+    csrMap = csrMap + genCSRMap(csrBase_i, param.writerParams(i), "WRITER_" + i)
   }
 
   // reader_writer csr configuration
+  csrBase = csrBase + param.writerParams
+    .map(_.csrNum)
+    .sum
   for (i <- 0 until param.readerWriterNum) {
-    csrBase = 960 + param.readerParams.map(_.csrNum).sum + param.writerParams
-      .map(_.csrNum)
-      .sum + param.readerWriterParams
+    csrBase_i = csrBase + param.readerWriterParams
       .take(i)
       .map(_.csrNum)
       .reduceLeftOption(_ + _)
       .getOrElse(0)
     csrMap = csrMap + genCSRMap(
-      csrBase,
+      csrBase_i,
       param.readerWriterParams(i),
       "READER_WRITER_" + i
     )
   }
 
   // extension csr configuration
+  csrBase = csrBase + param.readerWriterParams
+    .map(_.csrNum)
+    .sum
   if (param.hasTranspose) {
-    for (i <- 0 until param.readerParams.length) {
-      csrBase = 960 + param.readerParams.map(_.csrNum).sum + param.writerParams
-        .map(_.csrNum)
-        .sum + param.readerWriterParams.map(_.csrNum).sum + i
-      csrMap =
-        csrMap + "#define TRANSPOSE_CSR_READER_" + i + " " + csrBase + "\n"
-    }
     csrMap = csrMap + "#define TRANSPOSE_EXTENSION_ENABLE \n"
+    for (i <- 0 until param.readerParams.length) {
+      csrBase_i = csrBase + i
+      csrMap =
+        csrMap + "#define TRANSPOSE_CSR_READER_" + i + " " + csrBase_i + "\n"
+    }
+  }
+
+  // c broadcast csr configuration
+  csrBase = csrBase + (if (param.hasTranspose)
+              param.readerParams.length
+            else 0)
+  if (param.hasCBroadcast) {
+    csrMap = csrMap + "#define C_BROADCAST_EXTENSION_ENABLE \n"
+    for (i <- 0 until param.readerWriterParams.length / 2) {
+      csrBase_i = csrBase + i
+      csrMap =
+        csrMap + "#define C_BROADCAST_CSR_READER_WRITER_" + i + " " + csrBase_i + "\n"
+    }
   }
 
   // start csr
   csrMap = csrMap + "// Other resgiters\n"
   csrMap = csrMap + "// Status register\n"
-  csrBase = 960 + param.readerParams.map(_.csrNum).sum + param.writerParams
-    .map(_.csrNum)
-    .sum + param.readerWriterParams
-    .map(_.csrNum)
-    .sum + (if (param.hasTranspose)
-              param.readerParams.length
-            else 0)
+  csrBase = csrBase + (if (param.hasCBroadcast)
+                         param.readerWriterParams.length / 2
+                       else 0)
   csrMap = csrMap + "#define STREAMER_START_CSR " + csrBase + "\n"
 
   // streamer busy csr

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/BroadcasterTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/BroadcasterTester.scala
@@ -1,0 +1,26 @@
+package snax.DataPathExtension
+
+import chisel3._
+import chisel3.util._
+
+import scala.util.Random
+import snax.DataPathExtension.HasBroadcaster256to2048
+
+class BroadcasterTester extends DataPathExtensionTester {
+
+  def hasExtension = HasBroadcaster256to2048
+
+  val csr_vec = Seq()
+
+  val input_data_vec = for (i <- 0 until 1024) yield {
+    BigInt.apply(256, Random)
+  }
+
+  val output_data_vec = for (i <- input_data_vec) yield {
+    var output_data = BigInt(0)
+    for (j <- 0 until 8) {
+      output_data = (output_data << 256) + i
+    }
+    output_data
+  }
+}

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/DataPathExtensionTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/DataPathExtensionTester.scala
@@ -1,4 +1,4 @@
-package snax.xdma.xdmaExtension
+package snax.DataPathExtension
 
 import chisel3._
 import chisel3.util._
@@ -24,7 +24,7 @@ import snax.DataPathExtension.HasDataPathExtension
   * and verify output data's correctness.
   */
 
-class DMAExtensionHarness(extension: HasDataPathExtension)
+class DataPathExtensionHarness(extension: HasDataPathExtension)
     extends Module
     with RequireAsyncReset {
   val dut = extension.instantiate("dma_extension_dut")
@@ -39,7 +39,7 @@ class DMAExtensionHarness(extension: HasDataPathExtension)
   dut.io.data_o -||> io.data_o
 }
 
-abstract class DMAExtensionTester
+abstract class DataPathExtensionTester
     extends AnyFlatSpec
     with ChiselScalatestTester {
   val csr_vec: Seq[Int]
@@ -48,7 +48,7 @@ abstract class DMAExtensionTester
   def hasExtension: HasDataPathExtension
 
   hasExtension.extensionParam.moduleName should "pass" in {
-    test(new DMAExtensionHarness(hasExtension))
+    test(new DataPathExtensionHarness(hasExtension))
       .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
         dut =>
           dut.io.csr_i.zip(csr_vec).foreach { case (csrPort, csrData) =>

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/MaxPoolTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/MaxPoolTester.scala
@@ -1,20 +1,12 @@
-package snax.xdma.xdmaExtension
+package snax.DataPathExtension
 
 import chisel3._
 import chisel3.util._
 
-// Hardware and its Generation Param
-import snax.xdma.DesignParams._
-import snax.utils.DecoupledCut._
-
-// Import Chiseltest
-import org.scalatest.flatspec.AnyFlatSpec
-import chiseltest._
-
 import scala.util.Random
 import snax.DataPathExtension.HasMaxPool
 
-class MaxPoolTester extends DMAExtensionTester {
+class MaxPoolTester extends DataPathExtensionTester {
 
   def hasExtension = HasMaxPool
 

--- a/hw/templates/stream_param_gen.scala.tpl
+++ b/hw/templates/stream_param_gen.scala.tpl
@@ -116,6 +116,12 @@ ${'   ), ' if not loop.last else '    )'}
   def hasTranspose = false
 % endif
 
+% if "has_C_broadcast" in cfg["snax_streamer_cfg"] and cfg["snax_streamer_cfg"]["has_C_broadcast"]:
+  def hasCBroadcast = true
+% else:
+  def hasCBroadcast = false
+% endif
+
   def headerFilepath = "../../target/snitch_cluster/sw/snax/${cfg["snax_streamer_cfg"]["snax_library_name"]}/include"
 }
 
@@ -131,6 +137,7 @@ object StreamerGen {
           writerParams = StreamerParametersGen.writerParams,
           readerWriterParams = StreamerParametersGen.readerWriterParams,
           hasTranspose = StreamerParametersGen.hasTranspose,
+          hasCBroadcast = StreamerParametersGen.hasCBroadcast,
           csrAddrWidth = 32,
           tagName = "${cfg["tag_name"]}_",
           headerFilepath = StreamerParametersGen.headerFilepath
@@ -149,6 +156,7 @@ object StreamerHeaderFileGen {
         writerParams = StreamerParametersGen.writerParams,
         readerWriterParams = StreamerParametersGen.readerWriterParams,
         hasTranspose = StreamerParametersGen.hasTranspose,
+        hasCBroadcast = StreamerParametersGen.hasCBroadcast,
         csrAddrWidth = 32,
         tagName = "${cfg["tag_name"]}_",
         headerFilepath = StreamerParametersGen.headerFilepath

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
@@ -221,6 +221,8 @@
 
         has_transpose: true,
 
+        has_C_broadcast: true,
+
         snax_library_name: "gemmx",
     },
     // SNAX Streamer Templates

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
@@ -202,6 +202,8 @@
 
         has_transpose: true,
 
+        has_C_broadcast: true,
+
         snax_library_name: "gemmx",
     }
 }

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/params.hjson
@@ -23,7 +23,7 @@
   N: 2,
   M: 1,
   bypassSIMD: 0,
-  broadcast_C: 0,
+  broadcast_C: 1,
   channel_en_C: 1,
   ifTestMatmul: 1,
 

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/params.hjson
@@ -23,7 +23,8 @@
   N: 2,
   M: 1,
   bypassSIMD: 0,
-  channel_en_C: 0,
+  broadcast_C: 0,
+  channel_en_C: 1,
   ifTestMatmul: 1,
 
   // hardware parameters

--- a/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
@@ -77,7 +77,7 @@ int main() {
 
             delta_local_a, delta_local_b, delta_local_d8, delta_local_c,
             delta_local_d32, bypassSIMD, transposed_A, transposed_B,
-            channel_en_C);
+            channel_en_C, broadcast_C);
 
         // Set GEMMX configuration CSR
         uint32_t subtraction_setting =

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -74,7 +74,7 @@ void set_gemmx_streamer_csr(
 
     int delta_local_a, int delta_local_b, int delta_local_d8, int delta_local_c,
     int delta_local_d32, int bypassSIMD, int32_t transpose_A,
-    int32_t transpose_B, int32_t channel_en_C);
+    int32_t transpose_B, int32_t channel_en_C, int32_t broadcast_C);
 
 // Set CSR to start STREAMER
 inline void set_gemmx_streamer_start() { csrw_ss(STREAMER_START_CSR, 1); }

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -53,7 +53,7 @@ void set_gemmx_streamer_csr(
 
     int delta_local_a, int delta_local_b, int delta_local_d8, int delta_local_c,
     int delta_local_d32, int bypassSIMD, int32_t transpose_A,
-    int32_t transpose_B, int32_t channel_en_C) {
+    int32_t transpose_B, int32_t channel_en_C, int32_t broadcast_C) {
     // base ptr for A
     csrw_ss(BASE_PTR_READER_0_LOW, (uint32_t)(delta_local_a + snrt_l1_next()));
 
@@ -133,6 +133,10 @@ void set_gemmx_streamer_csr(
 
 #ifdef ENABLED_CHANNEL_READER_WRITER_0
     csrw_ss(ENABLED_CHANNEL_READER_WRITER_0, channel_en_C);
+#endif
+
+#ifdef C_BROADCAST_EXTENSION_ENABLE
+    csrw_ss(C_BROADCAST_CSR_READER_WRITER_0, broadcast_C == 1 ? 0 : 1);
 #endif
 
     // base ptr for D32

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -203,6 +203,10 @@ def streamer_csr_num(acc_cfgs):
         if acc_cfgs["snax_streamer_cfg"]["has_transpose"]:
             streamer_csr_num += 2
 
+    if "has_C_broadcast" in acc_cfgs["snax_streamer_cfg"]:
+        if acc_cfgs["snax_streamer_cfg"]["has_C_broadcast"]:
+            streamer_csr_num += 1
+
     return streamer_csr_num
 
 


### PR DESCRIPTION
This PR introduces the new DataPath extension: by using this extension, C channel of streamer can reduce the unnecessary fetches from the reader. 

In this PR, we also add the broadcast C extension flag, especially for the gemm C32 readers. With this extension enabled, every output channel can share one bias. More specifically, we add:
* streamer with the has_C_broadcast flag support to enable the broadcast extension, none by default
* csr modification for the broadcast C extension, relevant sw test and snaxgen