### PR TITLE
Add the sw bin to load by spi

### DIFF
--- a/target/snitch_cluster/sw/apps/common.mk
+++ b/target/snitch_cluster/sw/apps/common.mk
@@ -61,7 +61,8 @@ ELF         = $(abspath $(addprefix $(BUILDDIR)/,$(addsuffix .elf,$(APP))))
 DEP         = $(abspath $(addprefix $(BUILDDIR)/,$(addsuffix .d,$(APP))))
 DUMP        = $(abspath $(addprefix $(BUILDDIR)/,$(addsuffix .dump,$(APP))))
 DWARF       = $(abspath $(addprefix $(BUILDDIR)/,$(addsuffix .dwarf,$(APP))))
-ALL_OUTPUTS = $(ELF) $(DEP) $(DUMP) $(DWARF)
+BIN       = $(abspath $(addprefix $(BUILDDIR)/,$(addsuffix .bin,$(APP))))
+ALL_OUTPUTS = $(ELF) $(DEP) $(DUMP) $(DWARF) $(BIN)
 
 #########
 # Rules #
@@ -89,6 +90,8 @@ $(DUMP): $(ELF) | $(BUILDDIR)
 $(DWARF): $(ELF) | $(BUILDDIR)
 	$(RISCV_DWARFDUMP) $< > $@
 
+$(BIN): $(ELF) | $(BUILDDIR)
+	$(RISCV_OBJCOPY) -O binary $< $@
 ifneq ($(MAKECMDGOALS),clean)
 -include $(DEP)
 endif


### PR DESCRIPTION
This PR adds the feature to generate the .bin file during the `make sw`.
The sw binary will be used to load into the main memory via the spi.