### PR TITLE
rename cfg file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,8 @@ jobs:
           make CFG_OVERRIDE=cfg/snax_dimc_cluster.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
 
-  sw-snax-KUL-cluster-vlt-generic:
-    name: Build KUL-cluster HW w/ Verilator (Generic LLVM)
+  sw-snax-KUL-dse-cluster-vlt-generic:
+    name: Build KUL-dse-cluster HW w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/kuleuven-micas/snax:main
@@ -246,16 +246,16 @@ jobs:
           submodules: "recursive"
       - name: RTL GEN
         run: |
-          make CFG_OVERRIDE=cfg/snax_KUL_cluster.hjson \
+          make CFG_OVERRIDE=cfg/snax_KUL_dse_cluster.hjson \
           -C target/snitch_cluster rtl-gen
       - name: Build Hardware
         run: |
-          make CFG_OVERRIDE=cfg/snax_KUL_cluster.hjson \
+          make CFG_OVERRIDE=cfg/snax_KUL_dse_cluster.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax_KUL_cluster.hjson
+          CFG_OVERRIDE=cfg/snax_KUL_dse_cluster.hjson
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -264,8 +264,8 @@ jobs:
           sw/snax-gemmx-run.yaml \
           sw/snax-data-reshuffler-run.yaml -j
 
-  snax-xdma-vlt-generic:
-    name: Simulate SW on xdma w/ Verilator (Generic LLVM)
+  snax-KUL-cluster-vlt-generic:
+    name: Simulate SW on KUL cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/kuleuven-micas/snax:main
@@ -276,15 +276,15 @@ jobs:
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
-          CFG_OVERRIDE=cfg/snax_KUL_xdma_cluster.hjson
+          CFG_OVERRIDE=cfg/snax_KUL_cluster.hjson
       - name: Build Hardware
         run: |
-          make CFG_OVERRIDE=cfg/snax_KUL_xdma_cluster.hjson \
+          make CFG_OVERRIDE=cfg/snax_KUL_cluster.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax_KUL_xdma_cluster.hjson
+          CFG_OVERRIDE=cfg/snax_KUL_cluster.hjson
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-

--- a/Bender.yml
+++ b/Bender.yml
@@ -365,17 +365,6 @@ sources:
       # Level 2
       - target/snitch_cluster/generated/snax_streamer_gemm_add_c/snax_streamer_gemm_add_c_wrapper.sv
 
-  - target: snax_streamer_simd
-    files:
-      # Level 0
-      - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_csrman_CsrManager.sv
-      - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_Streamer.sv
-      # Level 1
-      - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_csrman_wrapper.sv
-      - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_streamer_wrapper.sv
-      # Level 2
-      - target/snitch_cluster/generated/snax_streamer_simd/snax_streamer_simd_wrapper.sv
-
   - target: snax_data_reshuffler
     files:
       # Level 0
@@ -402,19 +391,12 @@ sources:
       # Level 2
       - target/snitch_cluster/generated/snax_streamer_gemmX/snax_streamer_gemmX_wrapper.sv
 
-  - target: snax_streamer_gemmX_xdma
+  - target: snax_KUL_cluster_xdma
     files:
       # Level 0
-      - target/snitch_cluster/generated/snax_streamer_gemmX_xdma_cluster_xdma/snax_streamer_gemmX_xdma_cluster_xdma.sv
+      - target/snitch_cluster/generated/snax_KUL_cluster_xdma/snax_KUL_cluster_xdma.sv
       # Level 1
-      - target/snitch_cluster/generated/snax_streamer_gemmX_xdma_cluster_xdma/snax_streamer_gemmX_xdma_cluster_xdma_wrapper.sv
-
-  - target: snax_KUL_xdma_cluster_xdma
-    files:
-      # Level 0
-      - target/snitch_cluster/generated/snax_KUL_xdma_cluster_xdma/snax_KUL_xdma_cluster_xdma.sv
-      # Level 1
-      - target/snitch_cluster/generated/snax_KUL_xdma_cluster_xdma/snax_KUL_xdma_cluster_xdma_wrapper.sv
+      - target/snitch_cluster/generated/snax_KUL_cluster_xdma/snax_KUL_cluster_xdma_wrapper.sv
 
   - target: test
     files:
@@ -458,36 +440,18 @@ sources:
   - target: snax_gemm_cluster
     files:
       - target/snitch_cluster/generated/snax_gemm_cluster_wrapper.sv
-  - target: snax_streamer_gemm_conv_cluster
-    files:
-      - target/snitch_cluster/generated/snax_streamer_gemm_conv_cluster_wrapper.sv
-  - target: snax_wide_gemm_data_reshuffler_cluster
-    files:
-      - target/snitch_cluster/generated/snax_wide_gemm_data_reshuffler_cluster_wrapper.sv
   - target: snax_streamer_gemm_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_cluster_wrapper.sv
