### PR TITLE
New affine address mapper in AGU for non-interleaved data access

### DIFF
--- a/hw/chisel/src/main/scala/snax/readerWriter/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/DesignParams.scala
@@ -32,10 +32,31 @@ class AddressGenUnitParam(
     val addressWidth: Int,
     val numChannel: Int,
     val outputBufferDepth: Int,
-    val tcdmSize: Int
+    val tcdmSize: Int,
+    val tcdmPhysWordSize: Int,
+    val tcdmLogicWordSize: Seq[Int]
 )
 
 object AddressGenUnitParam {
+  def apply(
+      spatialBounds: List[Int],
+      temporalDimension: Int,
+      numChannel: Int,
+      outputBufferDepth: Int,
+      tcdmSize: Int,
+      tcdmPhysWordSize: Int,
+      tcdmLogicWordSize: Seq[Int]
+  ): AddressGenUnitParam = new AddressGenUnitParam(
+    spatialBounds = spatialBounds,
+    temporalDimension = temporalDimension,
+    addressWidth = log2Ceil(tcdmSize) + 10,
+    numChannel = numChannel,
+    outputBufferDepth = outputBufferDepth,
+    tcdmSize = tcdmSize,
+    tcdmPhysWordSize = tcdmPhysWordSize,
+    tcdmLogicWordSize = tcdmLogicWordSize
+  )
+
   def apply(
       spatialBounds: List[Int],
       temporalDimension: Int,
@@ -48,7 +69,9 @@ object AddressGenUnitParam {
     addressWidth = log2Ceil(tcdmSize) + 10,
     numChannel = numChannel,
     outputBufferDepth = outputBufferDepth,
-    tcdmSize = tcdmSize
+    tcdmSize = tcdmSize,
+    tcdmPhysWordSize = 256,
+    tcdmLogicWordSize = Seq(256)
   )
 
   // The Very Simple instantiation of the Param
@@ -57,7 +80,9 @@ object AddressGenUnitParam {
     temporalDimension = 2,
     numChannel = 8,
     outputBufferDepth = 8,
-    tcdmSize = 128
+    tcdmSize = 128,
+    tcdmPhysWordSize = 256,
+    tcdmLogicWordSize = Seq(256)
   )
 }
 
@@ -66,6 +91,8 @@ class ReaderWriterParam(
     temporalDimension: Int = 2,
     tcdmDataWidth: Int = 64,
     tcdmSize: Int = 128,
+    tcdmPhysWordSize: Int = 256,
+    tcdmLogicWordSize: Seq[Int] = Seq(256),
     numChannel: Int = 8,
     addressBufferDepth: Int = 8,
     dataBufferDepth: Int = 8,
@@ -78,7 +105,9 @@ class ReaderWriterParam(
     temporalDimension = temporalDimension,
     numChannel = numChannel,
     outputBufferDepth = addressBufferDepth,
-    tcdmSize = tcdmSize
+    tcdmSize = tcdmSize,
+    tcdmPhysWordSize = tcdmPhysWordSize,
+    tcdmLogicWordSize = tcdmLogicWordSize
   )
 
   val tcdmParam = TCDMParam(

--- a/hw/chisel/src/main/scala/snax/readerWriter/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/DesignParams.scala
@@ -127,5 +127,9 @@ class ReaderWriterParam(
                                                                   configurableByteMask
                                                                 ) 1
                                                                 else
-                                                                  0)
+                                                                  0) + (if (
+                                                                          tcdmLogicWordSize.length > 1
+                                                                        ) 1
+                                                                        else
+                                                                          0)
 }

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -547,6 +547,13 @@ class StreamerHeaderFile(param: StreamerParam) {
       csrOffset = csrOffset + 1
     }
 
+    // address remap index
+    if (param.aguParam.tcdmLogicWordSize.length > 1) {
+      csrMap =
+        csrMap + "#define " + "ADDR_REMAP_INDEX_" + tag + " " + csrOffset + "\n"
+      csrOffset = csrOffset + 1
+    }
+
     // channel enable
     if (param.configurableChannel) {
       csrMap =

--- a/hw/chisel/src/test/scala/snax/readerWriter/AddressGenUnitTester.scala
+++ b/hw/chisel/src/test/scala/snax/readerWriter/AddressGenUnitTester.scala
@@ -78,4 +78,58 @@ class AddressGenUnitTester extends AnyFlatSpec with ChiselScalatestTester {
           dut.clock.step()
         }
     }
