### PR TITLE
Pass snax_gemmx_serial_c32_d32_width and snax_gemmx_serial_d8_width to ParallelSerialConverter

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
@@ -195,9 +195,9 @@ object BlockGemmRescaleSIMDGen {
           case Array(key, value) if key.startsWith("--") => key.drop(2) -> value
         }
         .toMap
-      if (parsed_args.size != 4) {
+      if (parsed_args.size != 6) {
         throw new Exception(
-          "Please provide the meshRow, meshCol, tileSize, and withPipeline. Example usage: sbt 'runMain snax_acc.gemmx.BlockGemmRescaleSIMDGen --meshRow 2 --meshCol 2 --tileSize 16 --withPipeline true'"
+          "Please provide the meshRow, meshCol, tileSize, serialC32D32Width, serialD8Width, and withPipeline. Example usage: sbt 'runMain snax_acc.gemmx.BlockGemmRescaleSIMDGen --meshRow 2 --meshCol 2 --tileSize 16 --serialC32D32Width --serialD8Width --withPipeline true'"
         )
       }
       parsed_args
@@ -210,6 +210,8 @@ object BlockGemmRescaleSIMDGen {
     val meshRow = argMap("meshRow").toInt
     val meshCol = argMap("meshCol").toInt
     val tileSize = argMap("tileSize").toInt
+    val serialC32D32Width = argMap("serialC32D32Width").toInt
+    val serialD8Width = argMap("serialD8Width").toInt
 
     // set the parameters for the gemm module
     // other parameters are set to default values
@@ -248,7 +250,9 @@ object BlockGemmRescaleSIMDGen {
       (if (withPipeline == true)
          snax_acc.simd.PipelinedConfig.rescaleSIMDConfig
        else SIMDParamsWithoutPipeline),
-      withPipeline
+      withPipeline,
+      C32_D32_width = serialC32D32Width,
+      D8_width = serialD8Width
     )
 
     emitVerilog(

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -130,6 +130,8 @@
             snax_gemmx_mesh_row: 8,
             snax_gemmx_tile_size: 8,
             snax_gemmx_mesh_col: 8,
+            snax_gemmx_serial_c32_d32_width: 2048,
+            snax_gemmx_serial_d8_width: 512,
             with_pipeline: true,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -561,7 +561,8 @@ def main():
                 raise ValueError(
                     "Missing gemmX configuration. \n"
                     "Please set snax_gemmx_mesh_row, snax_gemmx_mesh_col, "
-                    "snax_gemmx_tile_size, snax_gemmx_serial_c32_d32_width, snax_gemmx_serial_d8_width, with_pipeline"
+                    "snax_gemmx_tile_size, snax_gemmx_serial_c32_d32_width, "
+                    "snax_gemmx_serial_d8_width, with_pipeline"
                 )
             gen_chisel_file(
                 chisel_path=chisel_acc_path,

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -554,12 +554,14 @@ def main():
                 "snax_gemmx_tile_size" in acc_cfgs[i]
                 and "snax_gemmx_mesh_row" in acc_cfgs[i]
                 and "snax_gemmx_mesh_col" in acc_cfgs[i]
+                and "snax_gemmx_serial_c32_d32_width" in acc_cfgs[i]
+                and "snax_gemmx_serial_d8_width" in acc_cfgs[i]
                 and "with_pipeline" in acc_cfgs[i]
             ):
                 raise ValueError(
                     "Missing gemmX configuration. \n"
                     "Please set snax_gemmx_mesh_row, snax_gemmx_mesh_col, "
-                    "snax_gemmx_tile_size, with_pipeline"
+                    "snax_gemmx_tile_size, snax_gemmx_serial_c32_d32_width, snax_gemmx_serial_d8_width, with_pipeline"
                 )
             gen_chisel_file(
                 chisel_path=chisel_acc_path,
@@ -570,6 +572,10 @@ def main():
                 + str(acc_cfgs[i]["snax_gemmx_mesh_col"])
                 + " --tileSize "
                 + str(acc_cfgs[i]["snax_gemmx_tile_size"])
+                + " --serialC32D32Width "
+                + str(acc_cfgs[i]["snax_gemmx_serial_c32_d32_width"])
+                + " --serialD8Width "
+                + str(acc_cfgs[i]["snax_gemmx_serial_d8_width"])
                 + " --withPipeline "
                 + str(acc_cfgs[i]["with_pipeline"]),
                 gen_path=rtl_target_path,


### PR DESCRIPTION
This PR 
* passes the parameters snax_gemmx_serial_c32_d32_width and snax_gemmx_serial_d8_width to ParallelSerialConverter. For snax_gemmx_serial_c32_d32_width/snax_gemmx_serial_d8_width  == the actual parallel port width, there is no converter set in between instead, we directly connect the input and output.
* set snax_gemmx_serial_c32_d32_width = 2048, snax_gemmx_serial_d8_width = 512 in snax_KUL_cluster.hjson