### PR TITLE
Adding TQDM and Matplotlib to python requirements

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -20,3 +20,5 @@ termcolor
 pandas
 pyelftools
 psutil
+tqdm
+matplotlib


### PR DESCRIPTION
This PR simply adds the tqdm and matplotlib python packages. These are small packages anyway.
Fix as requested by @IveanEx so that we don't always have to install manually.