### PR TITLE
Increasing spatial dim of C32 and D32 in GeMMX to 2 

### DIFF
--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
@@ -212,7 +212,7 @@
         },
 
         data_reader_writer_params:{
-            spatial_bounds: [[32], [32]],
+            spatial_bounds: [[4, 8], [4, 8]],
             temporal_dim: [3, 3],
             num_channel: [32, 32],
             fifo_depth: [2, 2],

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
@@ -193,7 +193,7 @@
         },
 
         data_reader_writer_params:{
-            spatial_bounds: [[32], [32]],
+            spatial_bounds: [[4, 8], [4, 8]],
             temporal_dim: [3, 3],
             num_channel: [32, 32],
             fifo_depth: [2, 2],

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
@@ -642,7 +642,11 @@ def emit_matmul_data(**kwargs):
 
     data_str += [format_scalar_definition("int32_t", "Cslstride0", bankWidth / 8)]
     c32_spatial_bound_0 = 4
-    data_str += [format_scalar_definition("int32_t", "Cslstride1", c32_spatial_bound_0 * (bankWidth / 8))]
+    data_str += [
+        format_scalar_definition(
+            "int32_t", "Cslstride1", c32_spatial_bound_0 * (bankWidth / 8)
+        )
+    ]
     data_str += [format_scalar_definition("int32_t", "Ctlbound0", kwargs["N"])]
     data_str += [
         format_scalar_definition(
@@ -662,7 +666,11 @@ def emit_matmul_data(**kwargs):
 
     data_str += [format_scalar_definition("int32_t", "D32slstride0", bankWidth / 8)]
     d32_spatial_bound_0 = 4
-    data_str += [format_scalar_definition("int32_t", "D32slstride1", d32_spatial_bound_0 * (bankWidth / 8))]
+    data_str += [
+        format_scalar_definition(
+            "int32_t", "D32slstride1", d32_spatial_bound_0 * (bankWidth / 8)
+        )
+    ]
     data_str += [format_scalar_definition("int32_t", "D32tlbound0", kwargs["N"])]
     data_str += [
         format_scalar_definition(

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
@@ -366,8 +366,8 @@ def emit_conv_data(**kwargs):
     # C is int32_t so the stride is 4 times of the int8_t
     if kwargs["ifC8HW8datalayout"] is True:
         # NHWC
-        Cslstride0 = 4
-        Cslstride1 = 8
+        Cslstride0 = 8
+        Cslstride1 = 32
 
         # N dim
         Ctlbound0 = Cout // 8
@@ -427,8 +427,8 @@ def emit_conv_data(**kwargs):
     ]
 
     if kwargs["ifC8HW8datalayout"] is True:
-        D32slstride0 = 1 * 4
-        D32slstride1 = 8
+        D32slstride0 = 8
+        D32slstride1 = 32
 
         # N dim
         D32tlbound0 = Cout // 8
@@ -640,8 +640,9 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "Btlbound2", kwargs["M"])]
     data_str += [format_scalar_definition("int32_t", "Btlstride2", 0)]
 
-    data_str += [format_scalar_definition("int32_t", "Cslstride0", 4)]
-    data_str += [format_scalar_definition("int32_t", "Cslstride1", bankWidth / 8)]
+    data_str += [format_scalar_definition("int32_t", "Cslstride0", bankWidth / 8)]
+    c32_spatial_bound_0 = 4
+    data_str += [format_scalar_definition("int32_t", "Cslstride1", c32_spatial_bound_0 * (bankWidth / 8))]
     data_str += [format_scalar_definition("int32_t", "Ctlbound0", kwargs["N"])]
     data_str += [
         format_scalar_definition(
@@ -659,8 +660,9 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "Ctlbound2", 1)]
     data_str += [format_scalar_definition("int32_t", "Ctlstride2", 0)]
 
-    data_str += [format_scalar_definition("int32_t", "D32slstride0", 4)]
-    data_str += [format_scalar_definition("int32_t", "D32slstride1", bankWidth / 8)]
+    data_str += [format_scalar_definition("int32_t", "D32slstride0", bankWidth / 8)]
+    d32_spatial_bound_0 = 4
+    data_str += [format_scalar_definition("int32_t", "D32slstride1", d32_spatial_bound_0 * (bankWidth / 8))]
     data_str += [format_scalar_definition("int32_t", "D32tlbound0", kwargs["N"])]
     data_str += [
         format_scalar_definition(

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -119,7 +119,8 @@ void set_gemmx_streamer_csr(
             (uint32_t)(delta_local_c + snrt_l1_next()));
 
     // spatial strides for C
-    csrw_ss(S_STRIDE_READER_WRITER_0_0, Cslstride1);
+    csrw_ss(S_STRIDE_READER_WRITER_0_0, Cslstride0);
+    csrw_ss(S_STRIDE_READER_WRITER_0_1, Cslstride1);
 
     // loop bounds, from innermost to outermost, for data mover C
     csrw_ss(T_BOUND_READER_WRITER_0_0, Ctlbound0);
@@ -144,7 +145,8 @@ void set_gemmx_streamer_csr(
             (uint32_t)(delta_local_d32 + snrt_l1_next()));
 
     // spatial strides for D32
-    csrw_ss(S_STRIDE_READER_WRITER_1_0, D32slstride1);
+    csrw_ss(S_STRIDE_READER_WRITER_1_0, D32slstride0);
+    csrw_ss(S_STRIDE_READER_WRITER_1_1, D32slstride1);
 
     // for D32, from N to M
     if (bypassSIMD == 0) {


### PR DESCRIPTION
In this PR, we increase the spatial dimension of the C32 and D32 ports in GeMMX to 2 (previously it was 1).
With this, we add an extra stride in the spatial address generation for C32 and D32 (now can jump at 2 elements and row granularity), thus enabling more data layout opportunities for reducing the bank conflict.

@jorendumoulin @JosseVanDelm , please have a look at it, now we have two extra spatial strides CSRs. Please let me know if there is anything unclear.