### PR TITLE
Add serial ports support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,4 @@ jobs:
         run: |-
           ./run.py --simulator verilator \
           sw/runtime.yaml \
-          sw/snax-gemmx-matmul-run.yaml \
-          sw/snax-gemmx-conv-run.yaml \
           sw/snax-xdma-run.yaml -j

--- a/hw/chisel/src/main/scala/snax/csr_manager/CsrManager.scala
+++ b/hw/chisel/src/main/scala/snax/csr_manager/CsrManager.scala
@@ -4,6 +4,7 @@ import snax.utils._
 
 import chisel3._
 import chisel3.util._
+import chisel3.chiselTypeOf
 
 /** This class represents the csr input and output ports of the streamer top
   * module
@@ -87,7 +88,7 @@ class CsrManager(
       when(io.csr_config_in.req.bits.write === 1.B) {
         assert(
           io.csr_config_in.req.bits.addr < csrNumReadWrite.U,
-          "csr write address overflow!"
+          cf"csr write address overflow! Address: ${io.csr_config_in.req.bits.addr}, Max: ${csrNumReadWrite - 1}, Config: ${io.csr_config_in.req.bits.data}"
         )
       }
     }

--- a/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/Streamer.scala
@@ -595,18 +595,29 @@ class Streamer(
   def genCSRMap(csrBase: Int, param: ReaderWriterParam, tag: String = "") = {
     var csrMap = "// CSR Map for " + tag + "\n"
     var csrOffset = csrBase
+
     // base pointer
     csrMap = csrMap + "#define BASE_PTR_" + tag + "_LOW " + csrOffset + "\n"
     csrOffset = csrOffset + 1
     csrMap = csrMap + "#define BASE_PTR_" + tag + "_HIGH " + csrOffset + "\n"
     csrOffset = csrOffset + 1
 
-    // spatial bounds
+    // spatial strides base address for this data mover
+    csrMap = csrMap + "#define S_STRIDE_BASE_" + tag + " " + csrOffset + "\n"
+    csrMap =
+      csrMap + "#define S_STRIDE_NUM_" + tag + " " + param.aguParam.spatialBounds.length + "\n"
+
+    // spatial strides
     for (i <- 0 until param.aguParam.spatialBounds.length) {
       csrMap =
         csrMap + "#define " + "S_STRIDE_" + tag + "_" + i + " " + csrOffset + "\n"
       csrOffset = csrOffset + 1
     }
+
+    // temporal bounds base address for this data mover
+    csrMap = csrMap + "#define T_BOUND_BASE_" + tag + " " + csrOffset + "\n"
+    csrMap =
+      csrMap + "#define T_BOUND_NUM_" + tag + " " + param.aguParam.temporalDimension + "\n"
 
     // temporal bounds
     for (i <- 0 until param.aguParam.temporalDimension) {
@@ -614,6 +625,11 @@ class Streamer(
         csrMap + "#define " + "T_BOUND_" + tag + "_" + i + " " + csrOffset + "\n"
       csrOffset = csrOffset + 1
     }
+
+    // temporal strides base address for this data mover
+    csrMap = csrMap + "#define T_STRIDE_BASE_" + tag + " " + csrOffset + "\n"
+    csrMap =
+      csrMap + "#define T_STRIDE_NUM_" + tag + " " + param.aguParam.temporalDimension + "\n"
 
     // temporal stride
     for (i <- 0 until param.aguParam.temporalDimension) {

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
@@ -6,6 +6,8 @@ import chisel3.util._
 import snax_acc.simd._
 import snax_acc.gemm._
 
+import snax_acc.utils._
+
 // The BlockGemmRescaleSIMD's control port declaration.
 class BlockGemmRescaleSIMDCtrlIO(params: BlockGemmRescaleSIMDParams)
     extends Bundle {
@@ -23,12 +25,31 @@ class BlockGemmRescaleSIMDCtrlIO(params: BlockGemmRescaleSIMDParams)
 // The BlockGemmRescaleSIMD's data port declaration. Decoupled interface connected to the streamer
 class BlockGemmRescaleSIMDDataIO(params: BlockGemmRescaleSIMDParams)
     extends Bundle {
-  val gemm_data = new BlockGemmDataIO(params.gemmParams)
-  val simd_data = Decoupled(
-    UInt(
-      (params.rescaleSIMDParams.dataLen * params.rescaleSIMDParams.outputType).W
+  val gemm_data = new Bundle {
+    val a_i = Flipped(
+      Decoupled(
+        UInt(
+          (params.gemmParams.dataWidthA * params.gemmParams.meshRow * params.gemmParams.tileSize).W
+        )
+      )
     )
-  )
+    val b_i = Flipped(
+      Decoupled(
+        UInt(
+          (params.gemmParams.dataWidthB * params.gemmParams.tileSize * params.gemmParams.meshCol).W
+        )
+      )
+    )
+    val c_serial_i = Flipped(Decoupled(UInt(params.C32_D32_width.W)))
+    val d_serial_o = Decoupled(UInt(params.C32_D32_width.W))
+  }
+  val simd_data = new Bundle {
+    val d_serial_o = Decoupled(
+      UInt(
+        params.D8_width.W
+      )
+    )
+  }
 }
 
 class BlockGemmRescaleSIMDIO(params: BlockGemmRescaleSIMDParams)
@@ -55,12 +76,50 @@ class BlockGemmRescaleSIMD(params: BlockGemmRescaleSIMDParams)
     case _ => throw new Exception("Unknown SIMD configuration")
   }
 
+  // C32 serial to parallel converter
+  val C32_s2p = Module(
+    new SerialToParallel(
+      SerialToParallelParams(
+        parallelWidth =
+          params.gemmParams.dataWidthC * params.gemmParams.meshRow * params.gemmParams.meshCol,
+        serialWidth = params.C32_D32_width
+      )
+    )
+  )
+
+  // D3232 parallel to serial converter
+  val D32_p2s = Module(
+    new ParallelToSerial(
+      ParallelToSerialParams(
+        parallelWidth =
+          params.gemmParams.dataWidthC * params.gemmParams.meshRow * params.gemmParams.meshCol,
+        serialWidth = params.C32_D32_width
+      )
+    )
+  )
+
+  // D8 parallel to serial converter
+  val D8_p2s = Module(
+    new ParallelToSerial(
+      ParallelToSerialParams(
+        parallelWidth =
+          params.rescaleSIMDParams.dataLen * params.rescaleSIMDParams.outputType,
+        serialWidth = params.D8_width
+      )
+    )
+  )
+
+  // data converter connection
+  io.data.gemm_data.c_serial_i <> C32_s2p.io.in
+  io.data.gemm_data.d_serial_o <> D32_p2s.io.out
+  io.data.simd_data.d_serial_o <> D8_p2s.io.out
+
   // gemm control signal connection
   gemm.io.ctrl <> io.ctrl.gemm_ctrl
   // gemm input data
   gemm.io.data.a_i <> io.data.gemm_data.a_i
   gemm.io.data.b_i <> io.data.gemm_data.b_i
-  gemm.io.data.c_i <> io.data.gemm_data.c_i
+  gemm.io.data.c_i <> C32_s2p.io.out
 
   // simd signal connection
   when(io.ctrl.bypassSIMD) {
@@ -79,9 +138,9 @@ class BlockGemmRescaleSIMD(params: BlockGemmRescaleSIMDParams)
     simd.io.data.input_i.valid := false.B
 
     // gemm output to outside directly
-    io.data.gemm_data.d_o.valid := gemm.io.data.d_o.valid
+    D32_p2s.io.in.valid := gemm.io.data.d_o.valid
     // directly connect the ready signal
-    gemm.io.data.d_o.ready := io.data.gemm_data.d_o.ready
+    gemm.io.data.d_o.ready := D32_p2s.io.in.ready
 
   }.otherwise {
     // insert a register to improve frequency
@@ -90,25 +149,25 @@ class BlockGemmRescaleSIMD(params: BlockGemmRescaleSIMDParams)
     gemm.io.data.d_o.ready := simd.io.data.input_i.ready
 
     // output driver
-    io.data.gemm_data.d_o.valid := false.B
+    D32_p2s.io.in.valid := false.B
 
   }
   simd.io.data.input_i.bits := gemm.io.data.d_o.bits
-  io.data.gemm_data.d_o.bits := gemm.io.data.d_o.bits
+  D32_p2s.io.in.bits := gemm.io.data.d_o.bits
 
   // simd output
   when(io.ctrl.bypassSIMD) {
     // output driver
-    io.data.simd_data.valid <> false.B
+    D8_p2s.io.in.valid <> false.B
     // fake ready signal
     simd.io.data.output_o.ready := false.B
   }.otherwise {
-    io.data.simd_data.valid := simd.io.data.output_o.valid
-    simd.io.data.output_o.ready := io.data.simd_data.ready
+    D8_p2s.io.in.valid := simd.io.data.output_o.valid
+    simd.io.data.output_o.ready := D8_p2s.io.in.ready
   }
-  io.data.simd_data.bits := simd.io.data.output_o.bits
+  D8_p2s.io.in.bits := simd.io.data.output_o.bits
 
-  io.ctrl.busy_o := gemm.io.busy_o || simd.io.busy_o
+  io.ctrl.busy_o := gemm.io.busy_o || simd.io.busy_o || D8_p2s.io.out.valid || D32_p2s.io.out.valid
   when(io.ctrl.bypassSIMD) {
     io.ctrl.performance_counter := gemm.io.performance_counter
   }.otherwise {
@@ -316,17 +375,17 @@ module snax_streamer_gemmX_shell_wrapper #(
       .io_data_gemm_data_b_i_valid(stream2acc_1_valid_i),
       .io_data_gemm_data_b_i_bits (stream2acc_1_data_i),
 
-      .io_data_gemm_data_c_i_ready(stream2acc_2_ready_o),
-      .io_data_gemm_data_c_i_valid(stream2acc_2_valid_i),
-      .io_data_gemm_data_c_i_bits (stream2acc_2_data_i),
+      .io_data_gemm_data_c_serial_i_ready(stream2acc_2_ready_o),
+      .io_data_gemm_data_c_serial_i_valid(stream2acc_2_valid_i),
+      .io_data_gemm_data_c_serial_i_bits (stream2acc_2_data_i),
 
-      .io_data_gemm_data_d_o_ready(acc2stream_1_ready_i),
-      .io_data_gemm_data_d_o_valid(acc2stream_1_valid_o),
-      .io_data_gemm_data_d_o_bits (acc2stream_1_data_o),
+      .io_data_gemm_data_d_serial_o_ready(acc2stream_1_ready_i),
+      .io_data_gemm_data_d_serial_o_valid(acc2stream_1_valid_o),
+      .io_data_gemm_data_d_serial_o_bits (acc2stream_1_data_o),
 
-      .io_data_simd_data_ready(acc2stream_0_ready_i),
-      .io_data_simd_data_valid(acc2stream_0_valid_o),
-      .io_data_simd_data_bits (acc2stream_0_data_o)
+      .io_data_simd_data_d_serial_o_ready(acc2stream_0_ready_i),
+      .io_data_simd_data_d_serial_o_valid(acc2stream_0_valid_o),
+      .io_data_simd_data_d_serial_o_bits (acc2stream_0_data_o)
   );
 
 endmodule
@@ -337,9 +396,8 @@ endmodule
       macro_template.getBytes(java.nio.charset.StandardCharsets.UTF_8)
     )
 
-
-  // generate the c runtime file arrording to the hardware configuration
-  val c_template = s"""// Copyright 2023 KU Leuven.
+    // generate the c runtime file arrording to the hardware configuration
+    val c_template = s"""// Copyright 2023 KU Leuven.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -352,11 +410,12 @@ endmodule
 #define meshCol $meshCol
 """
 
-  val c_header_file_path = "../../target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-params.h"
+    val c_header_file_path =
+      "../../target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-params.h"
 
-  java.nio.file.Files.write(
-    java.nio.file.Paths.get(s"${c_header_file_path}"),
-    c_template.getBytes(java.nio.charset.StandardCharsets.UTF_8)
-  )
+    java.nio.file.Files.write(
+      java.nio.file.Paths.get(s"${c_header_file_path}"),
+      c_template.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    )
   }
 }

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/Parameters.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/Parameters.scala
@@ -9,7 +9,9 @@ import snax_acc.gemm._
 case class BlockGemmRescaleSIMDParams(
     gemmParams: GemmParams,
     rescaleSIMDParams: RescaleSIMDParams,
-    withPipeline: Boolean
+    withPipeline: Boolean,
+    C32_D32_width: Int = 512,
+    D8_width: Int = 512
 )
 
 object BlockGemmRescaleSIMDDefaultConfig {

--- a/hw/chisel_acc/src/main/scala/snax_acc/utils/ParallelSerialConverter.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/utils/ParallelSerialConverter.scala
@@ -1,0 +1,122 @@
+package snax_acc.utils
+
+import chisel3._
+import chisel3.util._
+
+/** Parameter class for ParallelToSerial.
+  *
+  * @param parallelWidth
+  *   The total width of the parallel input data.
+  * @param serialWidth
+  *   The width of each output serial chunk, must divide parallelWidth evenly.
+  */
+case class ParallelToSerialParams(
+    parallelWidth: Int,
+    serialWidth: Int
+) {
+  require(
+    parallelWidth % serialWidth == 0,
+    "parallelWidth must be an integer multiple of serialWidth."
+  )
+}
+
+/** A module that sends a parallel input (via Decoupled I/O) out as multiple
+  * serial chunks (also Decoupled I/O).
+  */
+class ParallelToSerial(val p: ParallelToSerialParams) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(Decoupled(UInt(p.parallelWidth.W)))
+    val out = Decoupled(UInt(p.serialWidth.W))
+  })
+
+  // Calculate how many serial chunks form one parallel word.
+  val factor = p.parallelWidth / p.serialWidth
+
+  // Shift register to hold the parallel data while serializing.
+  val shiftReg = RegInit(0.U(p.parallelWidth.W))
+  // Counts how many chunks remain to be sent.
+  val count = RegInit(0.U(log2Ceil(factor + 1).W))
+
+  // Accept a new parallel word only if we have nothing left to send.
+  io.in.ready := (count === 0.U)
+
+  // Once we get a new parallel word, store it and prepare to send.
+  when(io.in.fire) {
+    shiftReg := io.in.bits
+  }.elsewhen(io.out.fire) {
+    // Shift the data to the right to get the next chunk.
+    shiftReg := shiftReg >> p.serialWidth.U
+  }
+
+  // On handshake, shift to the next chunk and decrement count.
+  when(io.in.fire) {
+    count := factor.U
+  }.elsewhen(io.out.fire) {
+    count := count - 1.U
+  }
+
+  // The output is valid if there are chunks left to send.
+  io.out.valid := (count > 0.U)
+  // The current chunk to send is the least significant bits of shiftReg.
+  io.out.bits := shiftReg(p.serialWidth - 1, 0)
+
+}
+
+/** Parameter class for SerialToParallel.
+  *
+  * @param serialWidth
+  *   The width of each incoming serial data chunk.
+  * @param parallelWidth
+  *   The total width of the parallel output data. Must be a multiple of
+  *   serialWidth.
+  */
+case class SerialToParallelParams(
+    serialWidth: Int,
+    parallelWidth: Int
+) {
+  require(
+    parallelWidth % serialWidth == 0,
+    "parallelWidth must be an integer multiple of serialWidth."
+  )
+}
+
+/** A module that collects multiple serial inputs (via Decoupled I/O) and
+  * outputs them as a single parallel word (also Decoupled I/O).
+  *
+  * This version defers output by one clock after receiving the final serial
+  * chunk, ensuring that the shift register contains the correct concatenated
+  * data.
+  */
+class SerialToParallel(val p: SerialToParallelParams) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(Decoupled(UInt(p.serialWidth.W)))
+    val out = Decoupled(UInt(p.parallelWidth.W))
+  })
+
+  // Number of input chunks required to form one parallel output
+  val factor: Int = p.parallelWidth / p.serialWidth
+
+  // Registers to track incoming data and chunk count
+  val shiftReg = RegInit(0.U(p.parallelWidth.W))
+  val count = RegInit(0.U(log2Ceil(factor + 1).W))
+
+  io.in.ready := count =/= factor.U
+
+  when(io.in.fire && count =/= 0.U) {
+    // Shift in the new serial bits at a position based on the count
+    shiftReg := shiftReg | (io.in.bits << (count * p.serialWidth.U))
+  }.elsewhen(io.in.fire) {
+    // If we're at the first chunk, reset the shift register
+    shiftReg := io.in.bits
+  }
+
+  when(io.out.fire) {
+    count := 0.U
+  }.elsewhen(io.in.fire) {
+    count := count + 1.U
+  }
+
+  io.out.valid := count === factor.U
+
+  io.out.bits := shiftReg
+}

