### PR TITLE
The new Datapath Extension Base Class

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtension.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtension.scala
@@ -221,11 +221,12 @@ class SystemVerilogDataPathExtension(topmodule: String, filelist: Seq[String])(
         val ext_busy_o = Output(Bool())
       })
       override def desiredName: String = topmodule
-      var InLineSV = ""
+      var inlineSV = ""
       for (file <- filelist) {
-        InLineSV += scala.io.Source.fromFile(file).getLines().mkString("\n")
+        inlineSV += scala.io.Source.fromFile(file).getLines().mkString("\n")
+        inlineSV += "\n"
       }
-      setInline(extensionParam.moduleName + ".sv", InLineSV)
+      setInline(extensionParam.moduleName + ".sv", inlineSV)
     }
   )
 

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtension.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/DataPathExtension.scala
@@ -5,6 +5,7 @@ import chisel3.util._
 
 import snax.utils._
 import snax.xdma.DesignParams._
+import java.io.File
 
 /** The parent (abstract) Class for the DMA Extension Generation Params This
   * class template is used to isolate the definition of class (when user provide
@@ -185,6 +186,23 @@ abstract class DataPathExtension(implicit
 class SystemVerilogDataPathExtension(topmodule: String, filelist: Seq[String])(
     implicit extensionParam: DataPathExtensionParam
 ) extends DataPathExtension {
+
+  def this(topmodule: String, dir: String)(implicit
+      extensionParam: DataPathExtensionParam
+  ) = this(
+    topmodule, {
+      val folder = new File(dir)
+      val filelist = if (folder.exists && folder.isDirectory) {
+        folder.listFiles.filter(_.isFile).toList
+      } else {
+        List.empty[File]
+      }
+      filelist
+        .filter(i => i.getName.endsWith(".sv") || i.getName.endsWith(".v"))
+        .map(_.toPath.toString)
+        .toSeq
+    }
+  )
 
   val sv_module = Module(
     new BlackBox(

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/VerilogMemset.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/VerilogMemset.scala
@@ -13,7 +13,8 @@ object HasVerilogMemset extends HasDataPathExtension {
   def instantiate(clusterName: String): SystemVerilogDataPathExtension = Module(
     new SystemVerilogDataPathExtension(
       topmodule = "VerilogMemset",
-      filelist = Seq("src/main/systemverilog/VerilogMemset/VerilogMemset.sv")
+      dir = "src/main/systemverilog/VerilogMemset"
+      // filelist = Seq("src/main/systemverilog/VerilogMemset/VerilogMemset.sv")
     ) {
       override def desiredName = clusterName + namePostfix
     }


### PR DESCRIPTION
This PR adds a new construction function in a **DatapathExtension** class to instantiate the module with multiple systemverilog source code inside one folder easily. 