### PR TITLE
Modify writer's buffer to normal one instead of pipe one

### DIFF
--- a/hw/chisel/src/main/scala/snax/readerWriter/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/Writer.scala
@@ -40,7 +40,7 @@ class Writer(
       inputWidth = param.tcdmParam.dataWidth * param.tcdmParam.numChannel,
       outputWidth = param.tcdmParam.dataWidth,
       depth = param.bufferDepth,
-      pipe = true
+      pipe = false
     ) {
       override val desiredName = s"${moduleNamePrefix}_Writer_DataBuffer"
     }

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaFrontEnd/DMADataPathTester.scala
@@ -43,9 +43,8 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
         axiParam = new AXIParam,
         rwParam = new ReaderWriterParam(
           configurableByteMask = true,
-          configurableChannel = true, 
-        ), 
-        extParam = Seq(HasMemset, HasMemset)
+          configurableChannel = true
+        )
       )
     )
   ).withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
@@ -132,9 +131,6 @@ class DMADataPathTester extends AnyFreeSpec with ChiselScalatestTester {
       // Poke the loop back to ture since we are only testing w/o any axi transactions
       dut.io.readerCfg.loopBack.poke(true)
       dut.io.writerCfg.loopBack.poke(true)
-
-      // Poke to bypass the extension
-      dut.io.writerCfg.extCfg(0).poke(0xf.U)
 
       // Start the reader and writer
       dut.io.readerStart.poke(true)

--- a/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/Transpose.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/Transpose.scala
@@ -25,6 +25,10 @@ class TransposeMux(params: ReshufflerParams) extends Module {
   // fixed pattern: transpose 8x8 matrix
   val out_data_array = Wire(Vec(8, Vec(8, UInt(8.W))))
 
+  val input_fire = WireInit(false.B)
+
+  input_fire := io.input.valid && io.input.ready
+
   for (i <- 0 until 8) {
     for (j <- 0 until 8) {
       out_data_array(i)(j) := io.input.bits(
@@ -34,9 +38,9 @@ class TransposeMux(params: ReshufflerParams) extends Module {
     }
   }
 
-  when(io.transpose && io.input.valid) {
+  when(io.transpose && input_fire) {
     data_reg := out_data_array.asUInt
-  }.elsewhen(!io.transpose && io.input.valid) {
+  }.elsewhen(!io.transpose && input_fire) {
     data_reg := io.input.bits
   }
 
@@ -47,7 +51,7 @@ class TransposeMux(params: ReshufflerParams) extends Module {
   val keep_output = RegInit(false.B)
   keep_output := output_stall
 
-  io.output.valid := RegNext(io.input.valid) || keep_output
+  io.output.valid := RegNext(input_fire) || keep_output
   io.input.ready := !keep_output && !output_stall
 
   io.output.bits := data_reg


### PR DESCRIPTION
Vivado reports combinatorial loop in GeMM cluster after recent updates in GeMM Cluster. 

The detailed log is as follows: 

```
LUTLP-1#1 Critical Warning
Combinatorial Loop Alert  
177 LUT cells form a combinatorial loop. This can create a race condition. Timing analysis may not be accurate. The preferred resolution is to modify the design to remove combinatorial logic loops. If the loop is known and understood, this DRC can be bypassed by acknowledging the condition and setting the following XDC constraint on any one of the nets in the loop: 'set_property ALLOW_COMBINATORIAL_LOOPS TRUE [get_nets <myHier/myNet>]'. One net in the loop is hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_cluster/i_axi_to_mem_dma/i_axi_to_mem_read/i_axi_to_detailed_mem/i_mem_to_banks/gen_reqs[0].i_ft_reg/fifo_i/gen_arbiter.gen_int_rr.rr_q_reg[2]_8. Please evaluate your design. The cells in the loop are: 


hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/FSM_onehot_state_q[2]_i_2__0,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/FSM_onehot_state_q[2]_i_6,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/FSM_onehot_state_q[2]_i_7,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/FSM_onehot_state_q[2]_i_9,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/gen_arbiter.gen_int_rr.rr_q[0]_i_7,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__2/LUT5 (in hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__2 macro),
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__2/LUT6 (in hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__2 macro),
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__3/LUT5 (in hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__3 macro),
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__3/LUT6 (in hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i__i_22__3 macro),
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i_snax_streamer_gemmX_shell_wrapper/inst_block_gemm_simd/gemm/gemm_array/mesh/mesh_0_0/data_i_fire_reg_i_2,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i_snax_streamer_gemmX_shell_wrapper/inst_block_gemm_simd/simd/d_output_ifvalid_counter[31]_i_4,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i_snax_streamer_gemmX_streamer_wrapper/i_snax_streamer_gemmX_streamer_top/reader_1/addressgen/outputBuffer/queues_0/ram_ext/gen_arbiter.gen_int_rr.rr_q[0]_i_2__42,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i_snax_streamer_gemmX_streamer_wrapper/i_snax_streamer_gemmX_streamer_top/reader_1/addressgen/outputBuffer/queues_0/ram_ext/gen_arbiter.gen_int_rr.rr_q[1]_i_5__12,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i_snax_streamer_gemmX_streamer_wrapper/i_snax_streamer_gemmX_streamer_top/reader_writer_0/writer/dataBuffer/queues_19/d_output_ifvalid_counter[31]_i_18,
hemaia_system_i/occamy_chip/inst/i_occamy/i_occamy_soc/i_occamy_quadrant_s1_0/i_occamy_cluster_0/i_snax_core_0_acc_0_snax_streamer_gemmX/i_snax_streamer_gemmX_streamer_wrapper/i_snax_streamer_gemmX_streamer_top/writer_0/addressgen/outputBuffer/queues_0/ram_ext/FSM_onehot_state_q[2]_i_8
 (the first 15 of 177 listed).

```

After investigation, this is caused by the combinatorial reliance between the readers and the writers. Specifically, imaging a condition when reader's output is directly connected to writer's input, and if FIFOs of both readers and writers are full; The round robin arbitrater initially gives writer side the permission to writer. As both **valid** and **ready** signals are high in this cycle, the writer can intake one more data. This information propagates to the reader, and finally reader starts to ask the new data. As writer already stored data in previous cycles, reader has the highest priority to writer, which lead to the revocation of writer's permission and give it. to reader. However, the revocation of writer's permission leads to the revocation of reader's permission to send the new request. Finaally it forms the combinatorial loop. 

The solution to fix it is to make writer and reader not combinatorially relying on each other. This is done by introducing another type of FIFO in writer and sacrafice one position in FIFO. 