### PR TITLE
Fatality

### DIFF
--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2320,6 +2320,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     if (!rst_i && illegal_inst && valid_instr) begin
       $display("[Illegal Instruction Core %0d] PC: %h Data: %h",
                                 hart_id_i, inst_addr_o, inst_data_i);
+      $finish;
     end
   end
   // pragma translate_on

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2320,7 +2320,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     if (!rst_i && illegal_inst && valid_instr) begin
       $display("[Illegal Instruction Core %0d] PC: %h Data: %h",
                                 hart_id_i, inst_addr_o, inst_data_i);
-      $finish;
+      $fatal();
     end
   end
   // pragma translate_on


### PR DESCRIPTION
Hi, right now, the simulation goes _loco_ when an illegal instruction is encountered.
In any case I can think of, you would want the simulation to end at this point, but now the simulation just goes on indefinitely and spams the screen full of  `illegal instruction you naughty programmer`
This PR adds a simple yet effective trick to fully kill a simulation that is running, by using a trick from mortal combat called [`$fatal`](https://en.wikipedia.org/wiki/Fatality_(Mortal_Kombat)) (I tried with `$finish`, which stops the spamming of illegal instruction, but does not fully stop the simulation) 
```
(snax_cluster) ❯ target/snitch_cluster/bin/snitch_cluster.vlt ../praxis/kernels/streamer_matmul/quantized_matmul_256_256_256_cfg1.x
[fesvr] Wrote 36 bytes of bootrom to 0x1000
[fesvr] Wrote entry point 0x80000000 to bootloader slot 0x1020
[fesvr] Wrote 72 bytes of bootdata to 0x1024
[Tracer] Logging Hart          0 to logs/trace_chip_00_hart_00000.dasm
[Tracer] Logging Hart          1 to logs/trace_chip_00_hart_00001.dasm
[Illegal Instruction Core 0] PC: 000080000984 Data: 00000000
[7952000] %Fatal: snitch.sv:2323: Assertion failed in TOP.testharness.i_snax_KUL_cluster.i_cluster.gen_core[0].i_snitch_cc.i_snitch
%Error: /home/josse/phd/snax_cluster/hw/snitch/src/snitch.sv:2323: Verilog $stop
Aborting...
```
