### PR TITLE
Remove bender sim targets for SYN and fix vsim preparation

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -52,7 +52,7 @@ VCS_BUILDDIR := work-vcs
 
 # For synthesis with DC compiler
 SYN_FLIST ?= syn_flist.tcl
-SYN_BENDER += -t test -t synthesis -t simulation
+SYN_BENDER += -t synthesis
 ifeq ($(MEM_TYPE), exclude_tcsram)
 	VSIM_BENDER += -t tech_cells_generic_exclude_tc_sram
 	VSIM_BENDER += -t tc_sram_cluster_only

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -354,6 +354,9 @@ bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 clean-vsim: clean-work
 	rm -rf bin/snitch_cluster.vsim bin/snitch_cluster.vsim.gui $(VSIM_BUILDDIR) vsim.wlf
 
+vsim_preparation: $(GENERATED_DIR)/bootdata.cc work/lib/libfesvr.a
+	@echo "VSIM preparation done"
+
 ${VSIM_BUILDDIR}/compile.vsim.tcl:
 	$(VLIB) $(dir $@)
 	${BENDER} script vsim ${VSIM_BENDER} --vlog-arg="${VLOG_FLAGS} -work $(dir $@) " > $@


### PR DESCRIPTION
This PR simply does the following:
- [x] Remove bender targets `-test` and `-simulation` for synthesis run to avoid unnecessary unsynthesizable errors.
- [x] Make vsim preparation for questasim simulations. 