### PR TITLE
Modification of snitch startup program

### DIFF
--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -59,12 +59,12 @@ static inline void snrt_init_tls() {
 #ifdef SNRT_INIT_BSS
 static inline void snrt_init_bss() {
     extern volatile uint32_t __bss_start, __bss_end;
-
     // Only one core needs to perform the initialization
+    // As the snitch core is 32bit, initialize the bss region above 4GB does not make sense. 
     if (snrt_cluster_idx() == 0 && snrt_is_dm_core()) {
         size_t size = (size_t)(&__bss_end) - (size_t)(&__bss_start);
-        snrt_dma_start_1d_wideptr((uint64_t)(&__bss_start),
-                                  (uint64_t)(snrt_zero_memory_ptr()), size);
+        snrt_dma_start_1d((void *)(&__bss_start),
+                          (void *)(snrt_zero_memory_ptr()), size);
     }
 }
 #endif

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -32,23 +32,23 @@ static inline void snrt_init_tls() {
 
         // First initialize the DM core's .tdata section from main memory
         asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
-        snrt_dma_start_1d((void*)tls_ptr, (void*)(&__tdata_start), size);
+        snrt_dma_start_1d((void *)tls_ptr, (void *)(&__tdata_start), size);
 
         // Then initialize all other cores' .tdata sections from the DM
         // core's. The offset between the TLS section of successive cores
         // is defined in start.S
         size_t tls_offset = (1 << SNRT_LOG2_STACK_SIZE) + 8;
         for (int i = 1; i < snrt_cluster_core_num(); i++) {
-            snrt_dma_start_1d((void*)(tls_ptr + i * tls_offset), (void*)tls_ptr,
-                              size);
+            snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
+                              (void *)tls_ptr, size);
         }
 
         // Initialize all cores' .tbss sections
         tls_ptr += size;
         size = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
         for (int i = 0; i < snrt_cluster_core_num(); i++) {
-            snrt_dma_start_1d((void*)(tls_ptr + i * tls_offset),
-                              (void*)(snrt_zero_memory_ptr()), size);
+            snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
+                              (void *)(snrt_zero_memory_ptr()), size);
         }
     }
 
@@ -60,7 +60,8 @@ static inline void snrt_init_tls() {
 static inline void snrt_init_bss() {
     extern volatile uint32_t __bss_start, __bss_end;
     // Only one core needs to perform the initialization
-    // As the snitch core is 32bit, initialize the bss region above 4GB does not make sense. 
+    // As the snitch core is 32bit, initialize the bss region above 4GB does not
+    // make sense.
     if (snrt_cluster_idx() == 0 && snrt_is_dm_core()) {
         size_t size = (size_t)(&__bss_end) - (size_t)(&__bss_start);
         snrt_dma_start_1d((void *)(&__bss_start),
@@ -74,21 +75,21 @@ static inline void snrt_init_cls() {
     extern volatile uint32_t __cdata_start, __cdata_end;
     extern volatile uint32_t __cbss_start, __cbss_end;
 
-    _cls_ptr = (cls_t*)snrt_cls_base_addr();
+    _cls_ptr = (cls_t *)snrt_cls_base_addr();
 
     // Only one core per cluster has to do this
     if (snrt_is_dm_core()) {
-        void* ptr = (void*)snrt_cls_base_addr();
+        void *ptr = (void *)snrt_cls_base_addr();
         size_t size;
 
         // Copy cdata section to base of the TCDM
         size = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
-        snrt_dma_start_1d(ptr, (void*)(&__cdata_start), size);
+        snrt_dma_start_1d(ptr, (void *)(&__cdata_start), size);
 
         // Clear cbss section
-        ptr = (void*)((uint32_t)ptr + size);
+        ptr = (void *)((uint32_t)ptr + size);
         size = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
-        snrt_dma_start_1d(ptr, (void*)(snrt_zero_memory_ptr()), size);
+        snrt_dma_start_1d(ptr, (void *)(snrt_zero_memory_ptr()), size);
     }
 }
 #endif


### PR DESCRIPTION
Before calling **main** written by us, snitch cores execute codes in **snrt_main**. 

This PR fixes one bug in here using **snrt_dma_start_1d_wideptr** to initialize bss region of the code. As snitch is a 32bit core, initializing memory region above 4GB is not necessary. 