### PR TITLE
Include mlir-cpu-runner in docker container

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -56,6 +56,7 @@ RUN curl -L $MLIR_URL -o /tmp/mlir.tar.gz && \
     tar -xzvf /tmp/mlir.tar.gz -C /tmp/mlir && \
     cp /tmp/mlir/build/bin/mlir-opt /usr/bin/ && \
     cp /tmp/mlir/build/bin/mlir-translate /usr/bin/ && \
+    cp /tmp/mlir/build/bin/mlir-cpu-runner /usr/bin/ && \
     rm -rf /tmp/mlir /tmp/mlir.tar.gz
 
 # Temporarily install python3.10 until xdsl has moved to newer MLIR version


### PR DESCRIPTION
This PR adds mlir-cpu-runner to the docker container.
I'm planning to use this for "running" some IR on x86 to get _very very fast_ cycle count estimates.
We did not really have a use for this program previously, since we never ran anything MLIR-compiled on x86.

`mlir-cpu-runner` is a JIT compiler that compiles a LLVM dialect IR program and runs the main MLIR function (as long as it returns one value and has no input arguments).
While technically you could also do something like this:
```
mlir-opt --test-lower-to-llvm | mlir-translate | clang - -x ir -target=x86_64  -o test.x -c some_runtime.o && ./test.x
```
This just simplifies things (avoids unnecessary C/C++ code, function wrappers  and makefiles) and is pretty much readily available:
If at some point we need to run more complex IRs, we can still move to the above approach.
```
mlir-opt --test-lower-to-llvm | mlir-cpu-runner
```
For this program:
```mlir
module {
  func.func public @main() -> i64 {
    %c36_i64 = arith.constant 36 : i64
    return %c36_i64 : i64
  }
}
```
You get this as output:
```
$ mlir-opt test.mlir --test-lower-to-llvm | mlir-cpu-runner -O3 --entry-point-result=i64
36
```
Adding The mlir-cpu-runner binary itself is (100 MB), because it pretty much contains mlir-translate (44 MB) AND a full x86 compiler backend