### PR TITLE
Add `--disable-tracing` and `--prefix-trace` options to snax_cluster

### DIFF
--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -865,7 +865,7 @@ module snitch_cc #(
     if(enable_tracing()) begin
       $sformat(fn, "trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
                tcdm_addr_base_i[43:40], hart_id_i);
-      $sformat(trace_file, "%s_%s", get_trace_file_prefix(), fn);
+      $sformat(trace_file, "%s%s", get_trace_file_prefix(), fn);
       f = $fopen(trace_file, "w");
       $display("[Tracer] Logging Hart %d to %s", hart_id_i, trace_file);
     end

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -7,13 +7,8 @@
 
 
 `ifdef VERILATOR // For verilator-based simulations, tracing can be disabled and prefixed
-
-    import "DPI-C" function bit disable_tracing();
-    import "DPI-C" function string get_trace_file_prefix();
-
-    `define BEGIN_DISABLEBLE_TRACING() if(!disable_tracing()) begin
-    `define END_DISABLEBLE_TRACING() end
-
+import "DPI-C" function bit disable_tracing();
+import "DPI-C" function string get_trace_file_prefix();
 `endif
 
 

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -879,13 +879,18 @@ module snitch_cc #(
     #1;
 `endif
     BEGIN_DISABLEBLE_TRACING()
-    `ifdef VERILATOR // Verilator allows prefixing trace
+
+    `ifdef VERILATOR
+    // Verilator allows prefixing trace, and makes logs folder in C++ code in the default case
     $sformat(suffix, "trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
              tcdm_addr_base_i[43:40], hart_id_i);
     $sformat(trace_file, "%s%s", get_trace_file_prefix(), suffix);
     `else