+
+  "AddressGenUnit: continuous 1D fetch with memory remapped to non-interleaved in superbank" should " pass" in test(
+    new AddressGenUnit(
+      AddressGenUnitParam(
+        spatialBounds = List(8),
+        temporalDimension = 2,
+        numChannel = 8,
+        outputBufferDepth = 2,
+        tcdmSize = 128,
+        tcdmPhysWordSize = 256,
+        tcdmLogicWordSize = Seq(256, 128, 64)
+      )
+    )
+  )
+    .withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
+      dut =>
+        dut.clock.setTimeout(0)
+        dut.io.cfg.ptr.poke(0x0.U)
+        dut.io.cfg.spatialStrides(0).poke(8)
+        dut.io.cfg.temporalStrides(0).poke(64)
+        dut.io.cfg.temporalStrides(1).poke(0)
+        dut.io.cfg.temporalBounds(0).poke(2048)
+        dut.io.cfg.temporalBounds(1).poke(1)
+        dut.io.cfg.addressRemapIndex.poke(2)
+
+        dut.io.start.poke(true)
+        dut.clock.step()
+        dut.io.start.poke(false)
+        for (i <- 0 until 16) {
+          dut.clock.step()
+        }
+
+        dut.io.addr.foreach(_.ready.poke(true.B))
+        for (i <- 0 until 2048) {
+          dut.clock.step()
+        }
+    }
+}
+
+object AddressGenUnitEmitter extends App {
+  _root_.circt.stage.ChiselStage.emitSystemVerilogFile(
+    new AddressGenUnit(
+      AddressGenUnitParam(
+        spatialBounds = List(8),
+        temporalDimension = 2,
+        numChannel = 8,
+        outputBufferDepth = 8,
+        tcdmSize = 128,
+        tcdmPhysWordSize = 256,
+        tcdmLogicWordSize = Seq(256, 128, 64)
+      )
+    ),
+    args = Array("--target-dir", "generated/xdma")
+  )
 }

