### PR TITLE
Add observable pins per cluster

### DIFF
--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -136,6 +136,11 @@
             "description": "Number of request entries the DMA can keep",
             "default": 3
         },
+        "observable_pin_width": {
+            "type": "number",
+            "description": "Number of observable pin width",
+            "default": 0
+        },
         "enable_debug": {
             "type": "boolean",
             "description": "Whether to provide a debug request input and external debug features",

--- a/hw/snitch/src/csr_snax_def.sv
+++ b/hw/snitch/src/csr_snax_def.sv
@@ -4,6 +4,5 @@ localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
 localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
 localparam logic [11:0] SNAX_CSR_BARRIER_EN = 12'h7c3;
 localparam logic [11:0] SNAX_CSR_BARRIER = 12'h7c4;
-localparam logic [11:0] SNAX_CSR_OBSERVE = 12'h7c5;
 endpackage
 // verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch/src/csr_snax_def.sv
+++ b/hw/snitch/src/csr_snax_def.sv
@@ -4,5 +4,6 @@ localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
 localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
 localparam logic [11:0] SNAX_CSR_BARRIER_EN = 12'h7c3;
 localparam logic [11:0] SNAX_CSR_BARRIER = 12'h7c4;
+localparam logic [11:0] SNAX_CSR_OBSERVE = 12'h7c5;
 endpackage
 // verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -248,7 +248,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   logic csr_stall_d, csr_stall_q;
   logic snax_csr_stall_d, snax_csr_stall_q;
   logic snax_csr_barr_en_d, snax_csr_barr_en_q;
-  logic snax_obs_reg_q, snax_obs_reg_d;
+  logic [31:0] snax_csr_obs_d, snax_csr_obs_q;
 
   localparam logic M = 0;
   localparam logic S = 1;
@@ -320,7 +320,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   `FFAR(csr_stall_q, csr_stall_d, '0, clk_i, rst_i)
   `FFAR(snax_csr_stall_q, snax_csr_stall_d, '0, clk_i, rst_i)
   `FFAR(snax_csr_barr_en_q, snax_csr_barr_en_d, '0, clk_i, rst_i)
-  `FFAR(snax_obs_reg_q, snax_obs_reg_d, '0, clk_i, rst_i)
+  `FFAR(snax_csr_obs_q, snax_csr_obs_d, '0, clk_i, rst_i)
 
   typedef struct packed {
     fpnew_pkg::fmt_mode_t  fmode;
@@ -2373,6 +2373,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     csr_stall_d = csr_stall_q;
     snax_csr_stall_d = snax_csr_stall_q;
     snax_csr_barr_en_d = snax_csr_barr_en_q;
+    snax_csr_obs_d = snax_csr_obs_q;
 
     // Snitch barrier
     if (barrier_i) csr_stall_d = 1'b0;
@@ -2612,6 +2613,11 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
 
           csr_snax_def::SNAX_CSR_BARRIER: begin
             snax_csr_stall_d = 1'b1;
+          end
+          // Observable register
+          csr_snax_def::SNAX_CSR_OBSERVE: begin
+            csr_rvalue = snax_csr_obs_q;
+            snax_csr_obs_d = alu_result;
           end
           // HW cluster barrier
           CSR_BARRIER: begin

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -53,6 +53,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   parameter int unsigned NumDTLBEntries = 0,
   parameter int unsigned NumITLBEntries = 0,
   parameter snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{default: 0},
+  /// Width of observable register
+  parameter int unsigned ObsWidth = 8,
   /// Enable debug support.
   parameter bit         DebugSupport = 1,
   /// Derived parameter *Do not override*
@@ -107,6 +109,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   input  fpnew_pkg::status_t        fpu_status_i,
   // Core events for performance counters
   output snitch_pkg::core_events_t  core_events_o,
+  // Observability register
+  output logic [ObsWidth-1:0] obs_o,
   // Cluster SNAX HW barrier
   input  logic          snax_barrier_i,
   // Cluster HW barrier
@@ -248,7 +252,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   logic csr_stall_d, csr_stall_q;
   logic snax_csr_stall_d, snax_csr_stall_q;
   logic snax_csr_barr_en_d, snax_csr_barr_en_q;
-  logic [31:0] snax_csr_obs_d, snax_csr_obs_q;
+  logic [31:0] csr_obs_d, csr_obs_q;
 
   localparam logic M = 0;
   localparam logic S = 1;
@@ -317,10 +321,13 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     assign debug_q = '0;
   end
 
+  // Built-in barriers
   `FFAR(csr_stall_q, csr_stall_d, '0, clk_i, rst_i)
   `FFAR(snax_csr_stall_q, snax_csr_stall_d, '0, clk_i, rst_i)
   `FFAR(snax_csr_barr_en_q, snax_csr_barr_en_d, '0, clk_i, rst_i)
-  `FFAR(snax_csr_obs_q, snax_csr_obs_d, '0, clk_i, rst_i)
+
+  // Observable register
+  `FFAR(csr_obs_q, csr_obs_d, '0, clk_i, rst_i)
 
   typedef struct packed {
     fpnew_pkg::fmt_mode_t  fmode;
@@ -2373,7 +2380,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     csr_stall_d = csr_stall_q;
     snax_csr_stall_d = snax_csr_stall_q;
     snax_csr_barr_en_d = snax_csr_barr_en_q;
-    snax_csr_obs_d = snax_csr_obs_q;
+    csr_obs_d = csr_obs_q;
 
     // Snitch barrier
     if (barrier_i) csr_stall_d = 1'b0;
@@ -2615,9 +2622,9 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
             snax_csr_stall_d = 1'b1;
           end
           // Observable register
-          csr_snax_def::SNAX_CSR_OBSERVE: begin
-            csr_rvalue = snax_csr_obs_q;
-            snax_csr_obs_d = alu_result;
+          CsrObsRegister: begin
+            csr_rvalue = csr_obs_q;
+            csr_obs_d = alu_result;
           end
           // HW cluster barrier
           CSR_BARRIER: begin
@@ -3030,6 +3037,11 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     BGE,
     BGEU
   }) && (consec_pc[1:0] != 2'b0);
+
+  // ----------
+  // Observability pin
+  // ----------
+  assign obs_o = csr_obs_q[ObsWidth-1:0];
 
   // ----------
   // Assertions

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -248,6 +248,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   logic csr_stall_d, csr_stall_q;
   logic snax_csr_stall_d, snax_csr_stall_q;
   logic snax_csr_barr_en_d, snax_csr_barr_en_q;
+  logic snax_obs_reg_q, snax_obs_reg_d;
 
   localparam logic M = 0;
   localparam logic S = 1;
@@ -319,6 +320,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   `FFAR(csr_stall_q, csr_stall_d, '0, clk_i, rst_i)
   `FFAR(snax_csr_stall_q, snax_csr_stall_d, '0, clk_i, rst_i)
   `FFAR(snax_csr_barr_en_q, snax_csr_barr_en_d, '0, clk_i, rst_i)
+  `FFAR(snax_obs_reg_q, snax_obs_reg_d, '0, clk_i, rst_i)
 
   typedef struct packed {
     fpnew_pkg::fmt_mode_t  fmode;

--- a/hw/snitch/src/snitch_pkg.sv
+++ b/hw/snitch/src/snitch_pkg.sv
@@ -180,6 +180,8 @@ package snitch_pkg;
   localparam logic [11:0] CsrBaseAddrH = 12'hBC2;
   // CSRClusterCoreID: RO, The Core ID locally inside the Cluster
   localparam logic [11:0] CsrClusterCoreId = 12'hBC3;
+  // CsrObsRegister: RW, a simple observability register
+  localparam logic [11:0] CsrObsRegister = 12'h7c5;
 
   // --------------------
   // Trace Infrastructure

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -95,6 +95,8 @@ module snitch_cc #(
   /// Insert Pipeline registers immediately after FPU datapath
   parameter bit          RegisterFPUOut     = 0,
   parameter snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{default: 0},
+  /// Width of observable register
+  parameter int unsigned ObsWidth = 8,
   /// Enable debug support.
   parameter bit          DebugSupport = 1,
   /// Derived parameter *Do not override*
@@ -138,6 +140,8 @@ module snitch_cc #(
   output snitch_pkg::core_events_t   core_events_o,
   // TCDM base address, which also is the Base Address of the Snitch Cluster that the core belongs to
   input  addr_t                      tcdm_addr_base_i,
+  // Observability register
+  output logic [ObsWidth-1:0]        obs_o,
   // Cluster HW barrier
   input  logic                       snax_barrier_i,
   output logic                       barrier_o,
@@ -274,6 +278,7 @@ module snitch_cc #(
     .fpu_fmt_mode_o ( fpu_fmt_mode ),
     .fpu_status_i ( fpu_status ),
     .core_events_o ( snitch_events),
+    .obs_o ( obs_o ),
     .snax_barrier_i (snax_barrier_i ),
     .barrier_o ( barrier_o ),
     .barrier_i ( barrier_i )

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -210,14 +210,19 @@ module snitch_cluster
   // In case you are using the `RegisterTCDMCuts` feature this adds an
   // additional cycle latency, which is taken into account here.
   parameter int unsigned MemoryMacroLatency = 1 + RegisterTCDMCuts,
+  /// Width of observable register
+  parameter int unsigned ObsWidth = 8,
   /// Enable debug support.
-  parameter bit         DebugSupport = 1
+  parameter bit          DebugSupport = 1
 ) (
   /// System clock. If `IsoCrossing` is enabled this port is the _fast_ clock.
   /// The slower, half-frequency clock, is derived internally.
   input  logic                          clk_i,
   /// Asynchronous active high reset. This signal is assumed to be _async_.
   input  logic                          rst_ni,
+  /// Observability register for the cluster. This register is assumed to be
+  /// sticky and only useful for observing signals from the outside.
+  output logic [ObsWidth-1:0]           obs_o,
   /// Per-core debug request signal. Asserting this signals puts the
   /// corresponding core into debug mode. This signal is assumed to be _async_.
   input  logic [NrCores-1:0]            debug_req_i,
@@ -550,6 +555,13 @@ module snitch_cluster
   logic [NrCores-1:0] cl_interrupt;
   logic [NrCores-1:0] barrier_in;
   logic barrier_out;
+  logic [NrCores-1:0] obs_signal;
+
+  //--------------
+  // Observability register
+  // Only applicable for the very 1st core
+  //--------------
+  assign obs_o = obs_signal[0];
 
   // -------------
   // DMA Subsystem
@@ -1339,6 +1351,7 @@ module snitch_cluster
         .snax_pready_o (snax_pready[i]),
         .core_events_o (core_events[i]),
         .tcdm_addr_base_i (tcdm_start_address),
+        .obs_o (obs_signal[i]),
         .snax_barrier_i (snax_barrier_i[i]),
         .barrier_o (barrier_in[i]),
         .barrier_i (barrier_out)

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -555,7 +555,7 @@ module snitch_cluster
   logic [NrCores-1:0] cl_interrupt;
   logic [NrCores-1:0] barrier_in;
   logic barrier_out;
-  logic [NrCores-1:0] obs_signal;
+  logic [ObsWidth-1:0] obs_signal [NrCores];
 
   //--------------
   // Observability register

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -95,6 +95,9 @@ package ${cfg['name']}_pkg;
   localparam int unsigned ICacheSets [NrHives] = '{${icache_cfg('sets')}};
 
   localparam int unsigned Hive [NrCores] = '{${core_cfg('hive')}};
+% if cfg['observable_pin_width'] > 0:
+  parameter int unsigned ObsWidth = ${cfg['observable_pin_width']};
+% endif
 
   // SRAM configurations
   typedef struct packed {
@@ -283,6 +286,12 @@ module ${cfg['name']}_wrapper (
   //-----------------------------
   input  logic                                   clk_i,
   input  logic                                   rst_ni,
+% if cfg['observable_pin_width'] > 0:
+  //-----------------------------
+  // Observable pins
+  //-----------------------------
+  output logic [ObsWidth-1:0]                    obs_o,
+% endif
   //-----------------------------
   // Interrupt ports
   //-----------------------------
@@ -610,6 +619,9 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .NarrowMaxSlvTrans (${cfg['narrow_trans']}),
     .sram_cfg_t (${cfg['pkg_name']}::sram_cfg_t),
     .sram_cfgs_t (${cfg['pkg_name']}::sram_cfgs_t),
+% if cfg['observable_pin_width'] > 0:
+    .ObsWidth (${cfg['pkg_name']}::ObsWidth),
+% endif
     .DebugSupport (${int(cfg['enable_debug'])}),
     .acc_req_t (${cfg['pkg_name']}::acc_req_t),
     .acc_resp_t (${cfg['pkg_name']}::acc_resp_t),
@@ -621,6 +633,12 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     //-----------------------------
     .clk_i  ( clk_i  ),
     .rst_ni ( rst_ni ),
+% if cfg['observable_pin_width'] > 0:
+    //-----------------------------
+    // Observable pins
+    //-----------------------------
+    .obs_o  ( obs_o  ),
+% endif
     //-----------------------------
     // Interrupt ports
     //----------------------------

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -290,7 +290,7 @@ module ${cfg['name']}_wrapper (
   //-----------------------------
   // Observable pins
   //-----------------------------
-  output logic [ObsWidth-1:0]                    obs_o,
+  output logic [snax_hypercorex_cluster_pkg::ObsWidth-1:0] obs_o,
 % endif
   //-----------------------------
   // Interrupt ports

--- a/sw/snRuntime/src/csr.h
+++ b/sw/snRuntime/src/csr.h
@@ -19,6 +19,15 @@
 // Uncomment the above line to enable 64 CSRs addressability, with the down side
 // of larger binary size.
 
+static void write_csr_obs(uint32_t value){
+    write_csr(1989, value);
+    return;
+}
+
+static uint32_t read_csr_obs(void){
+    return read_csr(1989);
+}
+
 static uint32_t csrr_ss(uint32_t csr_address) {
     uint32_t value;
     switch (csr_address) {

--- a/sw/snRuntime/src/csr.h
+++ b/sw/snRuntime/src/csr.h
@@ -19,14 +19,12 @@
 // Uncomment the above line to enable 64 CSRs addressability, with the down side
 // of larger binary size.
 
-static void write_csr_obs(uint32_t value){
+static void write_csr_obs(uint32_t value) {
     write_csr(1989, value);
     return;
 }
 
-static uint32_t read_csr_obs(void){
-    return read_csr(1989);
-}
+static uint32_t read_csr_obs(void) { return read_csr(1989); }
 
 static uint32_t csrr_ss(uint32_t csr_address) {
     uint32_t value;

--- a/target/snitch_cluster/cfg/snax_hypercorex.hjson
+++ b/target/snitch_cluster/cfg/snax_hypercorex.hjson
@@ -28,6 +28,9 @@
         dma_axi_req_fifo_depth: 16,
         dma_req_fifo_depth: 8,
 
+        // Observable pins parameter
+        observable_pin_width: 8,
+
         // Additional parameters for Hemaia integration
         narrow_trans: 4,
         wide_trans: 32,

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/test-csr/src/test-csr.c
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/test-csr/src/test-csr.c
@@ -70,6 +70,9 @@ int main() {
             test_streamer_test_val5, test_streamer_test_val6,
             test_streamer_test_val7);
 
+        // Write to observable CSR for visibile state
+        write_csr_obs(0x001);
+
         //-------------------------------
         // Read from streamer RW registers
         //-------------------------------
@@ -287,6 +290,9 @@ int main() {
             err += 1;
         };
 
+        // Write to observable CSR for visibile state
+        write_csr_obs(0x002);
+
         //-------------------------------
         // Write to several Hypercorex registers
         //-------------------------------
@@ -319,6 +325,9 @@ int main() {
         hypercorex_set_inst_loop_count(test_inst_loop_count1,
                                        test_inst_loop_count2,
                                        test_inst_loop_count3);
+
+        // Write to observable CSR for visibile state
+        write_csr_obs(0x003);
 
         //-------------------------------
         // Read from registers if they have correct values
@@ -388,6 +397,9 @@ int main() {
             golden_inst_loop_count) {
             err += 1;
         }
+
+        // Write to observable CSR for visibile state
+        write_csr_obs(0x004);
     };
 
     return err;


### PR DESCRIPTION
This PR adds observable pins to each SNAX cluster. (This has been adapted according to @IveanEx's suggestion).

We have observable pins only from the first snitch core as shown below:

![image](https://github.com/user-attachments/assets/2e68f4d6-f21a-48c9-b235-8bf2b359e337)

Details:
* It is an RW register inside the Snitch core and part of the Snitch CSR registers.
* The register address is `0x7c5` which was arbitrarily chosen. It can change later. It occupies a free CSR space.
* How do we use it?
  * It's a simple RW register, it functions like a SW debug for observability.
  * In the C-code (or any code) you can insert CSR write operations to write unto this register.
  * Suppose your accelerator has states: idle > run > busy. Then you put in the C-code, some arbitrary value (say you want `0xffa` to indicate the idle mode. Then when you activate your accelerator, write `0xffb` to the register. 
  * Note that it is only connected to the 1st core. All other cores do have the register but they are not visible to the top. Just the first core.


Major TODO:
- [x] Modify Snitch
- [x] Modify Snitch core cluster
- [x] Modify Snitch cluster
- [x] Modify Snitch cluster template
- [x] Add switch in config signals
- [x] Add csr run time to read or write
- [x] Test if it works by checking if the signals are visible from the top cluster
