### PR TITLE
Fix SIMD for different spatial unrolling

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/simd/RescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/simd/RescaleSIMD.scala
@@ -131,12 +131,12 @@ class RescaleSIMD(params: RescaleSIMDParams)
       .asSInt
 
     // this control input port is 32 bits, so it needs 1 csr
-    ctrl_csr(i).multiplier_i := io.ctrl.bits(4 + i).asSInt
+    ctrl_csr(i).multiplier_i := io.ctrl.bits(2 + ctrl_csr_set_num / packed_shift_num + i).asSInt
     // ---------------------
 
     // length of the data
     ctrl_csr(i).len := io.ctrl
-      .bits(2 + ctrl_csr_set_num / 4 + ctrl_csr_set_num)
+      .bits(2 + ctrl_csr_set_num / packed_shift_num + ctrl_csr_set_num)
       .asUInt
 
   }


### PR DESCRIPTION
Make the SIMD's parameter/CSR mapping can be set directly according to the output size of the GeMM.
Only supported when the SIDM is not unrolled in a hardware loop!