### PR TITLE
Fix bit widths for the instruction loop counts

### DIFF
--- a/target/snitch_cluster/sw/apps/snax-hypercorex/test-csr/data/data.h
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/test-csr/data/data.h
@@ -51,9 +51,9 @@ uint32_t test_inst_loop_jump_addr3 = 0xff;
 uint32_t test_inst_loop_end_addr1 = 0xff;
 uint32_t test_inst_loop_end_addr2 = 0xff;
 uint32_t test_inst_loop_end_addr3 = 0xff;
-uint32_t test_inst_loop_count1 = 0xff;
-uint32_t test_inst_loop_count2 = 0xff;
-uint32_t test_inst_loop_count3 = 0xff;
+uint32_t test_inst_loop_count1 = 0x3ff;
+uint32_t test_inst_loop_count2 = 0x3ff;
+uint32_t test_inst_loop_count3 = 0x3ff;
 
 //-------------------------------
 // Golden values
@@ -82,4 +82,4 @@ uint32_t golden_inst_at_addr = 0xffffffff;
 uint32_t golden_inst_loop_ctrl = 0x00000003;
 uint32_t golden_inst_loop_jump_addr = 0x001fffff;
 uint32_t golden_inst_loop_end_addr = 0x001fffff;
-uint32_t golden_inst_loop_count = 0x001fffff;
+uint32_t golden_inst_loop_count = 0x3fffffff;

--- a/target/snitch_cluster/sw/snax/hypercorex/include/snax-hypercorex-lib.h
+++ b/target/snitch_cluster/sw/snax/hypercorex/include/snax-hypercorex-lib.h
@@ -88,8 +88,8 @@ void hypercorex_set_inst_loop_jump_addr(uint8_t config1, uint8_t config2,
 void hypercorex_set_inst_loop_end_addr(uint8_t config1, uint8_t config2,
                                        uint8_t config3);
 
-void hypercorex_set_inst_loop_count(uint8_t config1, uint8_t config2,
-                                    uint8_t config3);
+void hypercorex_set_inst_loop_count(uint32_t config1, uint32_t config2,
+                                    uint32_t config3);
 
 void hypercorex_start_core(void);
 

--- a/target/snitch_cluster/sw/snax/hypercorex/src/snax-hypercorex-lib.c
+++ b/target/snitch_cluster/sw/snax/hypercorex/src/snax-hypercorex-lib.c
@@ -183,7 +183,8 @@ void hypercorex_set_inst_loop_end_addr(uint8_t config1, uint8_t config2,
 void hypercorex_set_inst_loop_count(uint32_t config1, uint32_t config2,
                                     uint32_t config3) {
     uint32_t config =
-        ((config3 & 0x3ff) << 20) | ((config2 & 0x3ff) << 10) | (config1 & 0x3ff);
+        ((config3 & 0x3ff) << 20) | ((config2 & 0x3ff) << 10) |
+        (config1 & 0x3ff);
 
     csrw_ss(HYPERCOREX_INST_LOOP_COUNT_REG_ADDR, config);
     return;

--- a/target/snitch_cluster/sw/snax/hypercorex/src/snax-hypercorex-lib.c
+++ b/target/snitch_cluster/sw/snax/hypercorex/src/snax-hypercorex-lib.c
@@ -180,10 +180,10 @@ void hypercorex_set_inst_loop_end_addr(uint8_t config1, uint8_t config2,
     return;
 };
 
-void hypercorex_set_inst_loop_count(uint8_t config1, uint8_t config2,
-                                    uint8_t config3) {
+void hypercorex_set_inst_loop_count(uint32_t config1, uint32_t config2,
+                                    uint32_t config3) {
     uint32_t config =
-        ((config3 & 0x7f) << 14) | ((config2 & 0x7f) << 7) | (config1 & 0x7f);
+        ((config3 & 0x3ff) << 20) | ((config2 & 0x3ff) << 10) | (config1 & 0x3ff);
 
     csrw_ss(HYPERCOREX_INST_LOOP_COUNT_REG_ADDR, config);
     return;

--- a/target/snitch_cluster/sw/snax/hypercorex/src/snax-hypercorex-lib.c
+++ b/target/snitch_cluster/sw/snax/hypercorex/src/snax-hypercorex-lib.c
@@ -182,9 +182,8 @@ void hypercorex_set_inst_loop_end_addr(uint8_t config1, uint8_t config2,
 
 void hypercorex_set_inst_loop_count(uint32_t config1, uint32_t config2,
                                     uint32_t config3) {
-    uint32_t config =
-        ((config3 & 0x3ff) << 20) | ((config2 & 0x3ff) << 10) |
-        (config1 & 0x3ff);
+    uint32_t config = ((config3 & 0x3ff) << 20) | ((config2 & 0x3ff) << 10) |
+                      (config1 & 0x3ff);
 
     csrw_ss(HYPERCOREX_INST_LOOP_COUNT_REG_ADDR, config);
     return;


### PR DESCRIPTION
This PR simply fixes the bit-widths of the instruction loop count needed for the hypercorex
