### PR TITLE
Snitch Cacheable Region Modification

### DIFF
--- a/hw/snitch/src/snitch_pma_pkg.sv
+++ b/hw/snitch/src/snitch_pma_pkg.sv
@@ -32,7 +32,7 @@ package snitch_pma_pkg;
 
   // Public interface
   // Hack the Public interface to make it working with floating addresses with floating addresses
-  // Since snitch is a 32b core, it never touch MSB; and MSB is automatically padded with the chip_id, so it does not need to be checked
+  // Since snitch is a 32b core, it never touch MSB; and MSB is automatically padded with the chip_id, so no checking on MSB is needed
   function automatic logic range_check(logic[47:0] base, logic[47:0] mask, logic[47:0] address);
     return (address[39:0] & mask[39:0]) == (base[39:0] & mask[39:0]);
   endfunction : range_check

--- a/hw/snitch/src/snitch_pma_pkg.sv
+++ b/hw/snitch/src/snitch_pma_pkg.sv
@@ -31,29 +31,33 @@ package snitch_pma_pkg;
   } snitch_pma_t;
 
   // Public interface
+  // Hack the Public interface to make it working with floating addresses with floating addresses
+  // Since snitch is a 32b core, it never touch MSB; and MSB is automatically padded with the chip_id, so it does not need to be checked
   function automatic logic range_check(logic[47:0] base, logic[47:0] mask, logic[47:0] address);
-    return (address & mask) == (base & mask);
+    return (address[39:0] & mask[39:0]) == (base[39:0] & mask[39:0]);
   endfunction : range_check
 
-  function automatic logic is_inside_nonidempotent_regions (snitch_pma_t cfg, logic[47:0] address);
-    logic [NrMaxRules-1:0] pass;
-    pass = '0;
-    for (int unsigned k = 0; k < cfg.NrNonIdempotentRegionRules; k++) begin
-      pass[k] =
-        range_check(cfg.NonIdempotentRegion[k].base, cfg.NonIdempotentRegion[k].mask, address);
-    end
-    return |pass;
-  endfunction : is_inside_nonidempotent_regions
+  // Snitch does not do inside_nonidempotent_regions and inside_nonidempotent_regions check; it only does inside_cacheable_regions check
 
-  function automatic logic is_inside_execute_regions (snitch_pma_t cfg, logic[47:0] address);
-    // if we don't specify any region we assume everything is accessible
-    logic [NrMaxRules-1:0] pass;
-    pass = '0;
-    for (int unsigned k = 0; k < cfg.NrExecuteRegionRules; k++) begin
-      pass[k] = range_check(cfg.ExecuteRegion[k].base, cfg.ExecuteRegion[k].mask, address);
-    end
-    return |pass;
-  endfunction : is_inside_execute_regions
+  // function automatic logic is_inside_nonidempotent_regions (snitch_pma_t cfg, logic[47:0] address);
+  //   logic [NrMaxRules-1:0] pass;
+  //   pass = '0;
+  //   for (int unsigned k = 0; k < cfg.NrNonIdempotentRegionRules; k++) begin
+  //     pass[k] =
+  //       range_check(cfg.NonIdempotentRegion[k].base, cfg.NonIdempotentRegion[k].mask, address);
+  //   end
+  //   return |pass;
+  // endfunction : is_inside_nonidempotent_regions
+
+  // function automatic logic is_inside_execute_regions (snitch_pma_t cfg, logic[47:0] address);
+  //   // if we don't specify any region we assume everything is accessible
+  //   logic [NrMaxRules-1:0] pass;
+  //   pass = '0;
+  //   for (int unsigned k = 0; k < cfg.NrExecuteRegionRules; k++) begin
+  //     pass[k] = range_check(cfg.ExecuteRegion[k].base, cfg.ExecuteRegion[k].mask, address);
+  //   end
+  //   return |pass;
+  // endfunction : is_inside_execute_regions
 
   function automatic logic is_inside_cacheable_regions (snitch_pma_t cfg, logic[47:0] address);
     automatic logic [NrMaxRules-1:0] pass;


### PR DESCRIPTION
This PR does a slight modification on the logic to judge whether one instruction's address falls within cacheable region. This is designed for future chiplet configuration but will not impact the current tapeout. 