-  - target: snax_streamer_simd_cluster
-    files:
-      - target/snitch_cluster/generated/snax_streamer_simd_cluster_wrapper.sv
-  - target: snax_data_reshuffler_cluster
-    files:
-      - target/snitch_cluster/generated/snax_data_reshuffler_cluster_wrapper.sv
-  - target: snax_streamer_gemmX_cluster
-    files:
-      - target/snitch_cluster/generated/snax_streamer_gemmX_cluster_wrapper.sv
-  - target: snax_streamer_gemmX_xdma_cluster
-    files:
-      - target/snitch_cluster/generated/snax_streamer_gemmX_xdma_cluster_wrapper.sv
   - target: snax_streamer_gemm_add_c_cluster
     files:
       - target/snitch_cluster/generated/snax_streamer_gemm_add_c_cluster_wrapper.sv
+  - target: snax_KUL_dse_cluster
+    files:
+      - target/snitch_cluster/generated/snax_KUL_dse_cluster_wrapper.sv
   - target: snax_KUL_cluster
     files:
       - target/snitch_cluster/generated/snax_KUL_cluster_wrapper.sv
-  - target: snax_KUL_xdma_cluster
-    files:
-      - target/snitch_cluster/generated/snax_KUL_xdma_cluster_wrapper.sv
   #---------------------------
   # Test harness declaration
   #---------------------------

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -89,7 +89,6 @@
                 },
                 cores: [
                     { $ref: "#/snax_streamer_gemmX_core_template" },
-                    { $ref: "#/snax_data_reshuffler_core_template" },
                     { $ref: "#/dma_core_template" },
                 ]
             }
@@ -123,7 +122,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemmX",
-            bender_target: ["snax_gemmX","snax_data_reshuffler"],
+            bender_target: ["snax_gemmX"],
             snax_narrow_tcdm_ports: 8,
             snax_wide_tcdm_ports: 48,
             snax_num_rw_csr: 19,
@@ -131,7 +130,7 @@
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,
             snax_gemmx_mesh_col: 8,
-            with_pipeline: false,
+            with_pipeline: true,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },
         snax_use_custom_ports: false,
@@ -146,37 +145,20 @@
         // Xdiv_sqrt: true,
     },
     // Templates.
-    snax_data_reshuffler_core_template: {
-        isa: "rv32ima",
-        xssr: false,
-        xfrep: false,
-        xdma: false,
-        xf16: false,
-        xf16alt: false,
-        xf8: false,
-        xf8alt: false,
-        xfdotp: false,
-        xfvec: false,
-        snax_acc_cfg: {
-            snax_acc_name: "snax_data_reshuffler",
-            snax_narrow_tcdm_ports: 16,
-            snax_num_rw_csr: 2,
-            snax_num_ro_csr: 2,
-            snax_streamer_cfg: {$ref: "#/snax_data_reshuffler_streamer_template" }
-        },
-        snax_use_custom_ports: false,
-        num_int_outstanding_loads: 1,
-        num_int_outstanding_mem: 4,
-        num_fp_outstanding_loads: 4,
-        num_fp_outstanding_mem: 4,
-        num_sequencer_instructions: 16,
-        num_dtlb_entries: 1,
-        num_itlb_entries: 1,
-        // Enable division/square root unit
-        // Xdiv_sqrt: true,
-    },
     dma_core_template: {
         isa: "rv32ima",
+        snax_xdma_cfg: {
+            bender_target: ["snax_KUL_cluster_xdma"],
+            reader_buffer: 4, 
+            writer_buffer: 4, 
+            reader_agu_spatial_bounds: "8",
+            reader_agu_temporal_dimension: 6, 
+            writer_agu_spatial_bounds: "8",
+            writer_agu_temporal_dimension: 6, 
+            HasTransposer: 3, 
+            HasVerilogMemset: 1, 
+            HasMaxPool: 2
+        }
         // Xdiv_sqrt: true,
         # isa: "rv32ema",
         xdma: true
@@ -231,25 +213,5 @@
         has_C_broadcast: true,
 
         snax_library_name: "gemmx",
-    },
-    // SNAX Streamer Templates
-    snax_data_reshuffler_streamer_template :{
-
-        data_reader_params: {
-            spatial_bounds: [[8]],
-            temporal_dim: [5],
-            num_channel: [8],
-            fifo_depth: [2],
-        },
-
-        data_writer_params:{
-            spatial_bounds: [[8]],
-            temporal_dim: [3],
-            num_channel: [8],
-            fifo_depth: [2],
-        },
-
-        snax_library_name: "data-reshuffler",
-
     }
 }