--- a/hw/templates/stream_param_gen.scala.tpl
+++ b/hw/templates/stream_param_gen.scala.tpl
@@ -50,6 +50,15 @@ object StreamerParametersGen {
       temporalDimension = ${cfg["snax_streamer_cfg"]["data_reader_params"]["temporal_dim"][idx]},
       tcdmDataWidth = ${tcdm_data_width},
       tcdmSize = ${tcdm_size},
+% if "tcdm_logic_word_size" in cfg["snax_streamer_cfg"]["data_reader_params"]:
+      tcdmLogicWordSize = Seq(
+% for jdx in range(0,len(cfg["snax_streamer_cfg"]["data_reader_params"]["tcdm_logic_word_size"][idx])):
+        ${cfg["snax_streamer_cfg"]["data_reader_params"]["tcdm_logic_word_size"][idx][jdx]}${',' if not loop.last else ''}
+% endfor
+      ),
+% else:
+      tcdmLogicWordSize = Seq(256),
+% endif
       numChannel = ${cfg["snax_streamer_cfg"]["data_reader_params"]["num_channel"][idx]},
       addressBufferDepth = ${cfg["snax_streamer_cfg"]["data_reader_params"]["fifo_depth"][idx]},
       dataBufferDepth = ${cfg["snax_streamer_cfg"]["data_reader_params"]["fifo_depth"][idx]},
@@ -78,6 +87,15 @@ ${'   ), ' if not loop.last else '    )'}
       temporalDimension = ${cfg["snax_streamer_cfg"]["data_writer_params"]["temporal_dim"][idx]},
       tcdmDataWidth = ${tcdm_data_width},
       tcdmSize = ${tcdm_size},
+% if "tcdm_logic_word_size" in cfg["snax_streamer_cfg"]["data_writer_params"]:
+      tcdmLogicWordSize = Seq(
+% for jdx in range(0,len(cfg["snax_streamer_cfg"]["data_writer_params"]["tcdm_logic_word_size"][idx])):
+        ${cfg["snax_streamer_cfg"]["data_writer_params"]["tcdm_logic_word_size"][idx][jdx]}${',' if not loop.last else ''}
+% endfor
+      ),
+% else:
+      tcdmLogicWordSize = Seq(256),
+% endif
       numChannel = ${cfg["snax_streamer_cfg"]["data_writer_params"]["num_channel"][idx]},
       addressBufferDepth = ${cfg["snax_streamer_cfg"]["data_writer_params"]["fifo_depth"][idx]},
       dataBufferDepth = ${cfg["snax_streamer_cfg"]["data_writer_params"]["fifo_depth"][idx]},
@@ -106,6 +124,15 @@ ${'   ), ' if not loop.last else '    )'}
       temporalDimension = ${cfg["snax_streamer_cfg"]["data_reader_writer_params"]["temporal_dim"][idx]},
       tcdmDataWidth = ${tcdm_data_width},
       tcdmSize = ${tcdm_size},
+% if "tcdm_logic_word_size" in cfg["snax_streamer_cfg"]["data_reader_writer_params"]:
+      tcdmLogicWordSize = Seq(
+% for jdx in range(0,len(cfg["snax_streamer_cfg"]["data_reader_writer_params"]["tcdm_logic_word_size"][idx])):
+        ${cfg["snax_streamer_cfg"]["data_reader_writer_params"]["tcdm_logic_word_size"][idx][jdx]}${',' if not loop.last else ''}
+% endfor
+      ),
+% else:
+      tcdmLogicWordSize = Seq(256),
+% endif
       numChannel = ${cfg["snax_streamer_cfg"]["data_reader_writer_params"]["num_channel"][idx]},
       addressBufferDepth = ${cfg["snax_streamer_cfg"]["data_reader_writer_params"]["fifo_depth"][idx]},
       dataBufferDepth = ${cfg["snax_streamer_cfg"]["data_reader_writer_params"]["fifo_depth"][idx]},

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
@@ -214,7 +214,7 @@
         },
 
         data_reader_writer_params:{
-            spatial_bounds: [[4, 8], [4, 8]],
+            spatial_bounds: [[8, 4], [8, 4]],
             temporal_dim: [3, 3],
             num_channel: [32, 32],
             fifo_depth: [2, 2],

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide.hjson
@@ -201,6 +201,7 @@
             num_channel: [8, 8],
             fifo_depth: [8, 8],
             configurable_channel: [0, 0],
+            tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
         },
 
         data_writer_params:{
@@ -209,6 +210,7 @@
             num_channel: [8],
             fifo_depth: [8],
             configurable_channel: [0],
+            tcdm_logic_word_size: [[256, 128, 64]],
         },
 
         data_reader_writer_params:{
@@ -217,6 +219,7 @@
             num_channel: [32, 32],
             fifo_depth: [2, 2],
             configurable_channel: [1, 0],
+            tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
         },
 
         has_transpose: true,

--- a/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
+++ b/target/snitch_cluster/cfg/snax_kul_cluster_mixed_narrow_wide_xdma.hjson
@@ -182,6 +182,7 @@
             num_channel: [8, 8],
             fifo_depth: [8, 8],
             configurable_channel: [0, 0],
+            tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
         },
 
         data_writer_params:{
@@ -190,14 +191,16 @@
             num_channel: [8],
             fifo_depth: [8],
             configurable_channel: [0],
+            tcdm_logic_word_size: [[256, 128, 64]],
         },
 
         data_reader_writer_params:{
-            spatial_bounds: [[4, 8], [4, 8]],
+            spatial_bounds: [[8, 4], [8, 4]],
             temporal_dim: [3, 3],
             num_channel: [32, 32],
             fifo_depth: [2, 2],
             configurable_channel: [1, 0],
+            tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
         },
 
         has_transpose: true,

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
@@ -367,7 +367,7 @@ def emit_conv_data(**kwargs):
     if kwargs["ifC8HW8datalayout"] is True:
         # NHWC
         Cslstride0 = 8
-        Cslstride1 = 32
+        Cslstride1 = 8 * 8
 
         # N dim
         Ctlbound0 = Cout // 8