-    $sformat(trace_file, "trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
+    // Make the logs directory from systemverilog
+    $system("mkdir -p logs")
+    $sformat(trace_file, "logs/trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
              tcdm_addr_base_i[43:40], hart_id_i);
+
     `endif
     f = $fopen(trace_file, "w");
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, trace_file);

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -4,8 +4,24 @@
 
 // Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 //
-import "DPI-C" function bit enable_tracing();
-import "DPI-C" function string get_trace_file_prefix();
+
+
+`ifdef VERILATOR // For verilator-based simulations, tracing can be disabled and prefixed
+
+    import "DPI-C" function bit enable_tracing();
+    import "DPI-C" function string get_trace_file_prefix();
+
+    `define BEGIN_DISABLEBLE_TRACING() if(enable_tracing()) begin
+    `define END_DISABLEBLE_TRACING() end
+
+`else // For non-verilator disabling tracing is not possible
+
+    `define BEGIN_DISABLEBLE_TRACING() begin
+    `define END_DISABLEBLE_TRACING() end
+
+`endif
+
+
 
 `include "common_cells/assertions.svh"
 `include "common_cells/registers.svh"
@@ -851,7 +867,7 @@ module snitch_cc #(
   // --------------------------
   // pragma translate_off
   int f;
-  string fn;
+  string suffix;
   string trace_file;
   string folder = "logs";
   logic [63:0] cycle = 0;
@@ -862,120 +878,123 @@ module snitch_cc #(
 `ifndef VERILATOR
     #1;
 `endif
-    if(enable_tracing()) begin
-      $sformat(fn, "trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
-               tcdm_addr_base_i[43:40], hart_id_i);
-      $sformat(trace_file, "%s%s", get_trace_file_prefix(), fn);
-      f = $fopen(trace_file, "w");
-      $display("[Tracer] Logging Hart %d to %s", hart_id_i, trace_file);
-    end
+    BEGIN_DISABLEBLE_TRACING()
+    `ifdef VERILATOR // Verilator allows prefixing trace
+    $sformat(suffix, "trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
+             tcdm_addr_base_i[43:40], hart_id_i);
+    $sformat(trace_file, "%s%s", get_trace_file_prefix(), suffix);
+    `else
+    $sformat(trace_file, "trace_chip_%01x%01x_hart_%05x.dasm", tcdm_addr_base_i[47:44],
+             tcdm_addr_base_i[43:40], hart_id_i);
+    `endif
+    f = $fopen(trace_file, "w");
+    $display("[Tracer] Logging Hart %d to %s", hart_id_i, trace_file);
+    END_DISABLEBLE_TRACING()
   end
 
   // verilog_lint: waive-start always-ff-non-blocking
   always_ff @(posedge clk_i) begin
-    if (enable_tracing()) begin
-      automatic string trace_entry;
-      automatic string extras_str;
-      automatic snitch_pkg::snitch_trace_port_t extras_snitch;
-      automatic snitch_pkg::fpu_trace_port_t extras_fpu;
-      automatic snitch_pkg::fpu_sequencer_trace_port_t extras_fpu_seq_out;
+    BEGIN_DISABLEBLE_TRACING()
+    automatic string trace_entry;
+    automatic string extras_str;
+    automatic snitch_pkg::snitch_trace_port_t extras_snitch;
+    automatic snitch_pkg::fpu_trace_port_t extras_fpu;
+    automatic snitch_pkg::fpu_sequencer_trace_port_t extras_fpu_seq_out;
 
-      if (rst_ni) begin
-        extras_snitch = '{
-          // State
-          source:       snitch_pkg::SrcSnitch,
-          stall:        i_snitch.stall,
-          exception:    i_snitch.exception,
-          // Decoding
-          rs1:          i_snitch.rs1,
-          rs2:          i_snitch.rs2,
-          rd:           i_snitch.rd,
-          is_load:      i_snitch.is_load,
-          is_store:     i_snitch.is_store,
-          is_branch:    i_snitch.is_branch,
-          pc_d:         i_snitch.pc_d,
-          // Operands
-          opa:          i_snitch.opa,
-          opb:          i_snitch.opb,
-          opa_select:   i_snitch.opa_select,
-          opb_select:   i_snitch.opb_select,
-          write_rd:     i_snitch.write_rd,
-          csr_addr:     i_snitch.inst_data_i[31:20],
-          // Pipeline writeback
-          writeback:    i_snitch.alu_writeback,
-          // Load/Store
-          gpr_rdata_1:  i_snitch.gpr_rdata[1],
-          ls_size:      i_snitch.ls_size,
-          ld_result_32: i_snitch.ld_result[31:0],
-          lsu_rd:       i_snitch.lsu_rd,
-          retire_load:  i_snitch.retire_load,
-          alu_result:   i_snitch.alu_result,
-          // Atomics
-          ls_amo:       i_snitch.ls_amo,
-          // Accelerator
-          retire_acc:   i_snitch.retire_acc,
-          acc_pid:      i_snitch.acc_prsp_i.id,
-          acc_pdata_32: i_snitch.acc_prsp_i.data[31:0],
-          // FPU offload
-          fpu_offload:
-            (i_snitch.acc_qready_i && i_snitch.acc_qvalid_o && i_snitch.acc_qreq_o.addr == 0),
-          is_seq_insn:  (i_snitch.inst_data_i inside {riscv_instr::FREP_I, riscv_instr::FREP_O})
-        };
-        if (FPEn) begin
-          extras_fpu = fpu_trace;
-          if (Xfrep) begin
-            // Addenda to FPU extras iff popping sequencer
-            extras_fpu_seq_out = fpu_sequencer_trace;
-          end
+    if (rst_ni) begin
+      extras_snitch = '{
+        // State
+        source:       snitch_pkg::SrcSnitch,
+        stall:        i_snitch.stall,
+        exception:    i_snitch.exception,
+        // Decoding
+        rs1:          i_snitch.rs1,
+        rs2:          i_snitch.rs2,
+        rd:           i_snitch.rd,
+        is_load:      i_snitch.is_load,
+        is_store:     i_snitch.is_store,
+        is_branch:    i_snitch.is_branch,
+        pc_d:         i_snitch.pc_d,
+        // Operands
+        opa:          i_snitch.opa,
+        opb:          i_snitch.opb,
+        opa_select:   i_snitch.opa_select,
+        opb_select:   i_snitch.opb_select,
+        write_rd:     i_snitch.write_rd,
+        csr_addr:     i_snitch.inst_data_i[31:20],
+        // Pipeline writeback
+        writeback:    i_snitch.alu_writeback,
+        // Load/Store
+        gpr_rdata_1:  i_snitch.gpr_rdata[1],
+        ls_size:      i_snitch.ls_size,
+        ld_result_32: i_snitch.ld_result[31:0],
+        lsu_rd:       i_snitch.lsu_rd,
+        retire_load:  i_snitch.retire_load,
+        alu_result:   i_snitch.alu_result,
+        // Atomics
+        ls_amo:       i_snitch.ls_amo,
+        // Accelerator
+        retire_acc:   i_snitch.retire_acc,
+        acc_pid:      i_snitch.acc_prsp_i.id,
+        acc_pdata_32: i_snitch.acc_prsp_i.data[31:0],
+        // FPU offload
+        fpu_offload:
+          (i_snitch.acc_qready_i && i_snitch.acc_qvalid_o && i_snitch.acc_qreq_o.addr == 0),
+        is_seq_insn:  (i_snitch.inst_data_i inside {riscv_instr::FREP_I, riscv_instr::FREP_O})
+      };
+      if (FPEn) begin
+        extras_fpu = fpu_trace;
+        if (Xfrep) begin
+          // Addenda to FPU extras iff popping sequencer
+          extras_fpu_seq_out = fpu_sequencer_trace;
         end
-
-        cycle++;
-        // Trace snitch iff:
-        // we are not stalled <==> we have issued and processed an instruction (including offloads)
-        // OR we are retiring (issuing a writeback from) a load or accelerator instruction
-        if (
-            !i_snitch.stall || i_snitch.retire_load || i_snitch.retire_acc
-        ) begin
-          if(enable_tracing()) begin
-            $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
-                $time, cycle, i_snitch.priv_lvl_q, i_snitch.pc_q, i_snitch.inst_data_i,
-                snitch_pkg::print_snitch_trace(extras_snitch));
-            $fwrite(f, trace_entry);
-          end
-        end
-        if (FPEn) begin
-          // Trace FPU iff:
-          // an incoming handshake on the accelerator bus occurs <==> an instruction was issued
-          // OR an FPU result is ready to be written back to an FPR register or the bus
-          // OR an LSU result is ready to be written back to an FPR register or the bus
-          // OR an FPU result, LSU result or bus value is ready to be written back to an FPR register
-          if (extras_fpu.acc_q_hs || extras_fpu.fpu_out_hs
-          || extras_fpu.lsu_q_hs || extras_fpu.fpr_we) begin
-            $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
-                $time, cycle, i_snitch.priv_lvl_q, 32'hz, extras_fpu.op_in,
-                snitch_pkg::print_fpu_trace(extras_fpu));
-            $fwrite(f, trace_entry);
-          end
-          // sequencer instructions
-          if (Xfrep) begin
-            if (extras_fpu_seq_out.cbuf_push) begin
-              $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
-                  $time, cycle, i_snitch.priv_lvl_q, 32'hz, 64'hz,
-                  snitch_pkg::print_fpu_sequencer_trace(extras_fpu_seq_out));
-              $fwrite(f, trace_entry);
-            end
-          end
-        end
-      end else begin
-        cycle = '0;
       end
+
+      cycle++;
+      // Trace snitch iff:
+      // we are not stalled <==> we have issued and processed an instruction (including offloads)
+      // OR we are retiring (issuing a writeback from) a load or accelerator instruction
+      if (
+          !i_snitch.stall || i_snitch.retire_load || i_snitch.retire_acc
+      ) begin
+        $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
+            $time, cycle, i_snitch.priv_lvl_q, i_snitch.pc_q, i_snitch.inst_data_i,
+            snitch_pkg::print_snitch_trace(extras_snitch));
+        $fwrite(f, trace_entry);
+      end
+      if (FPEn) begin
+        // Trace FPU iff:
+        // an incoming handshake on the accelerator bus occurs <==> an instruction was issued
+        // OR an FPU result is ready to be written back to an FPR register or the bus
+        // OR an LSU result is ready to be written back to an FPR register or the bus
+        // OR an FPU result, LSU result or bus value is ready to be written back to an FPR register
+        if (extras_fpu.acc_q_hs || extras_fpu.fpu_out_hs
+        || extras_fpu.lsu_q_hs || extras_fpu.fpr_we) begin
+          $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
+              $time, cycle, i_snitch.priv_lvl_q, 32'hz, extras_fpu.op_in,
+              snitch_pkg::print_fpu_trace(extras_fpu));
+          $fwrite(f, trace_entry);
+        end
+        // sequencer instructions
+        if (Xfrep) begin
+          if (extras_fpu_seq_out.cbuf_push) begin
+            $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
+                $time, cycle, i_snitch.priv_lvl_q, 32'hz, 64'hz,
+                snitch_pkg::print_fpu_sequencer_trace(extras_fpu_seq_out));
+            $fwrite(f, trace_entry);
+          end
+        end
+      end
+    end else begin
+      cycle = '0;
     end
+    END_DISABLEBLE_TRACING()
   end
 
   final begin
-    if (enable_tracing()) begin
-      $fclose(f);
-    end
+    BEGIN_DISABLEBLE_TRACING()
+    $fclose(f);
+    END_DISABLEBLE_TRACING()
   end
   // verilog_lint: waive-stop always-ff-non-blocking
   // pragma translate_on

--- a/target/common/test/tb_bin.cc
+++ b/target/common/test/tb_bin.cc
@@ -3,22 +3,24 @@
 // SPDX-License-Identifier: SHL-0.51
 
 #include <printf.h>
+#include <cstring>
 #include <iostream>
 #include <vector>
-#include <cstring>
 
 #include "sim.hh"
 
 // Declare these as global variables
 bool WRAPPER_disable_tracing = false;
-char* WRAPPER_trace_prefix = nullptr;
+char *WRAPPER_trace_prefix = nullptr;
 
 void print_usage(const char *prog_name) {
-    std::cout << "Usage: " << prog_name << " [SNAX WRAPPER Options] [HTIF Options]\n"
+    std::cout << "Usage: " << prog_name
+              << " [SNAX WRAPPER Options] [HTIF Options]\n"
               << "  Wrap Rocket Chip Emulator in SNAX RTL Simulator\n\n"
               << "SNAX WRAPPER Options:\n"
               << "  --disable-tracing       Disable Snitch tracing\n"
-              << "  --prefix-trace=PREFIX   Set trace prefix (cannot be used with --disable-tracing)\n\n";
+              << "  --prefix-trace=PREFIX   Set trace prefix (cannot be used "
+                 "with --disable-tracing)\n\n";
 }
 
 int main(int argc, char **argv, char **env) {
@@ -37,36 +39,41 @@ int main(int argc, char **argv, char **env) {
         if (strcmp(argv[i], "--disable-tracing") == 0) {
             WRAPPER_disable_tracing = true;
         } else if (strncmp(argv[i], "--prefix-trace=", 15) == 0) {
-            WRAPPER_trace_prefix = argv[i] + 15; // Extract the value after `--prefix-trace=`
-        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            WRAPPER_trace_prefix =
+                argv[i] + 15;  // Extract the value after `--prefix-trace=`
+        } else if (strcmp(argv[i], "-h") == 0 ||
+                   strcmp(argv[i], "--help") == 0) {
             print_usage(argv[0]);
-	    // Also show help from underlying fesvr function
-	    // Note:
-	    // If a binary is supplied, it will show both the snax wrapper help,
-	    // AND continue with the execution of the program...
-	    auto sim = std::make_unique<sim::Sim>(argc, argv);
-	    return sim->run();
+            // Also show help from underlying fesvr function
+            // Note:
+            // If a binary is supplied, it will show both the snax wrapper help,
+            // AND continue with the execution of the program...
+            auto sim = std::make_unique<sim::Sim>(argc, argv);
+            return sim->run();
             return -1;
         }
     }
     // Validate conflicting options
     if (WRAPPER_disable_tracing && WRAPPER_trace_prefix != nullptr) {
-        std::cerr << "Error: --disable-tracing and --prefix-trace cannot be used together.\n";
-        return 1; // Indicate an error
+        std::cerr << "Error: --disable-tracing and --prefix-trace cannot be "
+                     "used together.\n";
+        return 1;
     }
     // Prepare filtered arguments
     std::vector<char *> filtered_argv;
     for (int i = 0; i < argc; ++i) {
         // Skip custom options
-        if (strcmp(argv[i], "--disable-tracing") == 0 || strncmp(argv[i], "--prefix-trace=", 15) == 0) {
+        if (strcmp(argv[i], "--disable-tracing") == 0 ||
+            strncmp(argv[i], "--prefix-trace=", 15) == 0) {
             continue;
         }
         filtered_argv.push_back(argv[i]);
     }
-    filtered_argv.push_back(nullptr); // Null-terminate for compatibility
+    filtered_argv.push_back(nullptr);  // Null-terminate for compatibility
 
     // Pass the filtered arguments to fesvr argument handling
-    int filtered_argc = static_cast<int>(filtered_argv.size()) - 1; // Exclude null terminator
+    int filtered_argc =
+        static_cast<int>(filtered_argv.size()) - 1;  // Exclude null terminator
     char **filtered_argv_ptr = filtered_argv.data();
     auto sim = std::make_unique<sim::Sim>(filtered_argc, filtered_argv_ptr);
     return sim->run();

--- a/target/common/test/tb_bin.cc
+++ b/target/common/test/tb_bin.cc
@@ -5,7 +5,6 @@
 #include <printf.h>
 #include <iostream>
 #include <vector>
-#include <string>
 #include <cstring>
 
 #include "sim.hh"

--- a/target/common/test/tb_bin.cc
+++ b/target/common/test/tb_bin.cc
@@ -3,8 +3,24 @@
 // SPDX-License-Identifier: SHL-0.51
 
 #include <printf.h>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cstring>
 
 #include "sim.hh"
+
+// Declare these as global variables
+bool WRAPPER_disable_tracing = false;
+char* WRAPPER_trace_prefix = nullptr;
+
+void print_usage(const char *prog_name) {
+    std::cout << "Usage: " << prog_name << " [SNAX WRAPPER Options] [HTIF Options]\n"
+              << "  Wrap Rocket Chip Emulator in SNAX RTL Simulator\n\n"
+              << "SNAX WRAPPER Options:\n"
+              << "  --disable-tracing       Disable Snitch tracing\n"
+              << "  --prefix-trace=PREFIX   Set trace prefix (cannot be used with --disable-tracing)\n\n";
+}
 
 int main(int argc, char **argv, char **env) {
     // Write binary path to logs/binary for the `make annotate` target
@@ -17,7 +33,42 @@ int main(int argc, char **argv, char **env) {
         fprintf(stderr,
                 "Warning: Failed to write binary name to logs/.rtlbinary\n");
     }
+    // Parse custom wrapper arguments
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--disable-tracing") == 0) {
+            WRAPPER_disable_tracing = true;
+        } else if (strncmp(argv[i], "--prefix-trace=", 15) == 0) {
+            WRAPPER_trace_prefix = argv[i] + 15; // Extract the value after `--prefix-trace=`
+        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            print_usage(argv[0]);
+	    // Also show help from underlying fesvr function
+	    // Note:
+	    // If a binary is supplied, it will show both the snax wrapper help,
+	    // AND continue with the execution of the program...
+	    auto sim = std::make_unique<sim::Sim>(argc, argv);
+	    return sim->run();
+            return -1;
+        }
+    }
+    // Validate conflicting options
+    if (WRAPPER_disable_tracing && WRAPPER_trace_prefix != nullptr) {
+        std::cerr << "Error: --disable-tracing and --prefix-trace cannot be used together.\n";
+        return 1; // Indicate an error
+    }
+    // Prepare filtered arguments
+    std::vector<char *> filtered_argv;
+    for (int i = 0; i < argc; ++i) {
+        // Skip custom options
+        if (strcmp(argv[i], "--disable-tracing") == 0 || strncmp(argv[i], "--prefix-trace=", 15) == 0) {
+            continue;
+        }
+        filtered_argv.push_back(argv[i]);
+    }
+    filtered_argv.push_back(nullptr); // Null-terminate for compatibility
 
-    auto sim = std::make_unique<sim::Sim>(argc, argv);
+    // Pass the filtered arguments to fesvr argument handling
+    int filtered_argc = static_cast<int>(filtered_argv.size()) - 1; // Exclude null terminator
+    char **filtered_argv_ptr = filtered_argv.data();
+    auto sim = std::make_unique<sim::Sim>(filtered_argc, filtered_argv_ptr);
     return sim->run();
 }

--- a/target/common/test/tb_bin.cc
+++ b/target/common/test/tb_bin.cc
@@ -19,7 +19,7 @@ void print_usage(const char *prog_name) {
               << "  Wrap Rocket Chip Emulator in SNAX RTL Simulator\n\n"
               << "SNAX WRAPPER Options:\n"
               << "  --disable-tracing       Disable Snitch tracing\n"
-              << "  --prefix-trace=PREFIX   Set trace prefix (cannot be used "
+              << "  --prefix-trace <prefix> Set trace prefix (cannot be used "
                  "with --disable-tracing)\n\n";
 }
 
@@ -38,7 +38,7 @@ int main(int argc, char **argv, char **env) {
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--disable-tracing") == 0) {
             WRAPPER_disable_tracing = true;
-        } else if (strncmp(argv[i], "--prefix-trace=", 15) == 0) {
+        } else if (strncmp(argv[i], "--prefix-trace ", 15) == 0) {
             WRAPPER_trace_prefix =
                 argv[i] + 15;  // Extract the value after `--prefix-trace=`
         } else if (strcmp(argv[i], "-h") == 0 ||
@@ -64,7 +64,7 @@ int main(int argc, char **argv, char **env) {
     for (int i = 0; i < argc; ++i) {
         // Skip custom options
         if (strcmp(argv[i], "--disable-tracing") == 0 ||
-            strncmp(argv[i], "--prefix-trace=", 15) == 0) {
+            strncmp(argv[i], "--prefix-trace ", 15) == 0) {
             continue;
         }
         filtered_argv.push_back(argv[i]);

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -3,12 +3,8 @@
 // SPDX-License-Identifier: SHL-0.51
 
 #include <printf.h>
-#include <cstdlib>  // For std::getenv
-#include <iostream> // For std::cout, std::cerr
-#include <string>   // For std::string
-#include <stdexcept> // For std::invalid_argument, std::out_of_range
-#include <filesystem> // C++17 filesystem library
-#include <system_error> // For error handling
+#include <string>
+#include <filesystem>
 
 #include "Vtestharness.h"
 #include "Vtestharness__Dpi.h"

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -117,29 +117,9 @@ void tb_memory_write(long long addr, int len, const svOpenArrayHandle data,
                    (const uint8_t *)strb_ptr);
 }
 
-int get_int_from_env(const char* var_name, int default_value = 0) {
-    const char* env_var = std::getenv(var_name);
-    if (env_var != nullptr) {
-        try {
-            // Convert string to integer using std::stoi
-            return std::stoi(env_var);
-        } catch (const std::invalid_argument&) {
-            std::cerr << "Environment variable " << var_name << " is not a valid integer: " << env_var << '\n';
-        } catch (const std::out_of_range&) {
-            std::cerr << "Environment variable " << var_name << " is out of integer range: " << env_var << '\n';
-        }
-    }
-    return default_value; // Return the default value if not found or invalid
-}
-
-svBit enable_tracing() {
+svBit disable_tracing() {
     // function to enable/disable tracers
-    if (WRAPPER_disable_tracing){
-        return 0;
-    }
-    else {
-        return 1;
-    }
+    return WRAPPER_disable_tracing;
 }
 
 const char* get_trace_file_prefix() {

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: SHL-0.51
 
 #include <printf.h>
-#include <string>
 #include <filesystem>
+#include <string>
 
 #include "Vtestharness.h"
 #include "Vtestharness__Dpi.h"
@@ -15,7 +15,7 @@
 
 // Declare these as globally declared (and parsed) in tb_bin.cc
 extern bool WRAPPER_disable_tracing;
-extern char* WRAPPER_trace_prefix;
+extern char *WRAPPER_trace_prefix;
 
 namespace sim {
 
@@ -118,9 +118,9 @@ svBit disable_tracing() {
     return WRAPPER_disable_tracing;
 }
 
-const char* get_trace_file_prefix() {
-    if (WRAPPER_trace_prefix == nullptr){
-	// Use the standard prefix, and create a logs directory if necessary
+const char *get_trace_file_prefix() {
+    if (WRAPPER_trace_prefix == nullptr) {
+        // Use the standard prefix, and create a logs directory if necessary
         std::string foldername = "logs/";
         std::filesystem::create_directories(foldername);
         static std::string log_file_name = "logs/";
@@ -131,8 +131,6 @@ const char* get_trace_file_prefix() {
         return WRAPPER_trace_prefix;
     }
 }
-
-
 
 const long long clint_addr = sim::BOOTDATA.clint_base;
 const long num_cores = sim::BOOTDATA.core_count;

--- a/target/common/test/verilator_lib.cc
+++ b/target/common/test/verilator_lib.cc
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: SHL-0.51
 
 #include <printf.h>
+#include <cstdlib>  // For std::getenv
+#include <iostream> // For std::cout, std::cerr
+#include <string>   // For std::string
+#include <stdexcept> // For std::invalid_argument, std::out_of_range
 
 #include "Vtestharness.h"
 #include "Vtestharness__Dpi.h"
@@ -105,6 +109,39 @@ void tb_memory_write(long long addr, int len, const svOpenArrayHandle data,
     sim::MEM.write(addr, len, (const uint8_t *)data_ptr,
                    (const uint8_t *)strb_ptr);
 }
+
+int get_int_from_env(const char* var_name, int default_value = 0) {
+    const char* env_var = std::getenv(var_name);
+    if (env_var != nullptr) {
+        try {
+            // Convert string to integer using std::stoi
+            return std::stoi(env_var);
+        } catch (const std::invalid_argument&) {
+            std::cerr << "Environment variable " << var_name << " is not a valid integer: " << env_var << '\n';
+        } catch (const std::out_of_range&) {
+            std::cerr << "Environment variable " << var_name << " is out of integer range: " << env_var << '\n';
+        }
+    }
+    return default_value; // Return the default value if not found or invalid
+}
+
+svBit enable_tracing() {
+    // function to enable/disable tracers
+    return get_int_from_env("ENABLE_TRACING", 1);
+}
+
+const char* get_trace_file_prefix() {
+    static std::string log_file_name = "my_favorite_prefix"; // Default name
+    // Logic to dynamically determine the log file name
+    // For example, from command-line arguments:
+    const char* env_name = std::getenv("LOG_FILE_NAME");
+    if (env_name != nullptr) {
+        log_file_name = env_name;
+    }
+    return log_file_name.c_str();
+}
+
+
 
 const long long clint_addr = sim::BOOTDATA.clint_base;
 const long num_cores = sim::BOOTDATA.core_count;


### PR DESCRIPTION
This adds two extra options to snitch_cluster, to address #395 

This was quite difficult to figure out, the way i've implemented it now is like this:

`2 C++ functions that return a command-line value --> DPI-C --> SystemVerilog Tracer`

* `--disable-tracing` : turns off tracing for the Verilog simulation, might speed up some long-taking CI runs, for which we don't care about log parsing anyway...
* `--prefix-trace="prefix"`: appends a prefix to the output traces.  If you use this, it will not default to a logs folder anymore, so be sure to include `logs/your_prefix` in the prefix if you want it to end up in a folder.

I'm keeping this as a draft for now because of the following reasons:
* I don't know how to test this for VCS or Questa (@IveanEx @xiaoling-yi ) can you help me with that? Right now it is implemented in a way that is quite likely to break those latter two, although it should be easily fixable with some preprocessor magic (that would make it impossible to use this functionality on VCS or questa though...)
* The argument parser is really janky... It separately parses the options I added, and then passes this on to the simulator. The reason for this is that the rest of the argument parsing is done by `htif.cc` from `riscv-isa-sim/fesvr`... Not sure if we are using any of those arguments right now though...
* @IveanEx has pointed out that there are multiple other places in the systemverilog that write to a separate log file. I would like to detect those and make them happen in a single place... the current way is pretty ugly/impractical...