### PR TITLE
Renaming of Chisel generated modules

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtension.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtension.scala
@@ -27,7 +27,7 @@ import snax.xdma.DesignParams._
 abstract class HasDataPathExtension {
   implicit val extensionParam: DataPathExtensionParam
 
-  def namePostfix = "_xdma_extension_" + extensionParam.moduleName
+  def namePostfix = "_DataPathExtension_" + extensionParam.moduleName
   def instantiate(clusterName: String): DataPathExtension
 }
 
@@ -88,7 +88,8 @@ abstract class DataPathExtension(implicit
   // Structure to bypass extension: Demux
   private[this] val inputDemux = Module(
     new DemuxDecoupled(UInt(extensionParam.dataWidth.W), numOutput = 2) {
-      override def desiredName = s"xdma_extension_inputDemux"
+      override def desiredName =
+        "DataPathExtension_Demux_W" + extensionParam.dataWidth.toString
     }
   )
   inputDemux.io.sel := io.bypass_i
@@ -101,7 +102,8 @@ abstract class DataPathExtension(implicit
   // Structure to bypass extension: Mux
   private[this] val outputMux = Module(
     new MuxDecoupled(UInt(extensionParam.dataWidth.W), numInput = 2) {
-      override def desiredName = s"xdma_extension_outputMux"
+      override def desiredName =
+        "DataPathExtension_Mux_W" + extensionParam.dataWidth.toString
     }
   )
   outputMux.io.sel := io.bypass_i

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/MaxPool.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/MaxPool.scala
@@ -48,7 +48,7 @@ class MaxPool(elementWidth: Int)(implicit
   // Counter to record the steps
   // 256-element MaxPool maximum
   val counter = Module(new snax.utils.BasicCounter(8) {
-    override val desiredName = "xdma_extension_MaxPoolCounter"
+    override val desiredName = "MaxPoolCounter"
   })
   counter.io.ceil := ext_csr_i(0)
   counter.io.reset := ext_start_i
@@ -63,7 +63,7 @@ class MaxPool(elementWidth: Int)(implicit
 
   val PEs = for (i <- 0 until extensionParam.dataWidth / elementWidth) yield {
     val PE = Module(new MAXPoolPE(dataWidth = elementWidth) {
-      override val desiredName = "xdma_extension_MaxPoolPE"
+      override val desiredName = "MaxPoolPE"
     })
     PE.io.init_i := counter.io.value === 0.U
     PE.io.data_i.valid := ext_data_i.fire

--- a/hw/chisel/src/main/scala/snax/readerWriter/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/AddressGenUnit.scala
@@ -99,7 +99,11 @@ class AddressGenUnit(
   // Create counters for each dimension
   val counters = for (i <- 0 until param.temporalDimension) yield {
     val counter = Module(
-      new ProgrammableCounter(param.addressWidth, hasCeil = true, s"${moduleNamePrefix}_AddressGenUnitCounter")
+      new ProgrammableCounter(
+        param.addressWidth,
+        hasCeil = true,
+        s"${moduleNamePrefix}_AddressGenUnitCounter"
+      )
     )
     counter.io.reset := io.start
     // counter.io.tick is conenected later, when all necessary signal becomes available

--- a/hw/chisel/src/main/scala/snax/readerWriter/AddressGenUnit.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/AddressGenUnit.scala
@@ -99,10 +99,7 @@ class AddressGenUnit(
   // Create counters for each dimension
   val counters = for (i <- 0 until param.temporalDimension) yield {
     val counter = Module(
-      new ProgrammableCounter(param.addressWidth, hasCeil = true) {
-        override val desiredName =
-          s"${moduleNamePrefix}_AddressGenUnit_Counter_${i}"
-      }
+      new ProgrammableCounter(param.addressWidth, hasCeil = true, s"${moduleNamePrefix}_AddressGenUnitCounter")
     )
     counter.io.reset := io.start
     // counter.io.tick is conenected later, when all necessary signal becomes available

--- a/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
@@ -38,7 +38,7 @@ class DataRequestorIO(
 class DataRequestor(
     tcdmDataWidth: Int,
     tcdmAddressWidth: Int,
-    isReader: Boolean, 
+    isReader: Boolean,
     moduleNamePrefix: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
@@ -102,7 +102,12 @@ class DataRequestors(
   // new DataRequestorsIO(tcdmDataWidth, tcdmAddressWidth, isReader, numChannel)
   val DataRequestor = for (i <- 0 until numChannel) yield {
     val module = Module(
-      new DataRequestor(tcdmDataWidth, tcdmAddressWidth, isReader, moduleNamePrefix = moduleNamePrefix)
+      new DataRequestor(
+        tcdmDataWidth,
+        tcdmAddressWidth,
+        isReader,
+        moduleNamePrefix = moduleNamePrefix
+      )
     )
 
     // Connect the IO

--- a/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
@@ -38,9 +38,12 @@ class DataRequestorIO(
 class DataRequestor(
     tcdmDataWidth: Int,
     tcdmAddressWidth: Int,
-    isReader: Boolean
+    isReader: Boolean, 
+    moduleNamePrefix: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
+  override val desiredName = s"${moduleNamePrefix}_DataRequestor"
+
   val io = IO(new DataRequestorIO(tcdmDataWidth, tcdmAddressWidth, isReader))
   // address queue is popped out if responser is ready and current is acknowldged by the tcdm
   // Or this channel is disabled
@@ -99,9 +102,7 @@ class DataRequestors(
   // new DataRequestorsIO(tcdmDataWidth, tcdmAddressWidth, isReader, numChannel)
   val DataRequestor = for (i <- 0 until numChannel) yield {
     val module = Module(
-      new DataRequestor(tcdmDataWidth, tcdmAddressWidth, isReader) {
-        override def desiredName = s"${moduleNamePrefix}_DataRequestor"
-      }
+      new DataRequestor(tcdmDataWidth, tcdmAddressWidth, isReader, moduleNamePrefix = moduleNamePrefix)
     )
 
     // Connect the IO

--- a/hw/chisel/src/main/scala/snax/utils/ComplexQueue.scala
+++ b/hw/chisel/src/main/scala/snax/utils/ComplexQueue.scala
@@ -53,12 +53,6 @@ class ComplexQueueConcat(
 
   val queues = for (i <- 0 until numChannel) yield {
     val queue = Module(new Queue(UInt(smallWidth.W), depth, pipe))
-    // io.nearlyEmpty(
-    //   i
-    // ) := queue.io.count === 0.U || (queue.io.count === 1.U && ~queue.io.enq.fire)
-    // io.nearlyFull(
-    //   i
-    // ) := queue.io.count === depth.U || (queue.io.count === (depth - 1).U && ~queue.io.deq.fire)
     queue
   }
 

--- a/hw/chisel/src/main/scala/snax/utils/Counter.scala
+++ b/hw/chisel/src/main/scala/snax/utils/Counter.scala
@@ -83,8 +83,11 @@ class UpDownCounter(width: Int) extends Module with RequireAsyncReset {
   io.firstVal := value === 0.U
 }
 
-class ProgrammableCounter(width: Int, hasCeil: Boolean = true, moduleName: String = "unnamed_counter")
-    extends Module
+class ProgrammableCounter(
+    width: Int,
+    hasCeil: Boolean = true,
+    moduleName: String = "unnamed_counter"
+) extends Module
     with RequireAsyncReset {
   override val desiredName = moduleName
   val io = IO(new Bundle {

--- a/hw/chisel/src/main/scala/snax/utils/Counter.scala
+++ b/hw/chisel/src/main/scala/snax/utils/Counter.scala
@@ -83,9 +83,10 @@ class UpDownCounter(width: Int) extends Module with RequireAsyncReset {
   io.firstVal := value === 0.U
 }
 
-class ProgrammableCounter(width: Int, hasCeil: Boolean = true)
+class ProgrammableCounter(width: Int, hasCeil: Boolean = true, moduleName: String = "unnamed_counter")
     extends Module
     with RequireAsyncReset {
+  override val desiredName = moduleName
   val io = IO(new Bundle {
     val tick = Input(Bool())
     val reset = Input(Bool())
@@ -102,7 +103,7 @@ class ProgrammableCounter(width: Int, hasCeil: Boolean = true)
   // The small counter's function is to determine whether the ceil is reached, and a reset is needed.
   if (hasCeil) {
     val smallCounter = Module(new BasicCounter(width, hasCeil) {
-      override val desiredName = "ProgrammableCounter_SmallCounter"
+      override val desiredName = s"${moduleName}_SmallCounter"
     })
 
     smallCounter.io.tick := io.tick

--- a/hw/chisel/src/main/scala/snax/utils/CustomOperators.scala
+++ b/hw/chisel/src/main/scala/snax/utils/CustomOperators.scala
@@ -53,10 +53,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new Queue(chiselTypeOf(left.bits), entries = 1, pipe = false)
+        new Queue(chiselTypeOf(left.bits), entries = 1, pipe = false) {
+          override val desiredName =
+            "FullCutHalfBandwidth_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("fullCutHalfBandwidth")
-
+      buffer.suggestName(left.circuitName + "_fullCutHalfBandwidth")
       left <> buffer.io.enq
       buffer.io.deq <> right
       right
@@ -66,9 +68,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new Queue(chiselTypeOf(left.bits), entries = 2, pipe = false)
+        new Queue(chiselTypeOf(left.bits), entries = 2, pipe = false) {
+          override val desiredName =
+            "FullCutFullBandwidth_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("fullCutFullBandwidth")
+      buffer.suggestName(left.circuitName + "_fullCutFullBandwidth")
       left <> buffer.io.enq
       buffer.io.deq <> right
       right
@@ -78,10 +83,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new DataCut(chiselTypeOf(left.bits), delay = 1)
+        new DataCut(chiselTypeOf(left.bits), delay = 1) {
+          override val desiredName =
+            "DataCut1_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("dataCut1")
-
+      buffer.suggestName(left.circuitName + "_dataCut1")
       left <> buffer.io.in
       buffer.io.out <> right
       right
@@ -91,10 +98,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new DataCut(chiselTypeOf(left.bits), delay = 2)
+        new DataCut(chiselTypeOf(left.bits), delay = 2) {
+          override val desiredName =
+            "DataCut2_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("dataCut2")
-
+      buffer.suggestName(left.circuitName + "_dataCut2")
       left <> buffer.io.in
       buffer.io.out <> right
       right
@@ -104,10 +113,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new DataCut(chiselTypeOf(left.bits), delay = 3)
+        new DataCut(chiselTypeOf(left.bits), delay = 3) {
+          override val desiredName =
+            "DataCut3_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("dataCut3")
-
+      buffer.suggestName(left.circuitName + "_dataCut3")
       left <> buffer.io.in
       buffer.io.out <> right
       right

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaFrontend/DMADataPath.scala
@@ -263,13 +263,17 @@ class DMADataPath(
     new DemuxDecoupled(
       chiselTypeOf(readerDataAfterExtension.bits),
       numOutput = 2
-    )
+    ) {
+      override def desiredName = clusterName + "_xdma_datapath_demux"
+    }
   )
   val writerMux = Module(
     new MuxDecoupled(
       chiselTypeOf(writerDataBeforeExtension.bits),
       numInput = 2
-    )
+    ) {
+      override def desiredName = clusterName + "_xdma_datapath_mux"
+    }
   )
 
   readerDemux.io.sel := io.readerCfg.loopBack

--- a/hw/chisel_acc/src/main/scala/snax_acc/utils/CustomOperators.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/utils/CustomOperators.scala
@@ -2,6 +2,7 @@ package snax_acc.utils
 
 import chisel3._
 import chisel3.util._
+import chisel3.reflect.DataMirror
 
 /** The definition of -|> / -||> / -|||> connector for decoupled signal it
   * connects leftward Decoupled signal (Decoupled port) and rightward Decoupled
@@ -52,10 +53,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new Queue(chiselTypeOf(left.bits), entries = 1, pipe = false)
+        new Queue(chiselTypeOf(left.bits), entries = 1, pipe = false) {
+          override val desiredName =
+            "FullCutHalfBandwidth_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("fullCutHalfBandwidth")
-
+      buffer.suggestName(left.circuitName + "_fullCutHalfBandwidth")
       left <> buffer.io.enq
       buffer.io.deq <> right
       right
@@ -65,9 +68,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new Queue(chiselTypeOf(left.bits), entries = 2, pipe = false)
+        new Queue(chiselTypeOf(left.bits), entries = 2, pipe = false) {
+          override val desiredName =
+            "FullCutFullBandwidth_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("fullCutFullBandwidth")
+      buffer.suggestName(left.circuitName + "_fullCutFullBandwidth")
       left <> buffer.io.enq
       buffer.io.deq <> right
       right
@@ -77,10 +83,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new DataCut(chiselTypeOf(left.bits), delay = 1)
+        new DataCut(chiselTypeOf(left.bits), delay = 1) {
+          override val desiredName =
+            "DataCut1_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("dataCut1")
-
+      buffer.suggestName(left.circuitName + "_dataCut1")
       left <> buffer.io.in
       buffer.io.out <> right
       right
@@ -90,10 +98,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new DataCut(chiselTypeOf(left.bits), delay = 2)
+        new DataCut(chiselTypeOf(left.bits), delay = 2) {
+          override val desiredName =
+            "DataCut2_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("dataCut2")
-
+      buffer.suggestName(left.circuitName + "_dataCut2")
       left <> buffer.io.in
       buffer.io.out <> right
       right
@@ -103,10 +113,12 @@ object DecoupledCut {
         right: DecoupledIO[T]
     )(implicit sourceInfo: chisel3.experimental.SourceInfo): DecoupledIO[T] = {
       val buffer = Module(
-        new DataCut(chiselTypeOf(left.bits), delay = 3)
+        new DataCut(chiselTypeOf(left.bits), delay = 3) {
+          override val desiredName =
+            "DataCut3_W_" + left.bits.getWidth.toString + "_T_" + left.bits.getClass.getSimpleName
+        }
       )
-      buffer.suggestName("dataCut3")
-
+      buffer.suggestName(left.circuitName + "_dataCut3")
       left <> buffer.io.in
       buffer.io.out <> right
       right


### PR DESCRIPTION
This PR renames more key components used in Streamer and XDMA (at an even deeper level) to avoid name conflict between multiple Chisel generation steps. 