@@ -428,7 +428,7 @@ def emit_conv_data(**kwargs):
 
     if kwargs["ifC8HW8datalayout"] is True:
         D32slstride0 = 8
-        D32slstride1 = 32
+        D32slstride1 = 8 * 8
 
         # N dim
         D32tlbound0 = Cout // 8
@@ -641,7 +641,7 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "Btlstride2", 0)]
 
     data_str += [format_scalar_definition("int32_t", "Cslstride0", bankWidth / 8)]
-    c32_spatial_bound_0 = 4
+    c32_spatial_bound_0 = 8
     data_str += [
         format_scalar_definition(
             "int32_t", "Cslstride1", c32_spatial_bound_0 * (bankWidth / 8)
@@ -665,7 +665,7 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "Ctlstride2", 0)]
 
     data_str += [format_scalar_definition("int32_t", "D32slstride0", bankWidth / 8)]
-    d32_spatial_bound_0 = 4
+    d32_spatial_bound_0 = 8
     data_str += [
         format_scalar_definition(
             "int32_t", "D32slstride1", d32_spatial_bound_0 * (bankWidth / 8)

--- a/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/data/datagen.py
@@ -922,6 +922,12 @@ def emit_gemmx_data(**kwargs):
 
     data_str += [format_vector_definition("int8_t", "D8", D8)]
 
+    data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_A", 0)]
+    data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_B", 0)]
+    data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_C", 0)]
+    data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_D32", 0)]
+    data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_D8", 0)]
+
     data_str = "\n\n".join(data_str)
 
     return data_str

--- a/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
@@ -107,7 +107,7 @@ int main() {
         if (!bypassSIMD) {
             err += check_gemmx_result_D8(local_d8, D8, Batch, M, N);
         } else {
-            err += check_gemmx_result_D32(local_d32, D32, Batch, M, N);
+            err += check_gemmx_result_D32(local_d32, D32, Batch, M, N, false);
         }
 #ifdef TEST_MATMUL
         printf("SNAX GEMM Matmul: %s, Error: %d . bypassSIMD = %d .\n",

--- a/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx/src/snax-gemmx.c
@@ -61,19 +61,19 @@ int main() {
         set_gemmx_streamer_csr(
             Aslstride0, Aslstride1, Atlbound0, Atlstride0, Atlbound1,
             Atlstride1, Atlbound2, Atlstride2, Atlbound3, Atlstride3, Atlbound4,
-            Atlstride4, Atlbound5, Atlstride5,
+            Atlstride4, Atlbound5, Atlstride5, set_addr_remap_index_A,
 
             Bslstride0, Bslstride1, Btlbound0, Btlstride0, Btlbound1,
-            Btlstride1, Btlbound2, Btlstride2,
+            Btlstride1, Btlbound2, Btlstride2, set_addr_remap_index_B,
 
             D8slstride0, D8slstride1, D8tlbound0, D8tlstride0, D8tlbound1,
-            D8tlstride1, D8tlbound2, D8tlstride2,
+            D8tlstride1, D8tlbound2, D8tlstride2, set_addr_remap_index_D8,
 
             Cslstride0, Cslstride1, Ctlbound0, Ctlstride0, Ctlbound1,
-            Ctlstride1, Ctlbound2, Ctlstride2,
+            Ctlstride1, Ctlbound2, Ctlstride2, set_addr_remap_index_C,
 
             D32slstride0, D32slstride1, D32tlbound0, D32tlstride0, D32tlbound1,
-            D32tlstride1, D32tlbound2, D32tlstride2,
+            D32tlstride1, D32tlbound2, D32tlstride2, set_addr_remap_index_D32,
 
             delta_local_a, delta_local_b, delta_local_d8, delta_local_c,
             delta_local_d32, bypassSIMD, transposed_A, transposed_B,

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -110,4 +110,5 @@ uint32_t check_gemmx_result_D8(int8_t* output, int8_t* output_golden,
                                int32_t Batch, int32_t M, int32_t N);
 
 uint32_t check_gemmx_result_D32(int32_t* output, int32_t* output_golden,
-                                int32_t Batch, int32_t M, int32_t N);
+                                int32_t Batch, int32_t M, int32_t N,
+                                bool banked_data_layout);

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -58,19 +58,23 @@ void set_gemmx_streamer_csr(
     int Aslstride0, int Aslstride1, int Atlbound0, int Atlstride0,
     int Atlbound1, int Atlstride1, int Atlbound2, int Atlstride2, int Atlbound3,
     int Atlstride3, int Atlbound4, int Atlstride4, int Atlbound5,
-    int Atlstride5,
+    int Atlstride5, int set_addr_remap_index_A,
 
     int Bslstride0, int Bslstride1, int Btlbound0, int Btlstride0,
     int Btlbound1, int Btlstride1, int Btlbound2, int Btlstride2,
+    int set_addr_remap_index_B,
 
     int D8slstride0, int D8slstride1, int D8tlbound0, int D8tlstride0,
     int D8tlbound1, int D8tlstride1, int D8tlbound2, int D8tlstride2,
+    int set_addr_remap_index_D8,
 
     int Cslstride0, int Cslstride1, int Ctlbound0, int Ctlstride0,
     int Ctlbound1, int Ctlstride1, int Ctlbound2, int Ctlstride2,
+    int set_addr_remap_index_C,
 
     int D32slstride0, int D32slstride1, int D32tlbound0, int D32tlstride0,
     int D32tlbound1, int D32tlstride1, int D32tlbound2, int D32tlstride2,
+    int set_addr_remap_index_D32,
 
     int delta_local_a, int delta_local_b, int delta_local_d8, int delta_local_c,
     int delta_local_d32, int bypassSIMD, int32_t transpose_A,

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -37,12 +37,10 @@ void set_gemmx_streamer_csr(
     int Aslstride0, int Aslstride1, int Atlbound0, int Atlstride0,
     int Atlbound1, int Atlstride1, int Atlbound2, int Atlstride2, int Atlbound3,
     int Atlstride3, int Atlbound4, int Atlstride4, int Atlbound5,
-    int Atlstride5,
-    int set_addr_remap_index_A,
+    int Atlstride5, int set_addr_remap_index_A,
 
-    int Bslstride0,
-    int Bslstride1, int Btlbound0, int Btlstride0, int Btlbound1,
-    int Btlstride1, int Btlbound2, int Btlstride2,
+    int Bslstride0, int Bslstride1, int Btlbound0, int Btlstride0,
+    int Btlbound1, int Btlstride1, int Btlbound2, int Btlstride2,
     int set_addr_remap_index_B,
 
     int D8slstride0, int D8slstride1, int D8tlbound0, int D8tlstride0,
@@ -82,6 +80,9 @@ void set_gemmx_streamer_csr(
     csrw_ss(T_STRIDE_READER_0_4, Atlstride4);
     csrw_ss(T_STRIDE_READER_0_5, Atlstride5);
 
+    // set the address remap index for A
+    csrw_ss(ADDR_REMAP_INDEX_READER_0, set_addr_remap_index_A);
+
     // base ptr for B
     csrw_ss(BASE_PTR_READER_1_LOW, (uint32_t)(delta_local_b + snrt_l1_next()));
 
@@ -97,6 +98,9 @@ void set_gemmx_streamer_csr(
     csrw_ss(T_STRIDE_READER_1_0, Btlstride0);
     csrw_ss(T_STRIDE_READER_1_1, Btlstride1);
     csrw_ss(T_STRIDE_READER_1_2, Btlstride2);
+
+    // set the address remap index for B
+    csrw_ss(ADDR_REMAP_INDEX_READER_1, set_addr_remap_index_B);
 
     // base ptr for D8
     csrw_ss(BASE_PTR_WRITER_0_LOW, (uint32_t)(delta_local_d8 + snrt_l1_next()));
@@ -120,6 +124,9 @@ void set_gemmx_streamer_csr(
     csrw_ss(T_STRIDE_WRITER_0_1, D8tlstride1);
     csrw_ss(T_STRIDE_WRITER_0_2, D8tlstride2);
 
+    // set the address remap index for D8
+    csrw_ss(ADDR_REMAP_INDEX_WRITER_0, set_addr_remap_index_D8);
+
     // base ptr for C
     csrw_ss(BASE_PTR_READER_WRITER_0_LOW,
             (uint32_t)(delta_local_c + snrt_l1_next()));
@@ -137,6 +144,9 @@ void set_gemmx_streamer_csr(
     csrw_ss(T_STRIDE_READER_WRITER_0_0, Ctlstride0);
     csrw_ss(T_STRIDE_READER_WRITER_0_1, Ctlstride1);
     csrw_ss(T_STRIDE_READER_WRITER_0_2, Ctlstride2);
+
+    // set the address remap index for C
+    csrw_ss(ADDR_REMAP_INDEX_READER_WRITER_0, set_addr_remap_index_C);
 
 #ifdef ENABLED_CHANNEL_READER_WRITER_0
     csrw_ss(ENABLED_CHANNEL_READER_WRITER_0, channel_en_C);
@@ -169,6 +179,9 @@ void set_gemmx_streamer_csr(
     csrw_ss(T_STRIDE_READER_WRITER_1_0, D32tlstride0);
     csrw_ss(T_STRIDE_READER_WRITER_1_1, D32tlstride1);
     csrw_ss(T_STRIDE_READER_WRITER_1_2, D32tlstride2);
+
+    // set the address remap index for D32
+    csrw_ss(ADDR_REMAP_INDEX_READER_WRITER_1, set_addr_remap_index_D32);
 
     // set the transpose
 #ifdef TRANSPOSE_EXTENSION_ENABLE
@@ -256,15 +269,32 @@ uint32_t check_gemmx_result_D8(int8_t* output, int8_t* output_golden,
 }
 
 uint32_t check_gemmx_result_D32(int32_t* output, int32_t* output_golden,
-                                int32_t Batch, int32_t M, int32_t N) {
+                                int32_t Batch, int32_t M, int32_t N,
+                                bool banked_data_layout) {
     uint32_t err = 0;
     uint32_t size = 0;
     size = Batch * M * N * meshRow * meshCol;
 
-    for (int i = 0; i < size; i++) {
-        if (output[i] != output_golden[i]) {
-            err++;
+    if (banked_data_layout) {
+        for (int i = 0; i < size / 16; i += 1) {
+            for (int j = 0; j < 16; j++) {
+                if (*(output + i * (256 / 4) + j) !=
+                    output_golden[i * 16 + j]) {
+                    printf("Error at %0x, %0x, %0x, %0x\n",
+                           output + i * (256 / 4) + j,
+                           *(output + i * (256 / 4) + j), i * 16 + j,
+                           output_golden[i * 16 + j]);
+                    err++;
+                }
+            }
+        }
+    } else {
+        for (int i = 0; i < size; i++) {
+            if (output[i] != output_golden[i]) {
+                err++;
+            }
         }
     }
+
     return err;
 }

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -38,18 +38,24 @@ void set_gemmx_streamer_csr(
     int Atlbound1, int Atlstride1, int Atlbound2, int Atlstride2, int Atlbound3,
     int Atlstride3, int Atlbound4, int Atlstride4, int Atlbound5,
     int Atlstride5,
+    int set_addr_remap_index_A,
 
-    int Bslstride0, int Bslstride1, int Btlbound0, int Btlstride0,
-    int Btlbound1, int Btlstride1, int Btlbound2, int Btlstride2,
+    int Bslstride0,
+    int Bslstride1, int Btlbound0, int Btlstride0, int Btlbound1,
+    int Btlstride1, int Btlbound2, int Btlstride2,
+    int set_addr_remap_index_B,
 
     int D8slstride0, int D8slstride1, int D8tlbound0, int D8tlstride0,
     int D8tlbound1, int D8tlstride1, int D8tlbound2, int D8tlstride2,
+    int set_addr_remap_index_D8,
 
     int Cslstride0, int Cslstride1, int Ctlbound0, int Ctlstride0,
     int Ctlbound1, int Ctlstride1, int Ctlbound2, int Ctlstride2,
+    int set_addr_remap_index_C,
 
     int D32slstride0, int D32slstride1, int D32tlbound0, int D32tlstride0,
     int D32tlbound1, int D32tlstride1, int D32tlbound2, int D32tlstride2,
+    int set_addr_remap_index_D32,
 
     int delta_local_a, int delta_local_b, int delta_local_d8, int delta_local_c,
     int delta_local_d32, int bypassSIMD, int32_t transpose_A,

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -125,12 +125,32 @@ def streamer_csr_num(acc_cfgs):
         )
 
     address_remapper_csr_num = 0
-    if "tcdm_logic_word_size" in acc_cfgs["snax_streamer_cfg"]["data_reader_params"]:
-        address_remapper_csr_num += len(acc_cfgs["snax_streamer_cfg"]["data_reader_params"]["tcdm_logic_word_size"])
-    if "tcdm_logic_word_size" in acc_cfgs["snax_streamer_cfg"]["data_writer_params"]:
-        address_remapper_csr_num += len(acc_cfgs["snax_streamer_cfg"]["data_writer_params"]["tcdm_logic_word_size"])
-    if "data_reader_writer_params" in acc_cfgs["snax_streamer_cfg"] and "tcdm_logic_word_size" in acc_cfgs["snax_streamer_cfg"]["data_reader_writer_params"]:
-        address_remapper_csr_num += len(acc_cfgs["snax_streamer_cfg"]["data_reader_writer_params"]["tcdm_logic_word_size"])
+    if (
+        "data_reader_params" in acc_cfgs["snax_streamer_cfg"]
+        and "tcdm_logic_word_size"
+        in acc_cfgs["snax_streamer_cfg"]["data_reader_params"]
+    ):
+        address_remapper_csr_num += len(
+            acc_cfgs["snax_streamer_cfg"]["data_reader_params"]["tcdm_logic_word_size"]
+        )
+    if (
+        "data_writer_params" in acc_cfgs["snax_streamer_cfg"]
+        and "tcdm_logic_word_size"
+        in acc_cfgs["snax_streamer_cfg"]["data_writer_params"]
+    ):
+        address_remapper_csr_num += len(
+            acc_cfgs["snax_streamer_cfg"]["data_writer_params"]["tcdm_logic_word_size"]
+        )
+    if (
+        "data_reader_writer_params" in acc_cfgs["snax_streamer_cfg"]
+        and "tcdm_logic_word_size"
+        in acc_cfgs["snax_streamer_cfg"]["data_reader_writer_params"]
+    ):
+        address_remapper_csr_num += len(
+            acc_cfgs["snax_streamer_cfg"]["data_reader_writer_params"][
+                "tcdm_logic_word_size"
+            ]
+        )
 
     # Calculation of data movers
     num_data_reader = 0

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -124,6 +124,14 @@ def streamer_csr_num(acc_cfgs):
             )
         )
 
+    address_remapper_csr_num = 0
+    if "tcdm_logic_word_size" in acc_cfgs["snax_streamer_cfg"]["data_reader_params"]:
+        address_remapper_csr_num += len(acc_cfgs["snax_streamer_cfg"]["data_reader_params"]["tcdm_logic_word_size"])
+    if "tcdm_logic_word_size" in acc_cfgs["snax_streamer_cfg"]["data_writer_params"]:
+        address_remapper_csr_num += len(acc_cfgs["snax_streamer_cfg"]["data_writer_params"]["tcdm_logic_word_size"])
+    if "data_reader_writer_params" in acc_cfgs["snax_streamer_cfg"] and "tcdm_logic_word_size" in acc_cfgs["snax_streamer_cfg"]["data_reader_writer_params"]:
+        address_remapper_csr_num += len(acc_cfgs["snax_streamer_cfg"]["data_reader_writer_params"]["tcdm_logic_word_size"])
+
     # Calculation of data movers
     num_data_reader = 0
     num_data_writer = 0
@@ -193,6 +201,7 @@ def streamer_csr_num(acc_cfgs):
         + num_s_loop_dim  # Number of spatial strides
         + 2 * num_data_mover  # Number of base pointers, 2 for each
         + num_configurable_channel  # Number of configurable channels
+        + address_remapper_csr_num  # Number of address remapper
         + 1  # Performance counter
         + 1  # Busy register
         + 1  # Start register


### PR DESCRIPTION
This PR introduces the new affined address mapping unit to map the address from interleaved to non-interleaved, aiming to help avoid bank conflict and performance degradation. More specifically, we:
1) add the address remap flag in the AGU/streamer
2) enable the addr remap flag for gemmx and relevant modification in the snaxgen
3) add CSR modification in snax-gemmx library