### PR TITLE
Add test for non-interleaved memory space for conv

### DIFF
--- a/target/snitch_cluster/sw/apps/snax-gemmx-conv/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-conv/data/params.hjson
@@ -22,6 +22,10 @@
   broadcast_C: 1,
   channel_en_C: 1,
 
+  // memory space configurations
+  interleaved_address: 0,
+  memory_size: 4096,
+
   // hardware parameters
   meshRow : 8,
   tileSize: 8,

--- a/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
@@ -140,7 +140,7 @@ int main() {
                                               true);
             }
         }
-        
+
         printf("SNAX GEMM Conv2d: %s, Error: %d . bypassSIMD = %d .\n",
                err ? "FAIL" : "PASS", err, bypassSIMD);
     };

--- a/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
@@ -17,12 +17,24 @@ int main() {
     // Set err value for checking
     int err = 0;
 
-    // Prepare addresses in TCDM
+    // Prepare addresses pointers in TCDM for DMA
+    int8_t *local_a_dma, *local_b_dma;
+    int32_t *local_c_dma, *local_d32_dma;
+    int8_t *local_d8_dma;
+
+    // Allocate space in TCDM for DMA
+    local_a_dma = (int8_t *)(snrt_l1_next() + delta_physical_a);
+    local_b_dma = (int8_t *)(snrt_l1_next() + delta_physical_b);
+    local_c_dma = (int32_t *)(snrt_l1_next() + delta_physical_c);
+    local_d32_dma = (int32_t *)(snrt_l1_next() + delta_physical_d32);
+    local_d8_dma = (int8_t *)(snrt_l1_next() + delta_physical_d8);
+
+    // Prepare addresses pointers in TCDM for streamer
     int8_t *local_a, *local_b;
     int32_t *local_c, *local_d32;
     int8_t *local_d8;
 
-    // Allocate space in TCDM
+    // Allocate space in TCDM for streamer
     local_a = (int8_t *)(snrt_l1_next() + delta_local_a);
     local_b = (int8_t *)(snrt_l1_next() + delta_local_b);
     local_c = (int32_t *)(snrt_l1_next() + delta_local_c);
@@ -32,18 +44,33 @@ int main() {
     // Transfer data from L3 to L1
     // Using DMA only
     if (snrt_is_dm_core()) {
-        snrt_dma_start_1d(
-            local_a, A,
-            Nbatch * (H + 2 * pad_h) * (W + 2 * pad_w) * Cin * sizeof(int8_t));
-        snrt_dma_start_1d(local_b, B, Cout * Kh * Kw * Cin * sizeof(int8_t));
+        if (interleaved_address == 1) {
+            snrt_dma_start_1d(local_a, A,
+                              Nbatch * (H + 2 * pad_h) * (W + 2 * pad_w) * Cin *
+                                  sizeof(int8_t));
+            snrt_dma_start_1d(local_b, B,
+                              Cout * Kh * Kw * Cin * sizeof(int8_t));
+        } else {
+            snrt_dma_start_2d(
+                local_a_dma, A, 64 * sizeof(int8_t), 256, 64,
+                Nbatch * (H + 2 * pad_h) * (W + 2 * pad_w) * Cin / 64);
+            snrt_dma_start_2d(local_b_dma, B, 64 * sizeof(int8_t), 256, 64,
+                              Cout * Kh * Kw * Cin / 64);
+        }
         snrt_dma_wait_all();
     }
 
     // Wait for DMA to finish
     snrt_cluster_hw_barrier();
     if (snrt_is_dm_core()) {
-        snrt_dma_start_1d(local_c, C,
-                          M * N * meshRow * meshCol * sizeof(int32_t));
+        if (interleaved_address == 1) {
+            snrt_dma_start_1d(local_c, C,
+                              M * N * meshRow * meshCol * sizeof(int32_t));
+        } else {
+            snrt_dma_start_2d(local_c_dma, C, 16 * sizeof(int32_t), 256,
+                              16 * sizeof(int32_t),
+                              M * N * meshRow * meshCol / 16);
+        }
         snrt_dma_wait_all();
     }
 
@@ -97,12 +124,23 @@ int main() {
         wait_gemmx_and_streamer();
 
         // check the result of the implicit im2col convolution
-        if (!bypassSIMD) {
-            err += check_gemmx_result_D8(local_d8, D8, Batch, M, N);
+        if (interleaved_address == 1) {
+            if (!bypassSIMD) {
+                err += check_gemmx_result_D8(local_d8, D8, Batch, M, N, false);
+            } else {
+                err +=
+                    check_gemmx_result_D32(local_d32, D32, Batch, M, N, false);
+            }
         } else {
-            err += check_gemmx_result_D32(local_d32, D32, Batch, M, N, false);
+            if (!bypassSIMD) {
+                err +=
+                    check_gemmx_result_D8(local_d8_dma, D8, Batch, M, N, true);
+            } else {
+                err += check_gemmx_result_D32(local_d32_dma, D32, Batch, M, N,
+                                              true);
+            }
         }
-
+        
         printf("SNAX GEMM Conv2d: %s, Error: %d . bypassSIMD = %d .\n",
                err ? "FAIL" : "PASS", err, bypassSIMD);
     };

--- a/target/snitch_cluster/sw/apps/snax-gemmx-matmul/src/snax-gemmx-matmul.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-matmul/src/snax-gemmx-matmul.c
@@ -99,7 +99,7 @@ int main() {
 
         // check the result of the implicit im2col convolution
         if (!bypassSIMD) {
-            err += check_gemmx_result_D8(local_d8, D8, Batch, M, N);
+            err += check_gemmx_result_D8(local_d8, D8, Batch, M, N, false);
         } else {
             err += check_gemmx_result_D32(local_d32, D32, Batch, M, N, false);
         }

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -107,7 +107,8 @@ uint32_t read_gemmx_perf_counter();
 
 // Check the result of the implicit im2col convolution
 uint32_t check_gemmx_result_D8(int8_t* output, int8_t* output_golden,
-                               int32_t Batch, int32_t M, int32_t N);
+                               int32_t Batch, int32_t M, int32_t N,
+                               bool banked_data_layout);
 
 uint32_t check_gemmx_result_D32(int32_t* output, int32_t* output_golden,
                                 int32_t Batch, int32_t M, int32_t N,


### PR DESCRIPTION
Add the banked data layout test for conv to improve its utilization.
Enable the banked data layout by setting: interleaved_address to 1 and make sure to set the correct TCDM memory size. Setting interleaved_address  to 1 means no change, exactly the same as before.