### PR TITLE
Fix datapath extension parameter format in hjson

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/Transposer.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/Transposer.scala
@@ -10,11 +10,11 @@ class HasTransposer(
     col: Seq[Int],
     elementWidth: Seq[Int]
 ) extends HasDataPathExtension {
-  // The length of row, col, and elementBits should be the same
+  // The length of row, col, and elementWidth should be the same
   require(row.length == col.length && col.length == elementWidth.length)
-  // DataWidth can be calculated by row, col, and elementBits
+  // DataWidth can be calculated by row, col, and elementWidth
   val dataWidth = row.head * col.head * elementWidth.head
-  // The product of row, col, and elementBits should be equal to dataWidth
+  // The product of row, col, and elementWidth should be equal to dataWidth
   require {
     row.zip(col).zip(elementWidth).forall { case ((r, c), e) =>
       r * c * e == dataWidth
@@ -38,11 +38,11 @@ class HasTransposer(
 class Transposer(
     row: Seq[Int],
     col: Seq[Int],
-    elementBits: Seq[Int]
+    elementWidth: Seq[Int]
 )(implicit
     extensionParam: DataPathExtensionParam
 ) extends DataPathExtension {
-  val outputArray = row.zip(col).zip(elementBits).map { case ((r, c), e) =>
+  val outputArray = row.zip(col).zip(elementWidth).map { case ((r, c), e) =>
     val transposedResult = Wire(Vec(c, Vec(r, UInt(e.W))))
     for (i <- 0 until r) {
       for (j <- 0 until c) {

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/xdmaTop.scala
@@ -226,7 +226,7 @@ object xdmaTopGen extends App {
         }
         .toSeq
         .map { case (k, v) =>
-          (k, v.as[String])
+          (k, v.as[Map[String, Seq[Int]]].values)
         }
     case _ => Seq.empty
   }
@@ -236,7 +236,9 @@ object xdmaTopGen extends App {
       writerextensionparam = writerextensionparam :+ toolbox
         .compile(toolbox.parse(s"""
 import snax.DataPathExtension._
-return new ${i._1}(${i._2})
+return new ${i._1}(${i._2
+            .map(list => s"Seq(${list.mkString(",")})")
+            .mkString(", ")})
       """))()
         .asInstanceOf[HasDataPathExtension]
     })

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -155,9 +155,9 @@
             reader_agu_temporal_dimension: 6, 
             writer_agu_spatial_bounds: "8",
             writer_agu_temporal_dimension: 6, 
-            HasVerilogMemset: "",
-            HasMaxPool: "",
-            HasTransposer: "row=Seq(8), col=Seq(8), elementWidth=Seq(8)", 
+            HasVerilogMemset: {},
+            HasMaxPool: {},
+            HasTransposer: {row:[8], col:[8], elementWidth:[8]}, 
         }
         // Xdiv_sqrt: true,
         # isa: "rv32ema",


### PR DESCRIPTION
Fix datapath extension parameter format in hjson: from "row=Seq(8), col=Seq(8), elementWidth=Seq(8)" to {row:[8], col:[8], elementWidth:[8]}.