--- a/hw/chisel_acc/src/main/scala/snax_acc/utils/ParallelSerialConverter.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/utils/ParallelSerialConverter.scala
@@ -3,6 +3,8 @@ package snax_acc.utils
 import chisel3._
 import chisel3.util._
 
+import scala.math._
+
 /** Parameter class for ParallelToSerial.
   *
   * @param parallelWidth
@@ -33,7 +35,17 @@ class ParallelToSerial(val p: ParallelToSerialParams) extends Module {
   val factor = p.parallelWidth / p.serialWidth
 
   // Shift register to hold the parallel data while serializing.
-  val shiftReg = RegInit(0.U(p.parallelWidth.W))
+  if (p.parallelWidth <= 2048) {} else {
+    // If the parallelWidth is greater than 2048, we need to use several smaller shift register
+    require(
+      p.parallelWidth % 2048 == 0,
+      "parallelWidth must be an integer multiple of 2048."
+    )
+  }
+
+  val numRegs = math.max(1, p.parallelWidth / 2048) // Number of registers
+  val shiftReg = RegInit(VecInit(Seq.fill(numRegs)(0.U(2048.W))))
+
   // Counts how many chunks remain to be sent.
   val count = RegInit(0.U(log2Ceil(factor + 1).W))
 
@@ -41,11 +53,36 @@ class ParallelToSerial(val p: ParallelToSerialParams) extends Module {
   io.in.ready := (count === 0.U)
 
   // Once we get a new parallel word, store it and prepare to send.
-  when(io.in.fire) {
-    shiftReg := io.in.bits
-  }.elsewhen(io.out.fire) {
-    // Shift the data to the right to get the next chunk.
-    shiftReg := shiftReg >> p.serialWidth.U
+  // store in the vector of regs
+  if (p.parallelWidth <= 2048) {
+    when(io.in.fire) {
+      shiftReg(0) := io.in.bits
+    }
+    .elsewhen(io.out.fire) {
+      shiftReg(0) := shiftReg(0) >> p.serialWidth.U
+    }
+  } else {
+    when(io.in.fire) {
+      for (i <- 0 until numRegs) {
+        shiftReg(i) := io.in.bits(i * 2048 + 2047, i * 2048)
+      }
+    }.elsewhen(io.out.fire) {
+      for (i <- 0 until numRegs) {
+        if (i == numRegs - 1) {
+          // If we are at the last register, we need to shift in zeros
+          shiftReg(i) := Cat(
+            0.U(p.serialWidth.W),
+            shiftReg(i)(2047, p.serialWidth)
+          )
+        } else {
+          // Otherwise, shift in the next register
+          shiftReg(i) := Cat(
+            shiftReg(i + 1)(p.serialWidth - 1, 0),
+            shiftReg(i)(2047, p.serialWidth)
+          )
+        }
+      }
+    }
   }
 
   // On handshake, shift to the next chunk and decrement count.
@@ -58,7 +95,7 @@ class ParallelToSerial(val p: ParallelToSerialParams) extends Module {
   // The output is valid if there are chunks left to send.
   io.out.valid := (count > 0.U)
   // The current chunk to send is the least significant bits of shiftReg.
-  io.out.bits := shiftReg(p.serialWidth - 1, 0)
+  io.out.bits := shiftReg(0)(p.serialWidth - 1, 0)
 
 }
 
@@ -97,17 +134,33 @@ class SerialToParallel(val p: SerialToParallelParams) extends Module {
   val factor: Int = p.parallelWidth / p.serialWidth
 
   // Registers to track incoming data and chunk count
-  val shiftReg = RegInit(0.U(p.parallelWidth.W))
+  val numRegs = math.max(1, p.parallelWidth / 2048) // Number of registers
+  val shiftReg = RegInit(VecInit(Seq.fill(numRegs)(0.U(2048.W))))
   val count = RegInit(0.U(log2Ceil(factor + 1).W))
 
   io.in.ready := count =/= factor.U
 
-  when(io.in.fire && count =/= 0.U) {
-    // Shift in the new serial bits at a position based on the count
-    shiftReg := shiftReg | (io.in.bits << (count * p.serialWidth.U))
-  }.elsewhen(io.in.fire) {
+  when(io.in.fire && count === 0.U) {
     // If we're at the first chunk, reset the shift register
-    shiftReg := io.in.bits
+    for (i <- 0 until numRegs) {
+      if (i == numRegs - 1) {
+        shiftReg(i) := Cat(io.in.bits, 0.U((2048 - p.serialWidth).W))
+      } else {
+        shiftReg(i) := 0.U
+      }
+    }
+  }.elsewhen(io.in.fire && count =/= 0.U) {
+    // Shift in the new serial bits at a position based on the count
+    for (i <- 0 until numRegs) {
+      if (i == numRegs - 1) {
+        shiftReg(i) := Cat(io.in.bits, shiftReg(i)(2047, p.serialWidth))
+      } else {
+        shiftReg(i) := Cat(
+          shiftReg(i + 1)(p.serialWidth - 1, 0),
+          shiftReg(i)(2047, p.serialWidth)
+        )
+      }
+    }
   }
 
   when(io.out.fire) {
@@ -118,5 +171,11 @@ class SerialToParallel(val p: SerialToParallelParams) extends Module {
 
   io.out.valid := count === factor.U
 
-  io.out.bits := shiftReg
+  // Concatenate the shift register contents to form the parallel output
+  if (p.parallelWidth <= 2048) {
+    io.out.bits := shiftReg(0)(2047, 2047 - p.parallelWidth + 1)
+  } else {
+    io.out.bits := Cat(shiftReg.reverse)
+  }
+
 }

--- a/hw/chisel_acc/src/test/scala/snax_acc/utils/ParallelSerialConverter.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/utils/ParallelSerialConverter.scala
@@ -115,6 +115,9 @@ class SerialToParallelSpec
           // Step to capture this byte
           dut.clock.step()
         }
+
+        // dut.io.out.valid.expect(true.B)
+        // dut.io.out.bits.expect(expectedParallel.U)
         dut.clock.step()
 
       }
@@ -133,6 +136,8 @@ class SerialToParallelSpec
           dut.clock.step()
         }
 
+        // dut.io.out.valid.expect(true.B)
+        // dut.io.out.bits.expect(expectedParallel.U)
         dut.clock.step()
 
       }

--- a/hw/chisel_acc/src/test/scala/snax_acc/utils/ParallelSerialConverter.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/utils/ParallelSerialConverter.scala
@@ -1,0 +1,141 @@
+package snax_acc.utils
+
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ParallelToSerialTest extends AnyFlatSpec with ChiselScalatestTester {
+
+  "ParallelToSerial" should "convert parallel data into multiple serial chunks" in {
+    val parallelWidth = 16
+    val serialWidth = 4
+    test(
+      new ParallelToSerial(ParallelToSerialParams(parallelWidth, serialWidth))
+    ).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+      // The factor is 16 / 4 = 4, so each parallel input will yield 4 serial outputs.
+      dut.io.in.initSource()
+      dut.io.out.initSink()
+
+      // Push a single parallel input to be serialized. Let's choose 0xABCD, or 43981 in decimal.
+      // 0xABCD in binary is 1010_1011_1100_1101.
+      // The 4-bit chunks (starting from LSB) should be: 1101 (0xD), 1100 (0xC), 1011 (0xB), 1010 (0xA).
+
+      var parallelData = 0xabcd.U
+      var expectedChunks = Seq("xd", "xc", "xb", "xa").map(_.U(4.W))
+
+      // Provide the single parallel input.
+      dut.clock.step(5)
+
+      dut.io.in.bits.poke(parallelData)
+      dut.io.in.valid.poke(true.B)
+      dut.clock.step()
+
+      // After 1 cycle, the module should have latched the parallel input, so in can go low.
+      dut.io.in.valid.poke(false.B)
+
+      // Now observe the serialized chunks.
+      for (expectedChunk <- expectedChunks) {
+        // Wait for valid to ensure the chunk is ready
+        while (!dut.io.out.valid.peekBoolean()) {
+          dut.clock.step()
+        }
+        // Check the chunk
+        dut.io.out.bits.expect(expectedChunk)
+        // Consume it
+        dut.io.out.ready.poke(true.B)
+        dut.clock.step()
+        dut.io.out.ready.poke(false.B)
+      }
+      parallelData = 0xefef.U
+      expectedChunks = Seq("xF", "xE", "xF", "xE").map(_.U(4.W))
+      dut.io.in.bits.poke(parallelData)
+      dut.io.in.valid.poke(true.B)
+      dut.clock.step()
+
+      // After 1 cycle, the module should have latched the parallel input, so in can go low.
+      dut.io.in.valid.poke(false.B)
+
+      // Now observe the serialized chunks.
+      for (expectedChunk <- expectedChunks) {
+        // Wait for valid to ensure the chunk is ready
+        while (!dut.io.out.valid.peekBoolean()) {
+          dut.clock.step()
+        }
+        // Check the chunk
+        dut.io.out.bits.expect(expectedChunk)
+        // Consume it
+        dut.io.out.ready.poke(true.B)
+        dut.clock.step()
+        dut.io.out.ready.poke(false.B)
+      }
+
+      // After sending out 4 chunks, the module should be ready for new data.
+      // Verify it's no longer valid.
+      dut.io.out.valid.expect(false.B)
+      dut.clock.step()
+    }
+  }
+}
+
+class SerialToParallelSpec
+    extends AnyFlatSpec
+    with ChiselScalatestTester
+    with Matchers {
+
+  behavior of "SerialToParallel"
+
+  it should "collect serial data and produce parallel output correctly" in {
+    test(
+      new SerialToParallel(
+        SerialToParallelParams(
+          serialWidth = 8, // 8 bits per serial input
+          parallelWidth = 32 // 32 bits parallel output
+        )
+      )
+    ).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+      // The parallel output is formed by collecting 4 serial inputs (4 * 8 = 32).
+      // We'll send in 4 consecutive bytes and expect them to appear in the out.bits.
+
+      // Prepare for the test
+      dut.io.out.ready.poke(true.B) // Always ready to consume parallel output
+      dut.clock.step()
+
+      // Example data to send (4 byte values)
+      var testData = Seq(0xab.U, 0xcd.U, 0x12.U, 0x34.U)
+
+      // We expect the parallel output to combine these 4 bytes: 0x34_12_CD_AB (little-endian accumulation)
+      var expectedParallel = (0x34 << 24) | (0x12 << 16) | (0xcd << 8) | 0xab
+
+      for (i <- 0 to 1) {
+        for ((byteVal, idx) <- testData.zipWithIndex) {
+          // Present the serial byte
+          dut.io.in.valid.poke(true.B)
+          dut.io.in.bits.poke(byteVal)
+          // Step to capture this byte
+          dut.clock.step()
+        }
+        dut.clock.step()
+
+      }
+
+      // Example data to send (4 byte values)
+      testData = Seq(0xef.U, 0xaa.U, 0xbb.U, 0xcc.U)
+
+      expectedParallel = (0xcc << 24) | (0xbb << 16) | (0xaa << 8) | 0xef
+
+      for (i <- 0 to 1) {
+        for ((byteVal, idx) <- testData.zipWithIndex) {
+          // Present the serial byte
+          dut.io.in.valid.poke(true.B)
+          dut.io.in.bits.poke(byteVal)
+          // Step to capture this byte
+          dut.clock.step()
+        }
+
+        dut.clock.step()
+
+      }
+    }
+  }
+}

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -130,6 +130,8 @@
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,
             snax_gemmx_mesh_col: 8,
+            snax_gemmx_serial_c32_d32_width: 2048,
+            snax_gemmx_serial_d8_width: 512,
             with_pipeline: true,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -130,8 +130,6 @@
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,
             snax_gemmx_mesh_col: 8,
-            snax_gemmx_serial_c32_d32_width: 2048,
-            snax_gemmx_serial_d8_width: 512,
             with_pipeline: true,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },

--- a/target/snitch_cluster/cfg/snax_KUL_dse_cluster_2D.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_dse_cluster_2D.hjson
@@ -51,17 +51,17 @@
             "snax_enable_assign_tcdm_idx": true,
             "snax_narrow_assign_start_idx": [
                 0,
-                326
+                22
             ],
             "snax_narrow_assign_end_idx": [
                 5,
-                341
+                37
             ],
             "snax_wide_assign_start_idx": [
                 6
             ],
             "snax_wide_assign_end_idx": [
-                325
+                21
             ]
         }
         // AXI bandwidth switcher
@@ -135,7 +135,7 @@
             snax_acc_name: "snax_streamer_gemmX",
             bender_target: ["snax_gemmX"],
             snax_narrow_tcdm_ports: 6,
-            snax_wide_tcdm_ports: 320,
+            snax_wide_tcdm_ports: 16,
             snax_num_rw_csr: 29,
             snax_num_ro_csr: 2,
             snax_gemmx_mesh_row: 32,

--- a/target/snitch_cluster/cfg/snax_KUL_dse_cluster_2D.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_dse_cluster_2D.hjson
@@ -141,6 +141,8 @@
             snax_gemmx_mesh_row: 32,
             snax_gemmx_tile_size: 1,
             snax_gemmx_mesh_col: 16,
+            snax_gemmx_serial_c32_d32_width: 512,
+            snax_gemmx_serial_d8_width: 512,
             with_pipeline: false,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },
@@ -220,20 +222,20 @@
         },
 
         data_writer_params:{
-            spatial_bounds: [[64]],
-            temporal_dim: [3],
-            num_channel: [64],
+            spatial_bounds: [[8]],
+            temporal_dim: [4],
+            num_channel: [8],
             fifo_depth: [1],
             configurable_channel: [0],
         },
 
         data_reader_writer_params:{
-            spatial_bounds: [[8, 32], [8, 32]],
-            temporal_dim: [3, 3],
-            num_channel: [256, 256],
+            spatial_bounds: [[8], [8]],
+            temporal_dim: [4, 4],
+            num_channel: [8, 8],
             fifo_depth: [1, 1],
             configurable_channel: [1, 0],
-            datapath_extensions: [{HasBroadcaster: {inputLength: 512, outputLength: 16384}}, {}]
+            datapath_extensions: [{HasBroadcaster: {inputLength: 512, outputLength: 512}}, {}]
         },
 
         has_transpose: true,

--- a/target/snitch_cluster/cfg/snax_KUL_dse_cluster_3D.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_dse_cluster_3D.hjson
@@ -49,10 +49,10 @@
         },
         snax_custom_tcdm_assign: {
             snax_enable_assign_tcdm_idx: true,
-            snax_narrow_assign_start_idx: [0,56],
-            snax_narrow_assign_end_idx: [7,71],
+            snax_narrow_assign_start_idx: [0,32],
+            snax_narrow_assign_end_idx: [7,47],
             snax_wide_assign_start_idx: [8],
-            snax_wide_assign_end_idx: [55],
+            snax_wide_assign_end_idx: [31],
         },
         // AXI bandwidth switcher
         use_ax_bw_converter: true,
@@ -125,7 +125,7 @@
             snax_acc_name: "snax_streamer_gemmX",
             bender_target: ["snax_gemmX"],
             snax_narrow_tcdm_ports: 8,
-            snax_wide_tcdm_ports: 48,
+            snax_wide_tcdm_ports: 24,
             snax_num_rw_csr: 19,
             snax_num_ro_csr: 2,
             snax_gemmx_mesh_row: 8,

--- a/target/snitch_cluster/cfg/snax_KUL_dse_cluster_3D.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_dse_cluster_3D.hjson
@@ -131,6 +131,8 @@
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,
             snax_gemmx_mesh_col: 8,
+            snax_gemmx_serial_c32_d32_width: 512,
+            snax_gemmx_serial_d8_width: 512,
             with_pipeline: false,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },
@@ -212,7 +214,7 @@
 
         data_writer_params:{
             spatial_bounds: [[8]],
-            temporal_dim: [3],
+            temporal_dim: [4],
             num_channel: [8],
             fifo_depth: [1],
             configurable_channel: [0],
@@ -220,13 +222,13 @@
         },
 
         data_reader_writer_params:{
-            spatial_bounds: [[8, 4], [8, 4]],
-            temporal_dim: [3, 3],
-            num_channel: [32, 32],
+            spatial_bounds: [[8], [8]],
+            temporal_dim: [4, 4],
+            num_channel: [8, 8],
             fifo_depth: [1, 1],
             configurable_channel: [1, 0],
             tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
-            datapath_extensions: [{HasBroadcaster: {inputLength: 256, outputLength: 2048}}, {}]
+            datapath_extensions: [{HasBroadcaster: {inputLength: 256, outputLength: 512}}, {}]
         },
 
         has_transpose: true,

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -24,7 +24,7 @@ ifeq (${CFG_OVERRIDE}, cfg/snax_KUL_dse_cluster_2D.hjson)
 SUBDIRS += snax/gemmx snax/data-reshuffler
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
-SUBDIRS += snax/gemmx snax/xdma
+SUBDIRS += snax/xdma
 endif
 
 ifeq (${CFG_OVERRIDE}, cfg/snax_alu_cluster.hjson)

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -38,8 +38,6 @@ SUBDIRS += snax-data-reshuffler
 SUBDIRS += snax-gemmx-matmul
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
-SUBDIRS += snax-gemmx-matmul
-SUBDIRS += snax-gemmx-conv
 SUBDIRS += snax-xdma-memset
 SUBDIRS += snax-xdma-maxpool
 endif

--- a/target/snitch_cluster/sw/apps/snax-gemmx-conv/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-conv/data/params.hjson
@@ -19,7 +19,8 @@
   transposed_A: 1,
   transposed_B: 0,
   bypassSIMD: 0,
-  broadcast_C: 1,
+  // broadcast_C won't work in the serial C input
+  broadcast_C: 0,
   channel_en_C: 1,
 
   // memory space configurations

--- a/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
@@ -75,27 +75,30 @@ int main() {
     }
 
     snrt_cluster_hw_barrier();
-    
+
     int32_t Aslstride[] = {Aslstride0};
-    int32_t Atlbound[] = {Atlbound0, Atlbound1, Atlbound2, Atlbound3, Atlbound4, Atlbound5};
-    int32_t Atlstride[] = {Atlstride0, Atlstride1, Atlstride2, Atlstride3, Atlstride4, Atlstride5};
+    int32_t Atlbound[] = {Atlbound0, Atlbound1, Atlbound2,
+                          Atlbound3, Atlbound4, Atlbound5};
+    int32_t Atlstride[] = {Atlstride0, Atlstride1, Atlstride2,
+                           Atlstride3, Atlstride4, Atlstride5};
     int32_t Bslstride[] = {Bslstride0};
     int32_t Btlbound[] = {Btlbound0, Btlbound1, Btlbound2};
     int32_t Btlstride[] = {Btlstride0, Btlstride1, Btlstride2};
     int32_t D8slstride[] = {D8slstride0};
-    int32_t D8tlbound []= {D8tlbound0, D8tlbound1, D8tlbound2, D8tlbound3};
-    int32_t D8tlstride []= {D8tlstride0, D8tlstride1, D8tlstride2, D8tlstride3};
-    int32_t Cslstride []= {Cslstride0};
+    int32_t D8tlbound[] = {D8tlbound0, D8tlbound1, D8tlbound2, D8tlbound3};
+    int32_t D8tlstride[] = {D8tlstride0, D8tlstride1, D8tlstride2, D8tlstride3};
+    int32_t Cslstride[] = {Cslstride0};
     int32_t Ctlbound[] = {Ctlbound0, Ctlbound1, Ctlbound2, Ctlbound3};
     int32_t Ctlstride[] = {Ctlstride0, Ctlstride1, Ctlstride2, Ctlstride3};
     int32_t D32slstride[] = {D32slstride0};
-    int32_t D32tlbound []= {D32tlbound0, D32tlbound1, D32tlbound2, D32tlbound3};
-    int32_t D32tlstride[] = {D32tlstride0, D32tlstride1, D32tlstride2, D32tlstride3};
+    int32_t D32tlbound[] = {D32tlbound0, D32tlbound1, D32tlbound2, D32tlbound3};
+    int32_t D32tlstride[] = {D32tlstride0, D32tlstride1, D32tlstride2,
+                             D32tlstride3};
 
     if (snrt_global_core_idx() == 0) {
         // Set Streamer configuration CSR for conv2d
         set_gemmx_streamer_csr(
-            Aslstride, Atlbound, Atlstride , set_addr_remap_index_A,
+            Aslstride, Atlbound, Atlstride, set_addr_remap_index_A,
 
             Bslstride, Btlbound, Btlstride, set_addr_remap_index_B,
 

--- a/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-conv/src/snax-gemmx-conv.c
@@ -75,26 +75,35 @@ int main() {
     }
 
     snrt_cluster_hw_barrier();
+    
+    int32_t Aslstride[] = {Aslstride0};
+    int32_t Atlbound[] = {Atlbound0, Atlbound1, Atlbound2, Atlbound3, Atlbound4, Atlbound5};
+    int32_t Atlstride[] = {Atlstride0, Atlstride1, Atlstride2, Atlstride3, Atlstride4, Atlstride5};
+    int32_t Bslstride[] = {Bslstride0};
+    int32_t Btlbound[] = {Btlbound0, Btlbound1, Btlbound2};
+    int32_t Btlstride[] = {Btlstride0, Btlstride1, Btlstride2};
+    int32_t D8slstride[] = {D8slstride0};
+    int32_t D8tlbound []= {D8tlbound0, D8tlbound1, D8tlbound2, D8tlbound3};
+    int32_t D8tlstride []= {D8tlstride0, D8tlstride1, D8tlstride2, D8tlstride3};
+    int32_t Cslstride []= {Cslstride0};
+    int32_t Ctlbound[] = {Ctlbound0, Ctlbound1, Ctlbound2, Ctlbound3};
+    int32_t Ctlstride[] = {Ctlstride0, Ctlstride1, Ctlstride2, Ctlstride3};
+    int32_t D32slstride[] = {D32slstride0};
+    int32_t D32tlbound []= {D32tlbound0, D32tlbound1, D32tlbound2, D32tlbound3};
+    int32_t D32tlstride[] = {D32tlstride0, D32tlstride1, D32tlstride2, D32tlstride3};
 
     if (snrt_global_core_idx() == 0) {
         // Set Streamer configuration CSR for conv2d
         set_gemmx_streamer_csr(
-            Aslstride0, Aslstride1, Atlbound0, Atlstride0, Atlbound1,
-            Atlstride1, Atlbound2, Atlstride2, Atlbound3, Atlstride3, Atlbound4,
-            Atlstride4, Atlbound5, Atlstride5, set_addr_remap_index_A,
+            Aslstride, Atlbound, Atlstride , set_addr_remap_index_A,
 
-            Bslstride0, Bslstride1, Btlbound0, Btlstride0, Btlbound1,
-            Btlstride1, Btlbound2, Btlstride2, set_addr_remap_index_B,
+            Bslstride, Btlbound, Btlstride, set_addr_remap_index_B,
 
-            D8slstride0, D8slstride1, D8tlbound0, D8tlstride0, D8tlbound1,
-            D8tlstride1, D8tlbound2, D8tlstride2, set_addr_remap_index_D8,
+            D8slstride, D8tlbound, D8tlstride, set_addr_remap_index_D8,
 
-            Cslstride0, Cslstride1, Ctlbound0, Ctlstride0, Ctlbound1,
-            Ctlstride1, Ctlbound2, Ctlstride2, set_addr_remap_index_C,
+            Cslstride, Ctlbound, Ctlstride, set_addr_remap_index_C,
 
-            D32slstride0, D32slstride1, D32tlbound0, D32tlstride0, D32tlbound1,
-            D32tlstride1, D32tlbound2, D32tlstride2, set_addr_remap_index_D32,
-
+            D32slstride, D32tlbound, D32tlstride, set_addr_remap_index_D32,
             delta_local_a, delta_local_b, delta_local_d8, delta_local_c,
             delta_local_d32, bypassSIMD, transposed_A, transposed_B,
             channel_en_C, broadcast_C);

--- a/target/snitch_cluster/sw/apps/snax-gemmx-matmul/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-matmul/data/datagen.py
@@ -57,17 +57,22 @@ def emit_matmul_data(**kwargs):
     meshCol = kwargs["snax_streamer_gemmX_core_template"]["snax_acc_cfg"][
         "snax_gemmx_mesh_col"
     ]
+    snax_gemmx_serial_c32_d32_width = kwargs["snax_streamer_gemmX_core_template"][
+        "snax_acc_cfg"
+    ]["snax_gemmx_serial_c32_d32_width"]
+    snax_gemmx_serial_d8_width = kwargs["snax_streamer_gemmX_core_template"][
+        "snax_acc_cfg"
+    ]["snax_gemmx_serial_d8_width"]
 
     # matmul settings
     data_str = []
 
-    data_str += [format_scalar_definition("int", "Batch", 1)]
-    data_str += [format_scalar_definition("int", "M", kwargs["M"])]
-    data_str += [format_scalar_definition("int", "K", kwargs["K"])]
-    data_str += [format_scalar_definition("int", "N", kwargs["N"])]
+    data_str += [format_scalar_definition("int32_t", "Batch", 1)]
+    data_str += [format_scalar_definition("int32_t", "M", kwargs["M"])]
+    data_str += [format_scalar_definition("int32_t", "K", kwargs["K"])]
+    data_str += [format_scalar_definition("int32_t", "N", kwargs["N"])]
 
-    data_str += [format_scalar_definition("int32_t", "Aslstride0", 1)]
-    data_str += [format_scalar_definition("int32_t", "Aslstride1", bankWidth / 8)]
+    data_str += [format_scalar_definition("int32_t", "Aslstride0", bankWidth / 8)]
     data_str += [format_scalar_definition("int32_t", "Atlbound0", kwargs["K"])]
     data_str += [
         format_scalar_definition(
@@ -91,8 +96,7 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "Atlbound5", 1)]
     data_str += [format_scalar_definition("int32_t", "Atlstride5", 0)]
 
-    data_str += [format_scalar_definition("int32_t", "Bslstride0", 1)]
-    data_str += [format_scalar_definition("int32_t", "Bslstride1", bankWidth / 8)]
+    data_str += [format_scalar_definition("int32_t", "Bslstride0", bankWidth / 8)]
     data_str += [format_scalar_definition("int32_t", "Btlbound0", kwargs["K"])]
     data_str += [
         format_scalar_definition(
@@ -110,75 +114,101 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "Btlbound2", kwargs["M"])]
     data_str += [format_scalar_definition("int32_t", "Btlstride2", 0)]
 
+    # -----------------------------------------------------------
+    # streamer c32 settings
+    # -----------------------------------------------------------
+    # spatial settings
     data_str += [format_scalar_definition("int32_t", "Cslstride0", bankWidth / 8)]
     c32_spatial_bound_0 = 8
+    # temporal settings
+    # serial input for C
+    data_str += [format_scalar_definition("int32_t", "Ctlbound0", output_data_width * meshRow * meshCol / snax_gemmx_serial_c32_d32_width)]
     data_str += [
         format_scalar_definition(
-            "int32_t", "Cslstride1", c32_spatial_bound_0 * (bankWidth / 8)
+            "int32_t", "Ctlstride0", c32_spatial_bound_0 * (bankWidth / 8)
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "Ctlbound0", kwargs["N"])]
+    data_str += [format_scalar_definition("int32_t", "Ctlbound1", kwargs["N"])]
     data_str += [
         format_scalar_definition(
-            "int32_t", "Ctlstride0", output_data_width * meshRow * meshCol / 8
+            "int32_t", "Ctlstride1", output_data_width * meshRow * meshCol / 8
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "Ctlbound1", kwargs["M"])]
+    data_str += [format_scalar_definition("int32_t", "Ctlbound2", kwargs["M"])]
     data_str += [
         format_scalar_definition(
             "int32_t",
-            "Ctlstride1",
+            "Ctlstride2",
             kwargs["N"] * output_data_width * meshRow * meshCol / 8,
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "Ctlbound2", 1)]
-    data_str += [format_scalar_definition("int32_t", "Ctlstride2", 0)]
+    data_str += [format_scalar_definition("int32_t", "Ctlbound3", 1)]
+    data_str += [format_scalar_definition("int32_t", "Ctlstride3", 0)]
 
+    # -----------------------------------------------------------
+    # streamer d32 settings
+    # -----------------------------------------------------------
+    # spatial settings
     data_str += [format_scalar_definition("int32_t", "D32slstride0", bankWidth / 8)]
     d32_spatial_bound_0 = 8
+    # temporal settings
+    data_str += [format_scalar_definition("int32_t", "D32tlbound0", output_data_width * meshRow * meshCol / snax_gemmx_serial_c32_d32_width)]
     data_str += [
         format_scalar_definition(
-            "int32_t", "D32slstride1", d32_spatial_bound_0 * (bankWidth / 8)
+            "int32_t", "D32tlstride0", d32_spatial_bound_0 * (bankWidth / 8)
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "D32tlbound0", kwargs["N"])]
+    data_str += [format_scalar_definition("int32_t", "D32tlbound1", kwargs["N"])]
     data_str += [
         format_scalar_definition(
-            "int32_t", "D32tlstride0", output_data_width * meshRow * meshCol / 8
+            "int32_t", "D32tlstride1", output_data_width * meshRow * meshCol / 8
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "D32tlbound1", kwargs["M"])]
+    data_str += [format_scalar_definition("int32_t", "D32tlbound2", kwargs["M"])]
     data_str += [
         format_scalar_definition(
             "int32_t",
-            "D32tlstride1",
+            "D32tlstride2",
             kwargs["N"] * output_data_width * meshRow * meshCol / 8,
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "D32tlbound2", 1)]
-    data_str += [format_scalar_definition("int32_t", "D32tlstride2", 0)]
+    data_str += [format_scalar_definition("int32_t", "D32tlbound3", 1)]
+    data_str += [format_scalar_definition("int32_t", "D32tlstride3", 0)]
 
-    data_str += [format_scalar_definition("int32_t", "D8slstride0", 1)]
-    data_str += [format_scalar_definition("int32_t", "D8slstride1", bankWidth / 8)]
-    data_str += [format_scalar_definition("int32_t", "D8tlbound0", kwargs["N"])]
+    # -----------------------------------------------------------
+    # streamer d8 settings
+    # -----------------------------------------------------------
+
+    # spatial settings
+    data_str += [format_scalar_definition("int32_t", "D8slstride0", bankWidth / 8)]
+    # temporal settings
+    d8_spatial_bound_0 = 8
+    data_str += [format_scalar_definition("int32_t", "D8tlbound0", quantized_output_data_width * meshRow * meshCol / snax_gemmx_serial_d8_width)]
     data_str += [
         format_scalar_definition(
-            "int32_t",
-            "D8tlstride0",
-            quantized_output_data_width * meshRow * meshCol / 8,
+            "int32_t", "D8tlstride0", d8_spatial_bound_0 * (bankWidth / 8)
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "D8tlbound1", kwargs["M"])]
+    data_str += [format_scalar_definition("int32_t", "D8tlbound1", kwargs["N"])]
     data_str += [
         format_scalar_definition(
             "int32_t",
             "D8tlstride1",
+            quantized_output_data_width * meshRow * meshCol / 8,
+        )
+    ]
+    data_str += [format_scalar_definition("int32_t", "D8tlbound2", kwargs["M"])]
+    data_str += [
+        format_scalar_definition(
+            "int32_t",
+            "D8tlstride2",
             kwargs["N"] * quantized_output_data_width * meshRow * meshCol / 8,
         )
     ]
-    data_str += [format_scalar_definition("int32_t", "D8tlbound2", 1)]
-    data_str += [format_scalar_definition("int32_t", "D8tlstride2", 0)]
+    data_str += [format_scalar_definition("int32_t", "D8tlbound3", 1)]
+    data_str += [format_scalar_definition("int32_t", "D8tlstride3", 0)]
 
+    # -----------------------------------------------------------
     delta_local_a = 0
     delta_local_b = (
         kwargs["K"] * kwargs["M"] * (meshRow * tileSize * input_data_width / 8)

--- a/target/snitch_cluster/sw/apps/snax-gemmx-matmul/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-matmul/data/datagen.py
@@ -122,7 +122,13 @@ def emit_matmul_data(**kwargs):
     c32_spatial_bound_0 = 8
     # temporal settings
     # serial input for C
-    data_str += [format_scalar_definition("int32_t", "Ctlbound0", output_data_width * meshRow * meshCol / snax_gemmx_serial_c32_d32_width)]
+    data_str += [
+        format_scalar_definition(
+            "int32_t",
+            "Ctlbound0",
+            output_data_width * meshRow * meshCol / snax_gemmx_serial_c32_d32_width,
+        )
+    ]
     data_str += [
         format_scalar_definition(
             "int32_t", "Ctlstride0", c32_spatial_bound_0 * (bankWidth / 8)
@@ -152,7 +158,13 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "D32slstride0", bankWidth / 8)]
     d32_spatial_bound_0 = 8
     # temporal settings
-    data_str += [format_scalar_definition("int32_t", "D32tlbound0", output_data_width * meshRow * meshCol / snax_gemmx_serial_c32_d32_width)]
+    data_str += [
+        format_scalar_definition(
+            "int32_t",
+            "D32tlbound0",
+            output_data_width * meshRow * meshCol / snax_gemmx_serial_c32_d32_width,
+        )
+    ]
     data_str += [
         format_scalar_definition(
             "int32_t", "D32tlstride0", d32_spatial_bound_0 * (bankWidth / 8)
@@ -183,7 +195,16 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "D8slstride0", bankWidth / 8)]
     # temporal settings
     d8_spatial_bound_0 = 8
-    data_str += [format_scalar_definition("int32_t", "D8tlbound0", quantized_output_data_width * meshRow * meshCol / snax_gemmx_serial_d8_width)]
+    data_str += [
+        format_scalar_definition(
+            "int32_t",
+            "D8tlbound0",
+            quantized_output_data_width
+            * meshRow
+            * meshCol
+            / snax_gemmx_serial_d8_width,
+        )
+    ]
     data_str += [
         format_scalar_definition(
             "int32_t", "D8tlstride0", d8_spatial_bound_0 * (bankWidth / 8)

--- a/target/snitch_cluster/sw/apps/snax-gemmx-matmul/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-matmul/data/params.hjson
@@ -11,6 +11,7 @@
   N: 1,
   M: 1,
   bypassSIMD: 1,
-  broadcast_C: 1,
+  // broadcast_C won't work in the serial C input
+  broadcast_C: 0,
   channel_en_C: 1,
 }

--- a/target/snitch_cluster/sw/apps/snax-gemmx-matmul/src/snax-gemmx-matmul.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-matmul/src/snax-gemmx-matmul.c
@@ -51,25 +51,28 @@ int main() {
     snrt_cluster_hw_barrier();
 
     int32_t Aslstride[] = {Aslstride0};
-    int32_t Atlbound[] = {Atlbound0, Atlbound1, Atlbound2, Atlbound3, Atlbound4, Atlbound5};
-    int32_t Atlstride[] = {Atlstride0, Atlstride1, Atlstride2, Atlstride3, Atlstride4, Atlstride5};
+    int32_t Atlbound[] = {Atlbound0, Atlbound1, Atlbound2,
+                          Atlbound3, Atlbound4, Atlbound5};
+    int32_t Atlstride[] = {Atlstride0, Atlstride1, Atlstride2,
+                           Atlstride3, Atlstride4, Atlstride5};
     int32_t Bslstride[] = {Bslstride0};
     int32_t Btlbound[] = {Btlbound0, Btlbound1, Btlbound2};
     int32_t Btlstride[] = {Btlstride0, Btlstride1, Btlstride2};
     int32_t D8slstride[] = {D8slstride0};
-    int32_t D8tlbound []= {D8tlbound0, D8tlbound1, D8tlbound2, D8tlbound3};
-    int32_t D8tlstride []= {D8tlstride0, D8tlstride1, D8tlstride2, D8tlstride3};
-    int32_t Cslstride []= {Cslstride0};
+    int32_t D8tlbound[] = {D8tlbound0, D8tlbound1, D8tlbound2, D8tlbound3};
+    int32_t D8tlstride[] = {D8tlstride0, D8tlstride1, D8tlstride2, D8tlstride3};
+    int32_t Cslstride[] = {Cslstride0};
     int32_t Ctlbound[] = {Ctlbound0, Ctlbound1, Ctlbound2, Ctlbound3};
     int32_t Ctlstride[] = {Ctlstride0, Ctlstride1, Ctlstride2, Ctlstride3};
     int32_t D32slstride[] = {D32slstride0};
-    int32_t D32tlbound []= {D32tlbound0, D32tlbound1, D32tlbound2, D32tlbound3};
-    int32_t D32tlstride[] = {D32tlstride0, D32tlstride1, D32tlstride2, D32tlstride3};
+    int32_t D32tlbound[] = {D32tlbound0, D32tlbound1, D32tlbound2, D32tlbound3};
+    int32_t D32tlstride[] = {D32tlstride0, D32tlstride1, D32tlstride2,
+                             D32tlstride3};
 
     if (snrt_global_core_idx() == 0) {
         // Set Streamer configuration CSR for conv2d
         set_gemmx_streamer_csr(
-            Aslstride, Atlbound, Atlstride , set_addr_remap_index_A,
+            Aslstride, Atlbound, Atlstride, set_addr_remap_index_A,
 
             Bslstride, Btlbound, Btlstride, set_addr_remap_index_B,
 

--- a/target/snitch_cluster/sw/apps/snax-gemmx-matmul/src/snax-gemmx-matmul.c
+++ b/target/snitch_cluster/sw/apps/snax-gemmx-matmul/src/snax-gemmx-matmul.c
@@ -50,24 +50,34 @@ int main() {
 
     snrt_cluster_hw_barrier();
 
+    int32_t Aslstride[] = {Aslstride0};
+    int32_t Atlbound[] = {Atlbound0, Atlbound1, Atlbound2, Atlbound3, Atlbound4, Atlbound5};
+    int32_t Atlstride[] = {Atlstride0, Atlstride1, Atlstride2, Atlstride3, Atlstride4, Atlstride5};
+    int32_t Bslstride[] = {Bslstride0};
+    int32_t Btlbound[] = {Btlbound0, Btlbound1, Btlbound2};
+    int32_t Btlstride[] = {Btlstride0, Btlstride1, Btlstride2};
+    int32_t D8slstride[] = {D8slstride0};
+    int32_t D8tlbound []= {D8tlbound0, D8tlbound1, D8tlbound2, D8tlbound3};
+    int32_t D8tlstride []= {D8tlstride0, D8tlstride1, D8tlstride2, D8tlstride3};
+    int32_t Cslstride []= {Cslstride0};
+    int32_t Ctlbound[] = {Ctlbound0, Ctlbound1, Ctlbound2, Ctlbound3};
+    int32_t Ctlstride[] = {Ctlstride0, Ctlstride1, Ctlstride2, Ctlstride3};
+    int32_t D32slstride[] = {D32slstride0};
+    int32_t D32tlbound []= {D32tlbound0, D32tlbound1, D32tlbound2, D32tlbound3};
+    int32_t D32tlstride[] = {D32tlstride0, D32tlstride1, D32tlstride2, D32tlstride3};
+
     if (snrt_global_core_idx() == 0) {
         // Set Streamer configuration CSR for conv2d
         set_gemmx_streamer_csr(
-            Aslstride0, Aslstride1, Atlbound0, Atlstride0, Atlbound1,
-            Atlstride1, Atlbound2, Atlstride2, Atlbound3, Atlstride3, Atlbound4,
-            Atlstride4, Atlbound5, Atlstride5, set_addr_remap_index_A,
+            Aslstride, Atlbound, Atlstride , set_addr_remap_index_A,
 
-            Bslstride0, Bslstride1, Btlbound0, Btlstride0, Btlbound1,
-            Btlstride1, Btlbound2, Btlstride2, set_addr_remap_index_B,
+            Bslstride, Btlbound, Btlstride, set_addr_remap_index_B,
 
-            D8slstride0, D8slstride1, D8tlbound0, D8tlstride0, D8tlbound1,
-            D8tlstride1, D8tlbound2, D8tlstride2, set_addr_remap_index_D8,
+            D8slstride, D8tlbound, D8tlstride, set_addr_remap_index_D8,
 
-            Cslstride0, Cslstride1, Ctlbound0, Ctlstride0, Ctlbound1,
-            Ctlstride1, Ctlbound2, Ctlstride2, set_addr_remap_index_C,
+            Cslstride, Ctlbound, Ctlstride, set_addr_remap_index_C,
 
-            D32slstride0, D32slstride1, D32tlbound0, D32tlstride0, D32tlbound1,
-            D32tlstride1, D32tlbound2, D32tlstride2, set_addr_remap_index_D32,
+            D32slstride, D32tlbound, D32tlstride, set_addr_remap_index_D32,
 
             delta_local_a, delta_local_b, delta_local_d8, delta_local_c,
             delta_local_d32, bypassSIMD, transposed_A, transposed_B,

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -43,38 +43,29 @@ int32_t gen_csr1_config(bool double_round_i);
 
 // Set STREAMER configuration CSR
 void set_gemmx_streamer_csr(
-    int Aslstride0, int Aslstride1, int Atlbound0, int Atlstride0,
-    int Atlbound1, int Atlstride1, int Atlbound2, int Atlstride2, int Atlbound3,
-    int Atlstride3, int Atlbound4, int Atlstride4, int Atlbound5,
-    int Atlstride5, int set_addr_remap_index_A,
+    int32_t* Aslstride, int32_t* Atlbound, int32_t* Atlstride, int32_t set_addr_remap_index_A,
 
-    int Bslstride0, int Bslstride1, int Btlbound0, int Btlstride0,
-    int Btlbound1, int Btlstride1, int Btlbound2, int Btlstride2,
-    int set_addr_remap_index_B,
+    int32_t* Bslstride, int32_t* Btlbound, int32_t* Btlstride, int32_t set_addr_remap_index_B,
 
-    int D8slstride0, int D8slstride1, int D8tlbound0, int D8tlstride0,
-    int D8tlbound1, int D8tlstride1, int D8tlbound2, int D8tlstride2,
-    int set_addr_remap_index_D8,
+    int32_t* D8slstride, int32_t* D8tlbound, int32_t* D8tlstride,
+    int32_t set_addr_remap_index_D8,
 
-    int Cslstride0, int Cslstride1, int Ctlbound0, int Ctlstride0,
-    int Ctlbound1, int Ctlstride1, int Ctlbound2, int Ctlstride2,
-    int set_addr_remap_index_C,
+    int32_t* Cslstride, int32_t* Ctlbound, int32_t* Ctlstride, int32_t set_addr_remap_index_C,
 
-    int D32slstride0, int D32slstride1, int D32tlbound0, int D32tlstride0,
-    int D32tlbound1, int D32tlstride1, int D32tlbound2, int D32tlstride2,
-    int set_addr_remap_index_D32,
+    int32_t* D32slstride, int32_t* D32tlbound, int32_t* D32tlstride,
+    int32_t set_addr_remap_index_D32,
 
-    int delta_local_a, int delta_local_b, int delta_local_d8, int delta_local_c,
-    int delta_local_d32, int bypassSIMD, int32_t transpose_A,
+    int32_t delta_local_a, int32_t delta_local_b, int32_t delta_local_d8, int32_t delta_local_c,
+    int32_t delta_local_d32, int32_t bypassSIMD, int32_t transpose_A,
     int32_t transpose_B, int32_t* channel_en_C, int32_t broadcast_C);
 
 // Set CSR to start STREAMER
 inline void set_gemmx_streamer_start() { csrw_ss(STREAMER_START_CSR, 1); }
 
 // Set GEMM configuration CSR
-void set_gemmx_csr(int tempLoop0, int tempLoop1, int tempLoop2,
-                   int subtractions, uint32_t csr0, uint32_t csr1,
-                   int* shared_bitpacked_shift, int* shared_multiplier,
+void set_gemmx_csr(int32_t tempLoop0, int32_t tempLoop1, int32_t tempLoop2,
+                   int32_t subtractions, uint32_t csr0, uint32_t csr1,
+                   int32_t* shared_bitpacked_shift, int32_t* shared_multiplier,
                    uint32_t temporal_loop_bound, uint32_t bypassSIMD);
 
 // Set CSR to start GEMM

--- a/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
+++ b/target/snitch_cluster/sw/snax/gemmx/include/snax-gemmx-lib.h
@@ -42,22 +42,28 @@ int32_t gen_csr0_config(uint8_t input_zp_i, uint8_t output_zp_i,
 int32_t gen_csr1_config(bool double_round_i);
 
 // Set STREAMER configuration CSR
-void set_gemmx_streamer_csr(
-    int32_t* Aslstride, int32_t* Atlbound, int32_t* Atlstride, int32_t set_addr_remap_index_A,
+void set_gemmx_streamer_csr(int32_t* Aslstride, int32_t* Atlbound,
+                            int32_t* Atlstride, int32_t set_addr_remap_index_A,
 
-    int32_t* Bslstride, int32_t* Btlbound, int32_t* Btlstride, int32_t set_addr_remap_index_B,
+                            int32_t* Bslstride, int32_t* Btlbound,
+                            int32_t* Btlstride, int32_t set_addr_remap_index_B,
 
-    int32_t* D8slstride, int32_t* D8tlbound, int32_t* D8tlstride,
-    int32_t set_addr_remap_index_D8,
+                            int32_t* D8slstride, int32_t* D8tlbound,
+                            int32_t* D8tlstride,
+                            int32_t set_addr_remap_index_D8,
 
-    int32_t* Cslstride, int32_t* Ctlbound, int32_t* Ctlstride, int32_t set_addr_remap_index_C,
+                            int32_t* Cslstride, int32_t* Ctlbound,
+                            int32_t* Ctlstride, int32_t set_addr_remap_index_C,
 
-    int32_t* D32slstride, int32_t* D32tlbound, int32_t* D32tlstride,
-    int32_t set_addr_remap_index_D32,
+                            int32_t* D32slstride, int32_t* D32tlbound,
+                            int32_t* D32tlstride,
+                            int32_t set_addr_remap_index_D32,
 
-    int32_t delta_local_a, int32_t delta_local_b, int32_t delta_local_d8, int32_t delta_local_c,
-    int32_t delta_local_d32, int32_t bypassSIMD, int32_t transpose_A,
-    int32_t transpose_B, int32_t* channel_en_C, int32_t broadcast_C);
+                            int32_t delta_local_a, int32_t delta_local_b,
+                            int32_t delta_local_d8, int32_t delta_local_c,
+                            int32_t delta_local_d32, int32_t bypassSIMD,
+                            int32_t transpose_A, int32_t transpose_B,
+                            int32_t* channel_en_C, int32_t broadcast_C);
 
 // Set CSR to start STREAMER
 inline void set_gemmx_streamer_start() { csrw_ss(STREAMER_START_CSR, 1); }

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -33,23 +33,28 @@ int32_t gen_csr1_config(bool double_round_i) {
 }
 
 // Set STREAMER configuration CSR
-void set_gemmx_streamer_csr(
-    int32_t* Aslstride, int32_t* Atlbound, int32_t* Atlstride, int32_t set_addr_remap_index_A,
+void set_gemmx_streamer_csr(int32_t* Aslstride, int32_t* Atlbound,
+                            int32_t* Atlstride, int32_t set_addr_remap_index_A,
 
-    int32_t* Bslstride, int32_t* Btlbound, int32_t* Btlstride, int32_t set_addr_remap_index_B,
+                            int32_t* Bslstride, int32_t* Btlbound,
+                            int32_t* Btlstride, int32_t set_addr_remap_index_B,
 
-    int32_t* D8slstride, int32_t* D8tlbound, int32_t* D8tlstride,
-    int32_t set_addr_remap_index_D8,
+                            int32_t* D8slstride, int32_t* D8tlbound,
+                            int32_t* D8tlstride,
+                            int32_t set_addr_remap_index_D8,
 
-    int32_t* Cslstride, int32_t* Ctlbound, int32_t* Ctlstride, int32_t set_addr_remap_index_C,
+                            int32_t* Cslstride, int32_t* Ctlbound,
+                            int32_t* Ctlstride, int32_t set_addr_remap_index_C,
 
-    int32_t* D32slstride, int32_t* D32tlbound, int32_t* D32tlstride,
-    int32_t set_addr_remap_index_D32,
+                            int32_t* D32slstride, int32_t* D32tlbound,
+                            int32_t* D32tlstride,
+                            int32_t set_addr_remap_index_D32,
 
-    int32_t delta_local_a, int32_t delta_local_b, int32_t delta_local_d8, int32_t delta_local_c,
-    int32_t delta_local_d32, int32_t bypassSIMD, int32_t transpose_A,
-    int32_t transpose_B, int32_t* channel_en_C, int32_t broadcast_C) {
-    
+                            int32_t delta_local_a, int32_t delta_local_b,
+                            int32_t delta_local_d8, int32_t delta_local_c,
+                            int32_t delta_local_d32, int32_t bypassSIMD,
+                            int32_t transpose_A, int32_t transpose_B,
+                            int32_t* channel_en_C, int32_t broadcast_C) {
     // ----------------------------------A-----------------------------------
     // ----------------------------------A-----------------------------------
     // ----------------------------------A-----------------------------------

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -167,6 +167,13 @@ void set_gemmx_streamer_csr(int32_t* Aslstride, int32_t* Atlbound,
     csrw_ss(ADDR_REMAP_INDEX_READER_WRITER_0, set_addr_remap_index_C);
 #endif
 
+    // set the channel enable
+#ifdef ENABLED_CHANNEL_READER_WRITER_0
+    for (int i = 0; i < ENABLED_CHANNEL_READER_WRITER_0_CSR_NUM; i++) {
+        csrw_ss(ENABLED_CHANNEL_READER_WRITER_0 + i, channel_en_C[i]);
+    }
+#endif
+
     // ----------------------------------D32-----------------------------------
     // ----------------------------------D32-----------------------------------
     // ----------------------------------D32-----------------------------------
@@ -191,7 +198,7 @@ void set_gemmx_streamer_csr(int32_t* Aslstride, int32_t* Atlbound,
     }
 
     // temporal strides for D32
-    for (int i = 0; i < T_STRIDE_BASE_READER_WRITER_1; i++) {
+    for (int i = 0; i < T_STRIDE_NUM_READER_WRITER_1; i++) {
         csrw_ss(T_STRIDE_BASE_READER_WRITER_1 + i, D32tlstride[i]);
     }
 
@@ -200,6 +207,10 @@ void set_gemmx_streamer_csr(int32_t* Aslstride, int32_t* Atlbound,
     csrw_ss(ADDR_REMAP_INDEX_READER_WRITER_1, set_addr_remap_index_D32);
 #endif
 
+    // ------------------------- datapath extension ----------------------------
+    // ------------------------- datapath extension ----------------------------
+    // ------------------------- datapath extension ----------------------------
+
     // set the transpose
 #ifdef READER_EXTENSION_0_CSR_BASE
     csrw_ss(READER_EXTENSION_0_CSR_BASE, transpose_A == 1 ? 0 : 1);
@@ -207,13 +218,6 @@ void set_gemmx_streamer_csr(int32_t* Aslstride, int32_t* Atlbound,
 
 #ifdef READER_EXTENSION_1_CSR_BASE
     csrw_ss(READER_EXTENSION_1_CSR_BASE, transpose_B == 1 ? 0 : 1);
-#endif
-
-    // set the channel enable
-#ifdef ENABLED_CHANNEL_READER_WRITER_0
-    for (int i = 0; i < ENABLED_CHANNEL_READER_WRITER_0_CSR_NUM; i++) {
-        csrw_ss(ENABLED_CHANNEL_READER_WRITER_0 + i, channel_en_C[i]);
-    }
 #endif
 
 #ifdef READER_WRITER_EXTENSION_0_CSR_BASE

--- a/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
+++ b/target/snitch_cluster/sw/snax/gemmx/src/snax-gemmx-lib.c
@@ -34,151 +34,161 @@ int32_t gen_csr1_config(bool double_round_i) {
 
 // Set STREAMER configuration CSR
 void set_gemmx_streamer_csr(
-    int Aslstride0, int Aslstride1, int Atlbound0, int Atlstride0,
-    int Atlbound1, int Atlstride1, int Atlbound2, int Atlstride2, int Atlbound3,
-    int Atlstride3, int Atlbound4, int Atlstride4, int Atlbound5,
-    int Atlstride5, int set_addr_remap_index_A,
+    int32_t* Aslstride, int32_t* Atlbound, int32_t* Atlstride, int32_t set_addr_remap_index_A,
 
-    int Bslstride0, int Bslstride1, int Btlbound0, int Btlstride0,
-    int Btlbound1, int Btlstride1, int Btlbound2, int Btlstride2,
-    int set_addr_remap_index_B,
+    int32_t* Bslstride, int32_t* Btlbound, int32_t* Btlstride, int32_t set_addr_remap_index_B,
 
-    int D8slstride0, int D8slstride1, int D8tlbound0, int D8tlstride0,
-    int D8tlbound1, int D8tlstride1, int D8tlbound2, int D8tlstride2,
-    int set_addr_remap_index_D8,
+    int32_t* D8slstride, int32_t* D8tlbound, int32_t* D8tlstride,
+    int32_t set_addr_remap_index_D8,
 
-    int Cslstride0, int Cslstride1, int Ctlbound0, int Ctlstride0,
-    int Ctlbound1, int Ctlstride1, int Ctlbound2, int Ctlstride2,
-    int set_addr_remap_index_C,
+    int32_t* Cslstride, int32_t* Ctlbound, int32_t* Ctlstride, int32_t set_addr_remap_index_C,
 
-    int D32slstride0, int D32slstride1, int D32tlbound0, int D32tlstride0,
-    int D32tlbound1, int D32tlstride1, int D32tlbound2, int D32tlstride2,
-    int set_addr_remap_index_D32,
+    int32_t* D32slstride, int32_t* D32tlbound, int32_t* D32tlstride,
+    int32_t set_addr_remap_index_D32,
 
-    int delta_local_a, int delta_local_b, int delta_local_d8, int delta_local_c,
-    int delta_local_d32, int bypassSIMD, int32_t transpose_A,
+    int32_t delta_local_a, int32_t delta_local_b, int32_t delta_local_d8, int32_t delta_local_c,
+    int32_t delta_local_d32, int32_t bypassSIMD, int32_t transpose_A,
     int32_t transpose_B, int32_t* channel_en_C, int32_t broadcast_C) {
+    
+    // ----------------------------------A-----------------------------------
+    // ----------------------------------A-----------------------------------
+    // ----------------------------------A-----------------------------------
     // base ptr for A
     csrw_ss(BASE_PTR_READER_0_LOW, (uint32_t)(delta_local_a + snrt_l1_next()));
 
     // spatial strides for A
-    csrw_ss(S_STRIDE_READER_0_0, Aslstride1);
+    for (int i = 0; i < S_STRIDE_NUM_READER_0; i++) {
+        csrw_ss(S_STRIDE_BASE_READER_0 + i, Aslstride[i]);
+    }
 
     // loop bounds, from innermost to outermost, for data mover A
-    csrw_ss(T_BOUND_READER_0_0, Atlbound0);
-    csrw_ss(T_BOUND_READER_0_1, Atlbound1);
-    csrw_ss(T_BOUND_READER_0_2, Atlbound2);
-    csrw_ss(T_BOUND_READER_0_3, Atlbound3);
-    csrw_ss(T_BOUND_READER_0_4, Atlbound4);
-    csrw_ss(T_BOUND_READER_0_5, Atlbound5);
+    for (int i = 0; i < T_BOUND_NUM_READER_0; i++) {
+        csrw_ss(T_BOUND_BASE_READER_0 + i, Atlbound[i]);
+    }
 
     // temporal strides for A
-    csrw_ss(T_STRIDE_READER_0_0, Atlstride0);
-    csrw_ss(T_STRIDE_READER_0_1, Atlstride1);
-    csrw_ss(T_STRIDE_READER_0_2, Atlstride2);
-    csrw_ss(T_STRIDE_READER_0_3, Atlstride3);
-    csrw_ss(T_STRIDE_READER_0_4, Atlstride4);
-    csrw_ss(T_STRIDE_READER_0_5, Atlstride5);
+    for (int i = 0; i < T_STRIDE_NUM_READER_0; i++) {
+        csrw_ss(T_STRIDE_BASE_READER_0 + i, Atlstride[i]);
+    }
 
     // set the address remap index for A
 #ifdef ADDR_REMAP_INDEX_READER_0
     csrw_ss(ADDR_REMAP_INDEX_READER_0, set_addr_remap_index_A);
 #endif
 
+    // ----------------------------------B-----------------------------------
+    // ----------------------------------B-----------------------------------
+    // ----------------------------------B-----------------------------------
+
     // base ptr for B
     csrw_ss(BASE_PTR_READER_1_LOW, (uint32_t)(delta_local_b + snrt_l1_next()));
 
     // spatial strides for B
-    csrw_ss(S_STRIDE_READER_1_0, Bslstride1);
+    for (int i = 0; i < S_STRIDE_NUM_READER_1; i++) {
+        csrw_ss(S_STRIDE_BASE_READER_1 + i, Bslstride[i]);
+    }
 
     // loop bounds, from innermost to outermost, for data mover B
-    csrw_ss(T_BOUND_READER_1_0, Btlbound0);
-    csrw_ss(T_BOUND_READER_1_1, Btlbound1);
-    csrw_ss(T_BOUND_READER_1_2, Btlbound2);
+    for (int i = 0; i < T_BOUND_NUM_READER_1; i++) {
+        csrw_ss(T_BOUND_BASE_READER_1 + i, Btlbound[i]);
+    }
 
     // temporal strides for B
-    csrw_ss(T_STRIDE_READER_1_0, Btlstride0);
-    csrw_ss(T_STRIDE_READER_1_1, Btlstride1);
-    csrw_ss(T_STRIDE_READER_1_2, Btlstride2);
+    for (int i = 0; i < T_STRIDE_NUM_READER_1; i++) {
+        csrw_ss(T_STRIDE_BASE_READER_1 + i, Btlstride[i]);
+    }
 
     // set the address remap index for B
 #ifdef ADDR_REMAP_INDEX_READER_1
     csrw_ss(ADDR_REMAP_INDEX_READER_1, set_addr_remap_index_B);
 #endif
 
+    // ----------------------------------D8-----------------------------------
+    // ----------------------------------D8-----------------------------------
+    // ----------------------------------D8-----------------------------------
     // base ptr for D8
     csrw_ss(BASE_PTR_WRITER_0_LOW, (uint32_t)(delta_local_d8 + snrt_l1_next()));
 
     // spatial strides for D8
-    csrw_ss(S_STRIDE_WRITER_0_0, D8slstride1);
+    for (int i = 0; i < S_STRIDE_NUM_WRITER_0; i++) {
+        csrw_ss(S_STRIDE_BASE_WRITER_0 + i, D8slstride[i]);
+    }
 
     // for D8, from N to M
-    if (bypassSIMD == 0) {
-        csrw_ss(T_BOUND_WRITER_0_0, D8tlbound0);
-        csrw_ss(T_BOUND_WRITER_0_1, D8tlbound1);
-        csrw_ss(T_BOUND_WRITER_0_2, D8tlbound2);
+    if (bypassSIMD == 1) {
+        for (int i = 0; i < T_BOUND_NUM_WRITER_0; i++) {
+            csrw_ss(T_BOUND_BASE_WRITER_0 + i, 0);
+        }
     } else {
-        csrw_ss(T_BOUND_WRITER_0_0, 0);
-        csrw_ss(T_BOUND_WRITER_0_1, 0);
-        csrw_ss(T_BOUND_WRITER_0_2, 0);
+        for (int i = 0; i < T_BOUND_NUM_WRITER_0; i++) {
+            csrw_ss(T_BOUND_BASE_WRITER_0 + i, D8tlbound[i]);
+        }
     }
 
     // temporal strides for D8
-    csrw_ss(T_STRIDE_WRITER_0_0, D8tlstride0);
-    csrw_ss(T_STRIDE_WRITER_0_1, D8tlstride1);
-    csrw_ss(T_STRIDE_WRITER_0_2, D8tlstride2);
+    for (int i = 0; i < T_STRIDE_NUM_WRITER_0; i++) {
+        csrw_ss(T_STRIDE_BASE_WRITER_0 + i, D8tlstride[i]);
+    }
 
     // set the address remap index for D8
 #ifdef ADDR_REMAP_INDEX_WRITER_0
     csrw_ss(ADDR_REMAP_INDEX_WRITER_0, set_addr_remap_index_D8);
 #endif
 
+    // ----------------------------------C-----------------------------------
+    // ----------------------------------C-----------------------------------
+    // ----------------------------------C-----------------------------------
     // base ptr for C
     csrw_ss(BASE_PTR_READER_WRITER_0_LOW,
             (uint32_t)(delta_local_c + snrt_l1_next()));
 
     // spatial strides for C
-    csrw_ss(S_STRIDE_READER_WRITER_0_0, Cslstride0);
-    csrw_ss(S_STRIDE_READER_WRITER_0_1, Cslstride1);
+    for (int i = 0; i < S_STRIDE_NUM_READER_WRITER_0; i++) {
+        csrw_ss(S_STRIDE_BASE_READER_WRITER_0 + i, Cslstride[i]);
+    }
 
     // loop bounds, from innermost to outermost, for data mover C
-    csrw_ss(T_BOUND_READER_WRITER_0_0, Ctlbound0);
-    csrw_ss(T_BOUND_READER_WRITER_0_1, Ctlbound1);
-    csrw_ss(T_BOUND_READER_WRITER_0_2, Ctlbound2);
+    for (int i = 0; i < T_BOUND_NUM_READER_WRITER_0; i++) {
+        csrw_ss(T_BOUND_BASE_READER_WRITER_0 + i, Ctlbound[i]);
+    }
 
     // temporal strides for C
-    csrw_ss(T_STRIDE_READER_WRITER_0_0, Ctlstride0);
-    csrw_ss(T_STRIDE_READER_WRITER_0_1, Ctlstride1);
-    csrw_ss(T_STRIDE_READER_WRITER_0_2, Ctlstride2);
+    for (int i = 0; i < T_STRIDE_NUM_READER_WRITER_0; i++) {
+        csrw_ss(T_STRIDE_BASE_READER_WRITER_0 + i, Ctlstride[i]);
+    }
 
     // set the address remap index for C
 #ifdef ADDR_REMAP_INDEX_READER_WRITER_0
     csrw_ss(ADDR_REMAP_INDEX_READER_WRITER_0, set_addr_remap_index_C);
 #endif
 
+    // ----------------------------------D32-----------------------------------
+    // ----------------------------------D32-----------------------------------
+    // ----------------------------------D32-----------------------------------
     // base ptr for D32
     csrw_ss(BASE_PTR_READER_WRITER_1_LOW,
             (uint32_t)(delta_local_d32 + snrt_l1_next()));
 
     // spatial strides for D32
-    csrw_ss(S_STRIDE_READER_WRITER_1_0, D32slstride0);
-    csrw_ss(S_STRIDE_READER_WRITER_1_1, D32slstride1);
+    for (int i = 0; i < S_STRIDE_NUM_READER_WRITER_1; i++) {
+        csrw_ss(S_STRIDE_BASE_READER_WRITER_1 + i, D32slstride[i]);
+    }
 
     // for D32, from N to M
     if (bypassSIMD == 0) {
-        csrw_ss(T_BOUND_READER_WRITER_1_0, 0);
-        csrw_ss(T_BOUND_READER_WRITER_1_1, 0);
-        csrw_ss(T_BOUND_READER_WRITER_1_2, 0);
+        for (int i = 0; i < T_BOUND_NUM_READER_WRITER_1; i++) {
+            csrw_ss(T_BOUND_BASE_READER_WRITER_1 + i, 0);
+        }
     } else {
-        csrw_ss(T_BOUND_READER_WRITER_1_0, D32tlbound0);
-        csrw_ss(T_BOUND_READER_WRITER_1_1, D32tlbound1);
-        csrw_ss(T_BOUND_READER_WRITER_1_2, D32tlbound2);
+        for (int i = 0; i < T_BOUND_NUM_READER_WRITER_1; i++) {
+            csrw_ss(T_BOUND_BASE_READER_WRITER_1 + i, D32tlbound[i]);
+        }
     }
 
     // temporal strides for D32
-    csrw_ss(T_STRIDE_READER_WRITER_1_0, D32tlstride0);
-    csrw_ss(T_STRIDE_READER_WRITER_1_1, D32tlstride1);
-    csrw_ss(T_STRIDE_READER_WRITER_1_2, D32tlstride2);
+    for (int i = 0; i < T_STRIDE_BASE_READER_WRITER_1; i++) {
+        csrw_ss(T_STRIDE_BASE_READER_WRITER_1 + i, D32tlstride[i]);
+    }
 
     // set the address remap index for D32
 #ifdef ADDR_REMAP_INDEX_READER_WRITER_1
@@ -207,9 +217,9 @@ void set_gemmx_streamer_csr(
 }
 
 // Set GEMM configuration CSR
-void set_gemmx_csr(int tempLoop0, int tempLoop1, int tempLoop2,
-                   int subtractions, uint32_t csr0, uint32_t csr1,
-                   int* shared_bitpacked_shift, int* shared_multiplier,
+void set_gemmx_csr(int32_t tempLoop0, int32_t tempLoop1, int32_t tempLoop2,
+                   int32_t subtractions, uint32_t csr0, uint32_t csr1,
+                   int32_t* shared_bitpacked_shift, int32_t* shared_multiplier,
                    uint32_t temporal_loop_bound, uint32_t bypassSIMD) {
     // set loop bounds, from innermost to outermost, aka from K to N to M
     csrw_ss(T_BOUND_K, tempLoop0);
@@ -281,6 +291,8 @@ uint32_t check_gemmx_result_D8(int8_t* output, int8_t* output_golden,
         for (int i = 0; i < size; i++) {
             if (output[i] != output_golden[i]) {
                 err++;
+                printf("output[%d] = %d, output_golden[%d] = %d\n", i,
+                       output[i], i, output_golden[i]);
             }
         }
     }
@@ -308,6 +320,8 @@ uint32_t check_gemmx_result_D32(int32_t* output, int32_t* output_golden,
         for (int i = 0; i < size; i++) {
             if (output[i] != output_golden[i]) {
                 err++;
+                printf("output[%d] = %d, output_golden[%d] = %d\n", i,
+                       output[i], i, output_golden[i]);
             }
         }
     }


### PR DESCRIPTION
Reduce the output ports of the GeMM array by adding a serial-parallel converter in between the array and the streamer. More specifically, we
* add the serial-parallel converter, currently the tcdm ports are fixed to 8 for both D32, C32 and D8 GeMM ports
* insert the converters inside GeMM and modify the GeMM wrapper interface data width
* modify the cfg files for both 2D and 3D array
* modify the test software for narrower streamer ports, change some spatial loops to temporal loops
* refactor the runtime library and streamer C header file gen for a more flexible temporal/spatial loop number
* with these modifications, the test won't work for the original KUL cluster (wide spatial loops).