### PR TITLE
Update DatapathExtension for the param passing

### DIFF
--- a/hw/chisel/build.sbt
+++ b/hw/chisel/build.sbt
@@ -5,6 +5,7 @@ ThisBuild / version := "0.1.0"
 ThisBuild / organization := "be.kuleuven.esat.micas"
 
 val chiselVersion = "6.4.0"
+val playJSONVersion = "3.0.4"
 
 lazy val root = (project in file("."))
   .settings(
@@ -12,7 +13,8 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % "2.13.14",
       "org.chipsalliance" %% "chisel" % chiselVersion,
-      "edu.berkeley.cs" %% "chiseltest" % "6.0.0" % "test"
+      "edu.berkeley.cs" %% "chiseltest" % "6.0.0" % "test",
+      "org.playframework" %% "play-json" % playJSONVersion
     ),
     scalacOptions ++= Seq(
       "-language:reflectiveCalls",

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/Broadcaster.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/Broadcaster.scala
@@ -4,15 +4,15 @@ import chisel3._
 import chisel3.util._
 import snax.xdma.DesignParams._
 
-class HasBroadcaster256to2048 extends HasDataPathExtension {
+class HasBroadcaster(inputLength: Int, outputLength: Int) extends HasDataPathExtension {
   implicit val extensionParam: DataPathExtensionParam =
     new DataPathExtensionParam(
-      moduleName = "Broadcaster256to2048",
+      moduleName = s"Broadcaster${inputLength}to${outputLength}",
       userCsrNum = 0,
-      dataWidth = 2048
+      dataWidth = outputLength
     )
   def instantiate(clusterName: String): Broadcaster = Module(
-    new Broadcaster(256) {
+    new Broadcaster(inputLength) {
       override def desiredName = clusterName + namePostfix
     }
   )

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/Transposer.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/Transposer.scala
@@ -5,11 +5,11 @@ import chisel3.util._
 import snax.xdma.DesignParams._
 import snax.utils.DecoupledCut._
 
-class HasTransposer(row: Int = 8, col: Int = 8, elementBits: Int = 8)
+class HasTransposer(row: Int, col: Int, elementBits: Int)
     extends HasDataPathExtension {
   implicit val extensionParam: DataPathExtensionParam =
     new DataPathExtensionParam(
-      moduleName = "Transposer",
+      moduleName = s"TransposerRow${row}Col${col}Bit${elementBits}",
       userCsrNum = 0,
       dataWidth = 512
     )

--- a/hw/chisel/src/main/scala/snax/streamer/DesignParams.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/DesignParams.scala
@@ -5,6 +5,7 @@ import snax.DataPathExtension._
 
 import chisel3.util.log2Up
 import chisel3.util.log2Ceil
+import os.read.inputStream
 
 /*
  *  This is the collection of all design Params
@@ -95,7 +96,7 @@ class StreamerParam(
   val dataPathABExtensionParam: Seq[HasDataPathExtension] =
     (if (hasTranspose)
        Seq[HasDataPathExtension](
-         new HasTransposer
+         new HasTransposer(row = 8, col = 8, elementBits = 8)
        )
      else
        Seq[HasDataPathExtension]())
@@ -103,7 +104,7 @@ class StreamerParam(
   val dataPathCExtensionParam: Seq[HasDataPathExtension] =
     (if (hasCBroadcast)
        Seq[HasDataPathExtension](
-         new HasBroadcaster256to2048
+         new HasBroadcaster(inputLength = 256, outputLength = 2048)
        )
      else
        Seq[HasDataPathExtension]())

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -16,6 +16,8 @@ import scala.reflect.runtime.currentMirror
 import scala.tools.reflect.ToolBox
 import scala.reflect.runtime.universe._
 
+import play.api.libs.json._
+
 class xdmaTopIO(
     readerParam: DMADataPathParam,
     writerParam: DMADataPathParam
@@ -143,6 +145,13 @@ class xdmaTop(
 
 object xdmaTopGen extends App {
   val parsedArgs = snax.utils.ArgParser.parse(args)
+  // The xdmaCfg region is passed to Scala program as a string in 
+  val xdmaCfg = parsedArgs.find(_._1 == "xdmaCfg")
+  if (xdmaCfg.isEmpty) {
+    println("xdmaCfg is not provided, generation failed. ")
+    sys.exit(-1)
+  }
+  val parsedXdmaCfg: JsValue = Json.parse(xdmaCfg.get._2)
 
   /*
   Needed Parameters:
@@ -165,27 +174,35 @@ object xdmaTopGen extends App {
   )
 
   val readerparam = new ReaderWriterParam(
-    spatialBounds =
-      parsedArgs("readerSpatialBounds").split(",").map(_.toInt).toList,
-    temporalDimension = parsedArgs("readerTemporalDimension").toInt,
+    spatialBounds = (parsedXdmaCfg \ "reader_agu_spatial_bounds")
+      .as[String]
+      .split(",")
+      .map(_.toInt)
+      .toList,
+    temporalDimension =
+      (parsedXdmaCfg \ "reader_agu_temporal_dimension").as[Int],
     tcdmDataWidth = parsedArgs("tcdmDataWidth").toInt,
     tcdmSize = parsedArgs("tcdmSize").toInt,
     numChannel =
       parsedArgs("axiDataWidth").toInt / parsedArgs("tcdmDataWidth").toInt,
-    addressBufferDepth = parsedArgs("readerBufferDepth").toInt,
+    addressBufferDepth = (parsedXdmaCfg \ "reader_buffer").as[Int],
     configurableChannel = true,
     configurableByteMask = false
   )
 
   val writerparam = new ReaderWriterParam(
-    spatialBounds =
-      parsedArgs("writerSpatialBounds").split(",").map(_.toInt).toList,
-    temporalDimension = parsedArgs("writerTemporalDimension").toInt,
+    spatialBounds = (parsedXdmaCfg \ "writer_agu_spatial_bounds")
+      .as[String]
+      .split(",")
+      .map(_.toInt)
+      .toList,
+    temporalDimension =
+      (parsedXdmaCfg \ "writer_agu_temporal_dimension").as[Int],
     tcdmDataWidth = parsedArgs("tcdmDataWidth").toInt,
     tcdmSize = parsedArgs("tcdmSize").toInt,
     numChannel =
       parsedArgs("axiDataWidth").toInt / parsedArgs("tcdmDataWidth").toInt,
-    addressBufferDepth = parsedArgs("writerBufferDepth").toInt,
+    addressBufferDepth = (parsedXdmaCfg \ "writer_buffer").as[Int],
     configurableChannel = true,
     configurableByteMask = true
   )
@@ -200,16 +217,25 @@ object xdmaTopGen extends App {
   // Extension developers only need to 1) Add the Extension source code 2) Add Has...: #priority in hjson configuration file
 
   val toolbox = currentMirror.mkToolBox()
-  parsedArgs
-    .filter(i => i._1.startsWith("Has") && i._2.toInt > 0)
-    .toSeq
-    .map(i => (i._1, i._2.toInt))
-    .sortWith(_._2 < _._2)
+  val datapathExtensionParam = parsedXdmaCfg match {
+    case obj: JsObject =>
+      obj.fields
+        .filter { case (k, v) =>
+          k.startsWith("Has")
+        }
+        .toSeq
+        .map { case (k, v) =>
+          (k, v.as[String])
+        }
+    case _ => Seq.empty
+  }
+
+  datapathExtensionParam
     .foreach(i => {
       writerextensionparam = writerextensionparam :+ toolbox
         .compile(toolbox.parse(s"""
 import snax.DataPathExtension._
-return new ${i._1}
+return new ${i._1}(${i._2})
       """))()
         .asInstanceOf[HasDataPathExtension]
     })

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/BroadcasterTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/BroadcasterTester.scala
@@ -4,11 +4,11 @@ import chisel3._
 import chisel3.util._
 
 import scala.util.Random
-import snax.DataPathExtension.HasBroadcaster256to2048
+import snax.DataPathExtension.HasBroadcaster
 
 class BroadcasterTester extends DataPathExtensionTester {
 
-  def hasExtension = HasBroadcaster256to2048
+  def hasExtension = new HasBroadcaster(inputLength = 256, outputLength = 2048)
 
   val csr_vec = Seq()
 

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/MaxPoolTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/MaxPoolTester.scala
@@ -8,7 +8,7 @@ import snax.DataPathExtension.HasMaxPool
 
 class MaxPoolTester extends DataPathExtensionTester {
 
-  def hasExtension = HasMaxPool
+  def hasExtension = new HasMaxPool
 
   // System Val
   val extension_width = 512

--- a/hw/chisel/src/test/scala/snax/xdma/xdmaTop/xdmaTopTester.scala
+++ b/hw/chisel/src/test/scala/snax/xdma/xdmaTop/xdmaTopTester.scala
@@ -123,7 +123,8 @@ class xDMATopTester extends AnyFreeSpec with ChiselScalatestTester {
           configurableByteMask = true,
           configurableChannel = true
         ),
-        extParam = Seq(HasVerilogMemset, HasMaxPool, HasTransposer)
+        extParam =
+          Seq(new HasVerilogMemset, new HasMaxPool, new HasTransposer(8, 8, 8))
       )
     )
   ).withAnnotations(Seq(WriteVcdAnnotation, VerilatorBackendAnnotation)) {
@@ -1129,7 +1130,7 @@ object xdmaTopEmitter extends App {
       writerParam = new DMADataPathParam(
         new AXIParam,
         new ReaderWriterParam,
-        Seq(HasMaxPool, HasVerilogMemset, HasTransposer)
+        Seq(new HasMaxPool, new HasVerilogMemset, new HasTransposer(8, 8, 8))
       )
     ),
     args = Array("--target-dir", "generated/xdma")

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -155,9 +155,9 @@
             reader_agu_temporal_dimension: 6, 
             writer_agu_spatial_bounds: "8",
             writer_agu_temporal_dimension: 6, 
-            HasTransposer: 3, 
-            HasVerilogMemset: 1, 
-            HasMaxPool: 2
+            HasVerilogMemset: "",
+            HasMaxPool: "",
+            HasTransposer: "row=8, col=8, elementBits=8", 
         }
         // Xdiv_sqrt: true,
         # isa: "rv32ema",

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -67,7 +67,7 @@ def gen_file(cfg, tpl, target_path: str, file_name: str) -> None:
 # Call chisel environment and generate the system verilog file
 def gen_chisel_file(chisel_path, chisel_param, gen_path):
     cmd = f" cd {chisel_path} && \
-        sbt \"runMain {chisel_param} {gen_path}\" "
+        sbt \'runMain {chisel_param} {gen_path}\' "
     print(f"Running command: {cmd}")
     if os.system(cmd) != 0:
         raise ChildProcessError("Chisel generation error. ")
@@ -556,19 +556,22 @@ def main():
             + str(cfg["cluster"]["addr_width"])
             + " --tcdmSize "
             + str(cfg["cluster"]["tcdm"]["size"])
-            + " --readerSpatialBounds "
-            + str(snax_xdma_cfg["reader_agu_spatial_bounds"])
-            + " --readerTemporalDimension "
-            + str(snax_xdma_cfg["reader_agu_temporal_dimension"])
-            + " --writerSpatialBounds "
-            + str(snax_xdma_cfg["writer_agu_spatial_bounds"])
-            + " --writerTemporalDimension "
-            + str(snax_xdma_cfg["writer_agu_temporal_dimension"])
-            + " --readerBufferDepth "
-            + str(snax_xdma_cfg["reader_buffer"])
-            + " --writerBufferDepth "
-            + str(snax_xdma_cfg["writer_buffer"])
-            + xdma_extension_arg
+            + " --xdmaCfg "
+            + hjson.dumpsJSON(obj=snax_xdma_cfg, separators=(",", ":")).replace(" ", "")
+
+            # + " --readerSpatialBounds "
+            # + str(snax_xdma_cfg["reader_agu_spatial_bounds"])
+            # + " --readerTemporalDimension "
+            # + str(snax_xdma_cfg["reader_agu_temporal_dimension"])
+            # + " --writerSpatialBounds "
+            # + str(snax_xdma_cfg["writer_agu_spatial_bounds"])
+            # + " --writerTemporalDimension "
+            # + str(snax_xdma_cfg["writer_agu_temporal_dimension"])
+            # + " --readerBufferDepth "
+            # + str(snax_xdma_cfg["reader_buffer"])
+            # + " --writerBufferDepth "
+            # + str(snax_xdma_cfg["writer_buffer"])
+            # + xdma_extension_arg
             + " --hw-target-dir "
             + args.gen_path
             + cfg["cluster"]["name"]


### PR DESCRIPTION
This PR does the following: 

1. Improve **Datapath Extension** 's generation flow to support passing the arguments when instantiate **HasDatapath** class (which can be defined in cfg file)
2. Improve the **XDMAGen** object. Now the JSON string describing the XDMA parameters are passed to scala, and parsing this JSON string is handled by Scala. 
3. Remove the default value of **HasTransposer** class because it is not needed anymore. 
4. Improve the instance naming of **Transposer** and **Broadcaster** extension
5. Add the generation param to Broadcaster. 