--- a/target/snitch_cluster/cfg/snax_KUL_dse_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_dse_cluster.hjson
@@ -10,8 +10,8 @@
     },
 
     cluster: {
-        name: "snax_KUL_xdma_cluster",
-        bender_target: ["snax_KUL_xdma_cluster"],
+        name: "snax_KUL_dse_cluster",
+        bender_target: ["snax_KUL_dse_cluster"],
         boot_addr: 4096, // 0x1000
         cluster_base_addr: 268435456, // 0x1000_0000
         cluster_base_offset: 4194304,  // 4MB
@@ -89,6 +89,7 @@
                 },
                 cores: [
                     { $ref: "#/snax_streamer_gemmX_core_template" },
+                    { $ref: "#/snax_data_reshuffler_core_template" },
                     { $ref: "#/dma_core_template" },
                 ]
             }
@@ -122,7 +123,7 @@
         xfvec: false,
         snax_acc_cfg: {
             snax_acc_name: "snax_streamer_gemmX",
-            bender_target: ["snax_gemmX","snax_KUL_xdma_cluster_xdma"],
+            bender_target: ["snax_gemmX"],
             snax_narrow_tcdm_ports: 8,
             snax_wide_tcdm_ports: 48,
             snax_num_rw_csr: 19,
@@ -130,7 +131,7 @@
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,
             snax_gemmx_mesh_col: 8,
-            with_pipeline: true,
+            with_pipeline: false,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },
         snax_use_custom_ports: false,
@@ -145,19 +146,38 @@
         // Xdiv_sqrt: true,
     },
     // Templates.
+    snax_data_reshuffler_core_template: {
+        isa: "rv32ima",
+        xssr: false,
+        xfrep: false,
+        xdma: false,
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        snax_acc_cfg: {
+            snax_acc_name: "snax_data_reshuffler",
+            bender_target: ["snax_data_reshuffler"],
+            snax_narrow_tcdm_ports: 16,
+            snax_num_rw_csr: 2,
+            snax_num_ro_csr: 2,
+            snax_streamer_cfg: {$ref: "#/snax_data_reshuffler_streamer_template" }
+        },
+        snax_use_custom_ports: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+        // Enable division/square root unit
+        // Xdiv_sqrt: true,
+    },
     dma_core_template: {
         isa: "rv32ima",
-        snax_xdma_cfg: {
-            reader_buffer: 4, 
-            writer_buffer: 4, 
-            reader_agu_spatial_bounds: "8",
-            reader_agu_temporal_dimension: 6, 
-            writer_agu_spatial_bounds: "8",
-            writer_agu_temporal_dimension: 6, 
-            HasTransposer: 3, 
-            HasVerilogMemset: 1, 
-            HasMaxPool: 2
-        }
         // Xdiv_sqrt: true,
         # isa: "rv32ema",
         xdma: true
@@ -212,5 +232,25 @@
         has_C_broadcast: true,
 
         snax_library_name: "gemmx",
+    },
+    // SNAX Streamer Templates
+    snax_data_reshuffler_streamer_template :{
+
+        data_reader_params: {
+            spatial_bounds: [[8]],
+            temporal_dim: [5],
+            num_channel: [8],
+            fifo_depth: [2],
+        },
+
+        data_writer_params:{
+            spatial_bounds: [[8]],
+            temporal_dim: [3],
+            num_channel: [8],
+            fifo_depth: [2],
+        },
+
+        snax_library_name: "data-reshuffler",
+
     }
 }

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -17,10 +17,10 @@ endif
 
 SUBDIRS += math $(RUNTIME) snax/mac apps tests
 
-ifeq (${CFG_OVERRIDE}, cfg/snax_KUL_cluster.hjson)
+ifeq (${CFG_OVERRIDE}, cfg/snax_KUL_dse_cluster.hjson)
 SUBDIRS += snax/gemmx snax/data-reshuffler
 endif
-ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_xdma_cluster.hjson)
+ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
 SUBDIRS += snax/gemmx snax/xdma
 endif
 

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -28,12 +28,12 @@ SUBDIRS += snax-mac-mult
 ifeq ($(CFG_OVERRIDE), cfg/snax_alu_cluster.hjson)
 SUBDIRS += snax-alu
 endif
-ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
+ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_dse_cluster.hjson)
 SUBDIRS += snax-data-reshuffler
 SUBDIRS += snax-gemmx-matmul
 SUBDIRS += snax-gemmx-conv
 endif
-ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_xdma_cluster.hjson)
+ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
 SUBDIRS += snax-gemmx-matmul
 SUBDIRS += snax-gemmx-conv
 SUBDIRS += snax-xdma-memset


### PR DESCRIPTION
In this PR, we rename the KUL_cluster to KUL_dse_cluster, the KUL_cluster_xdma_cluster to kul_cluster and also delete some dead code in the bender file.