### PR TITLE
Add BlockGemm and GemmArray tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ gmon.out
 /docs/generated/
 
 # Generated files
+test_run_dir
 target/streams/
 target/scala*
-hw/chisel_acc/src/snax_streamer_gemmX_shell_wrapper.sv

--- a/hw/chisel/.gitignore
+++ b/hw/chisel/.gitignore
@@ -1,13 +1,10 @@
-generated
 project/*
 !project/plugins.sbt
 !project/build.properties
+generated
 target
-test_run_dir
-.bsp
-.scala-build
 out
-.bloop
-.metals
+
+# Files
 src/main/scala/snax/csr_manager/CsrManParamGen.scala
 src/main/scala/snax/streamer/StreamParamGen.scala

--- a/hw/chisel_acc/.gitignore
+++ b/hw/chisel_acc/.gitignore
@@ -1,4 +1,9 @@
-generated/
-project/
-target/
-out/
+project/*
+!project/plugins.sbt
+!project/build.properties
+generated
+target
+out
+
+# Files
+src/snax_streamer_gemmX_shell_wrapper.sv

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm/Parameter.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm/Parameter.scala
@@ -14,22 +14,44 @@ case class GemmParams(
   sizeConfigWidth:     Int
 )
 
+trait HasGemmParams {
+  val params: GemmParams
+  // Unpack
+  lazy val dataWidthA          = params.dataWidthA
+  lazy val dataWidthB          = params.dataWidthB
+  lazy val dataWidthMul        = params.dataWidthMul
+  lazy val dataWidthC          = params.dataWidthC
+  lazy val dataWidthAccum      = params.dataWidthAccum
+  lazy val subtractionCfgWidth = params.subtractionCfgWidth
+  lazy val meshRow             = params.meshRow
+  lazy val tileSize            = params.tileSize
+  lazy val meshCol             = params.meshCol
+  lazy val addrWidth           = params.addrWidth
+  lazy val sizeConfigWidth     = params.sizeConfigWidth
+
+  // Compute
+  val a_bits_len  = meshRow * tileSize * dataWidthA
+  val b_bits_len  = tileSize * meshCol * dataWidthB
+  val sa_bits_len = dataWidthA
+  val sb_bits_len = dataWidthB
+}
+
 object GemmConstant {
 
-  def dataWidthA     = 8
-  def dataWidthB     = dataWidthA
-  def dataWidthMul   = dataWidthA * 4
-  def dataWidthC     = dataWidthA * 4
-  def dataWidthAccum = dataWidthA * 4
+  lazy val dataWidthA     = 8
+  lazy val dataWidthB     = dataWidthA
+  lazy val dataWidthMul   = dataWidthA * 4
+  lazy val dataWidthC     = dataWidthA * 4
+  lazy val dataWidthAccum = dataWidthA * 4
 
-  def subtractionCfgWidth = 32
+  lazy val subtractionCfgWidth = 16 // was 32, but why?
 
-  def meshRow  = 8
-  def tileSize = 8
-  def meshCol  = 8
+  lazy val meshRow  = 8
+  lazy val tileSize = 8
+  lazy val meshCol  = 8
 
-  def addrWidth       = 32
-  def sizeConfigWidth = 32
+  lazy val addrWidth       = 32
+  lazy val sizeConfigWidth = 32
 
 }
 

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm_simd/BlockGemmRescaleSIMD.scala
@@ -67,7 +67,6 @@ class BlockGemmRescaleSIMD(params: BlockGemmRescaleSIMDParams) extends Module wi
       Module(new PipelinedRescaleSIMD(params.rescaleSIMDParams))
     case false =>
       Module(new RescaleSIMD(params.rescaleSIMDParams))
-    case _     => throw new Exception("Unknown SIMD configuration")
   }
 
   // C32 serial to parallel converter

--- a/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/MaxPoolingPE.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/reshuffle/MaxPoolingPE.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.util._
 
 // control signals for the basic processing element, related to the pooling algorithm
-class MAXPoolPECtrlIO(params: ReshufflerParams) extends Bundle {
+class MAXPoolPECtrlIO() extends Bundle {
 
   val init_i = Input(Bool())
 
@@ -21,7 +21,7 @@ class MAXPoolPEDataIO(params: ReshufflerParams) extends Bundle {
 // processing element input and output declaration
 class MAXPoolPEIO(params: ReshufflerParams) extends Bundle {
 
-  val ctrl = new MAXPoolPECtrlIO(params)
+  val ctrl = new MAXPoolPECtrlIO()
   val data = new MAXPoolPEDataIO(params)
 
 }

--- a/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmDelayedWrapper.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmDelayedWrapper.scala
@@ -14,6 +14,6 @@ class BlockGemmDelayedWrapper(val params: GemmParams) extends Module with Requir
 
   io <> blockGemm.io
   io.data.a_i -||> blockGemm.io.data.a_i
-  io.data.b_i -|> blockGemm.io.data.b_i
+  io.data.b_i -||> blockGemm.io.data.b_i
 
 }

--- a/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmDelayedWrapper.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmDelayedWrapper.scala
@@ -13,7 +13,7 @@ class BlockGemmDelayedWrapper(val params: GemmParams) extends Module with Requir
   val blockGemm = Module(new BlockGemm(params))
 
   io <> blockGemm.io
-  io.data.a_i -|> blockGemm.io.data.a_i
+  io.data.a_i -||> blockGemm.io.data.a_i
   io.data.b_i -|> blockGemm.io.data.b_i
 
 }

--- a/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmDelayedWrapper.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmDelayedWrapper.scala
@@ -1,0 +1,19 @@
+package snax_acc.gemm
+
+import chisel3._
+
+import snax_acc.utils.DecoupledCut._
+
+/** In BlockGemm, c_i.ready depends on a_i.valid and b_i.valid, making it impossible to drive A and C concurrently. This
+  * wrapper delays the a_i and b_i signals to break the combinatorial loop.
+  */
+class BlockGemmDelayedWrapper(val params: GemmParams) extends Module with RequireAsyncReset {
+
+  val io        = IO(new BlockGemmIO(params))
+  val blockGemm = Module(new BlockGemm(params))
+
+  io <> blockGemm.io
+  io.data.a_i -|> blockGemm.io.data.a_i
+  io.data.b_i -|> blockGemm.io.data.b_i
+
+}

--- a/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmTest.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/gemm/BlockGemmTest.scala
@@ -1,0 +1,150 @@
+package snax_acc.gemm
+
+import chisel3._
+
+import chiseltest._
+import chiseltest.internal.TesterThreadList
+import org.scalatest.flatspec.AnyFlatSpec
+import snax_acc.utils.MatrixLibBase.CheckResults
+import snax_acc.utils.MatrixLibBlock._
+
+/** A trait with basic gemm test function to be used in different test */
+trait AbstractBlockGemmTest {
+
+  /** Step the clock until the given signal asserts, or stop after timeout
+    * @param signal
+    *   Signal to wait for until it is asserted
+    * @param timeout
+    *   Assert after this number of cycles
+    */
+  def WaitOrTimeout(signalToAssert: Bool, clock: Clock, timeout: Int = 100) = {
+    var waitCnt = 0
+    while (!signalToAssert.peekBoolean()) {
+      if (waitCnt > timeout) {
+        println(s"Timeout at cycle ${clock.getStepCount} for signal ${signalToAssert}")
+        assert(false)
+      }
+      clock.step(1)
+      waitCnt += 1
+    }
+  }
+
+  /** Block gemm test generation function */
+  def BlockGemmRandomTest[T <: BlockGemmDelayedWrapper](dut: T, size_M: Int, size_K: Int, size_N: Int) = {
+    val params = dut.params
+
+    // Randomly generation of input matrices
+    val (matrix_A, matrix_B, matrix_C) = GenBlockMatrices(size_M, size_K, size_N, dut.params)
+
+    // Convert the sub-matrices to a big bus
+    val (split_matrix_A, split_matrix_B, split_matrix_C) =
+      SplitBlockMatrix(size_M, size_K, size_N, matrix_A, matrix_B, matrix_C, params)
+
+    // Outputs
+    val golden_array   = BlockMatrixMul_1D(size_M, size_K, size_N, matrix_A, matrix_B, matrix_C, params)
+    val split_matrix_D = Array.ofDim[BigInt](size_M * size_N)
+
+    // Set up configuration
+    dut.clock.step(5)
+    dut.io.ctrl.bits.K_i.poke(size_K)
+    dut.io.ctrl.bits.N_i.poke(size_N)
+    dut.io.ctrl.bits.M_i.poke(size_M)
+    dut.io.ctrl.bits.subtraction_constant_i.poke(0.U)
+    dut.io.ctrl.valid.poke(true.B)
+
+    WaitOrTimeout(dut.io.ctrl.ready, dut.clock)
+    dut.clock.step(1)
+    dut.io.ctrl.valid.poke(false.B)
+
+    // Always ready to accept output data. This must happen before the concurrent threads because the data_in.ready
+    // signal is combinatorially connected to this signal
+    dut.io.data.d_o.ready.poke(true.B)
+
+    var concurrent_threads = new TesterThreadList(Seq())
+
+    // A, B Input injector
+    concurrent_threads = concurrent_threads.fork {
+
+      // dut.clock.step(Random.between(1, 16))
+      for (temporalIndexInput <- 0 until size_M * size_N * size_K) {
+        val (indexA, indexB) = temporalToSpatialIndicesAB(temporalIndexInput, K = size_K, N = size_N)
+        // A, B
+        dut.io.data.a_i.bits.poke(split_matrix_A(indexA))
+        dut.io.data.b_i.bits.poke(split_matrix_B(indexB))
+        dut.io.data.a_i.valid.poke(true.B)
+        dut.io.data.b_i.valid.poke(true.B)
+        WaitOrTimeout(dut.io.data.a_i.ready, dut.clock)
+        assert(dut.io.data.b_i.ready.peekBoolean() && dut.io.data.b_i.ready.peekBoolean())
+
+        dut.clock.step(1) // Valid needs to be asserted for >=1 cycle
+
+        dut.io.data.a_i.valid.poke(false.B)
+        dut.io.data.b_i.valid.poke(false.B)
+      }
+    }
+
+    // C injector
+    concurrent_threads = concurrent_threads.fork {
+
+      // dut.clock.step(Random.between(1, 16))
+      for (temporalIndex <- 0 until size_M * size_N) {
+        val indexC = temporalToSpatialIndexD(temporalIndex, M = size_M, N = size_N)
+
+        dut.io.data.c_i.bits.poke(split_matrix_C(indexC))
+        dut.io.data.c_i.valid.poke(true.B)
+        WaitOrTimeout(dut.io.data.c_i.ready, dut.clock)
+
+        dut.clock.step(1) // Valid needs to be asserted for >=1 cycle
+
+        dut.io.data.c_i.valid.poke(false.B)
+      }
+    }
+
+    // Output checker
+    concurrent_threads = concurrent_threads.fork {
+      for (outputTemporalIndex <- 0 until size_M * size_N) {
+        WaitOrTimeout(dut.io.data.d_o.valid, dut.clock)
+        // println(s"Received output tile $outputTemporalIndex at cycle ${dut.clock.getStepCount}")
+        val result = dut.io.data.d_o.bits.peekInt()
+        val indexD = temporalToSpatialIndexD(outputTemporalIndex, M = size_M, N = size_N)
+        split_matrix_D(indexD) = result
+        dut.clock.step(1)
+      }
+    }
+
+    concurrent_threads.joinAndStep()
+
+    // Compare the output data with the golden model
+    CheckResults(split_matrix_D, golden_array)
+    println(s"Test passed for M = $size_M, K = $size_K, N = $size_N")
+  }
+
+}
+
+/** Random size of input matrices and Integer 8 data test and check with the results of Block Gemm with golden model */
+class BlockGemmTest extends AnyFlatSpec with ChiselScalatestTester with AbstractBlockGemmTest {
+  "BlockGemm" should "work in corner case configurations" in {
+    test(new BlockGemmDelayedWrapper(TestParameters.testConfig))
+      .withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+        dut.clock.step(5)
+        BlockGemmRandomTest(dut, 1, 1, 1)
+        BlockGemmRandomTest(dut, 1, 2, 1)
+        BlockGemmRandomTest(dut, 1, 1, 4)
+        BlockGemmRandomTest(dut, 4, 1, 1)
+        BlockGemmRandomTest(dut, 2, 2, 2)
+      }
+  }
+
+  "BlockGemm" should "correctly compute randomly sized matrices" in {
+    test(new BlockGemmDelayedWrapper(DefaultConfig.gemmConfig)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+      val nbTests = 10
+      for (_ <- 0 until nbTests) {
+        // Randomly generate the size of the input matrices
+        val (size_M, size_K, size_N) = GenRandSizeTest()
+        BlockGemmRandomTest(dut, size_M, size_K, size_N)
+      }
+
+    }
+  }
+
+}

--- a/hw/chisel_acc/src/test/scala/snax_acc/gemm/GemmArrayTest.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/gemm/GemmArrayTest.scala
@@ -1,0 +1,77 @@
+package snax_acc.gemm
+
+import chisel3._
+
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import snax_acc.utils.MatrixLibBase._
+
+class GemmArrayTest extends AnyFlatSpec with ChiselScalatestTester {
+
+  // Random Integer 8 data test and check with the results of Gemm with golden model
+  // TODO Add C is not tested
+  "GemmArray" should "correctly compute INT8 GeMM" in {
+    test(new GemmArray(TestParameters.testConfig)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+
+      val meshRow  = dut.params.meshRow
+      val tileSize = dut.params.tileSize
+      val meshCol  = dut.params.meshCol
+
+      /** Generate Random Integer 8 data (from -128 to 127) */
+      def RandomTest() = {
+        val random_matrix_A                = GenRandomMatrix(meshRow, tileSize)
+        val random_matrix_B                = GenRandomMatrix(tileSize, meshCol)
+        val (subtraction_a, subtraction_b) = GenRandomSubtractionValue()
+
+        // Generate golden result data for verification
+        val goldenMatrix   =
+          MatrixMul_1D(
+            meshRow,
+            tileSize,
+            meshCol,
+            random_matrix_A,
+            random_matrix_B,
+            subtraction_a,
+            subtraction_b
+          )
+        val goldenBus      = MatrixArray2BigBus(meshRow, meshCol, goldenMatrix, dut.params.dataWidthAccum)
+        // Translate data array to big bus for Gemm module input
+        val RandomBigBus_A = MatrixArray2BigBus(meshRow, tileSize, random_matrix_A, dut.params.dataWidthA)
+        val RandomBigBus_B = MatrixArray2BigBus(tileSize, meshCol, random_matrix_B, dut.params.dataWidthB)
+
+        // Inputs to start computation
+        dut.io.data.c_i.poke(0.U)
+        dut.io.ctrl.dotprod_a_b.poke(1.U)
+        dut.io.ctrl.add_c_i.poke(1.U)
+        dut.io.ctrl.d_ready_i.poke(false.B)
+
+        dut.io.ctrl.subtraction_a_i.poke(subtraction_a)
+        dut.io.ctrl.subtraction_b_i.poke(subtraction_b)
+        dut.io.data.a_i.poke(RandomBigBus_A)
+        dut.io.data.b_i.poke(RandomBigBus_B)
+
+        dut.clock.step(1)
+        dut.io.ctrl.dotprod_a_b.poke(0.U)
+        dut.io.ctrl.add_c_i.poke(0.U)
+
+        // Wait for data_valid_o assert, then take the result
+        while (!dut.io.ctrl.d_valid_o.peekBoolean()) dut.clock.step(1)
+
+        val results = dut.io.data.d_o.peekInt()
+        dut.io.ctrl.d_ready_i.poke(true.B)
+        dut.clock.step(1)
+        dut.io.ctrl.d_ready_i.poke(true.B)
+
+        CheckResults(Array(results), Array(goldenBus))
+
+        dut.clock.step(10)
+      }
+
+      dut.clock.step(1)
+      val TestLoop = 3
+
+      for (_ <- 0 until TestLoop) RandomTest()
+
+    }
+  }
+}

--- a/hw/chisel_acc/src/test/scala/snax_acc/gemm/TestParameters.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/gemm/TestParameters.scala
@@ -1,0 +1,23 @@
+package snax_acc.gemm
+
+object TestParameters {
+
+  lazy val MatrixLibBlock_random_M_range = 10
+  lazy val MatrixLibBlock_random_K_range = 10
+  lazy val MatrixLibBlock_random_N_range = 10
+
+  val testConfig = new GemmParams(
+    dataWidthA          = GemmConstant.dataWidthA,
+    dataWidthB          = GemmConstant.dataWidthB,
+    dataWidthMul        = GemmConstant.dataWidthMul,
+    dataWidthC          = GemmConstant.dataWidthC,
+    dataWidthAccum      = GemmConstant.dataWidthAccum,
+    subtractionCfgWidth = GemmConstant.subtractionCfgWidth,
+    meshRow             = 5,
+    tileSize            = 5,
+    meshCol             = 5,
+    addrWidth           = GemmConstant.addrWidth,
+    sizeConfigWidth     = GemmConstant.sizeConfigWidth
+  )
+
+}

--- a/hw/chisel_acc/src/test/scala/snax_acc/utils/MatrixLibBase.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/utils/MatrixLibBase.scala
@@ -1,0 +1,118 @@
+package snax_acc.utils
+
+import scala.math.BigInt
+import scala.math.abs
+
+import chisel3._
+
+/** Scala math matrix multiplication library for Gemm verification */
+object MatrixLibBase {
+
+  /** Generate a random data matrix of 8-bit ints (Byte in Scala) */
+  def GenRandomMatrix(nRow: Int, nCol: Int, negative: Boolean = true) = {
+    val random_matrix = Array.ofDim[Byte](nRow * nCol)
+    val rand          = new scala.util.Random
+    val minVal        = if (negative) -128 else 0
+    val maxVal        = 127
+
+    for (r <- 0 until nRow) {
+      for (c <- 0 until nCol) {
+        random_matrix(r * nCol + c) = rand.between(minVal, maxVal).toByte
+      }
+    }
+    random_matrix
+  }
+
+  def GenRandomSubtractionValue() = {
+    val rand = new scala.util.Random
+    (rand.between(0, 127).toByte, rand.between(0, 127).toByte)
+  }
+
+  /** Translate Byte / Int data to hex data for interaction with the Chisel module
+    *
+    * @param width
+    *   The number of hex symbols
+    */
+  def int2hex(width: Int, intValue: Int): String = {
+    require(abs(intValue) <= (BigInt(1) << (4 * width - 1)))
+
+    val paddingChar = if (intValue >= 0) '0' else 'f'
+    val baseString  = f"$intValue%x".reverse
+    if (baseString.length > width) {
+      baseString.slice(0, width).reverse
+    } else {
+      baseString.padTo(width, paddingChar).reverse
+    }
+  }
+
+  /** Translate matrix to big bus for inputting to Chisel module The data type is Array[Int]
+    *   - e.g., A = [1, 2, 3, 4] and nbBits = 16 -> 0x0004000300020001
+    *
+    * @param nbBits
+    *   The number of bits where each data element is packed into.
+    */
+  def MatrixArray2BigBus(nRow: Int, nCol: Int, A: Array[Int], nbBits: Int) = {
+    require(A.length == nRow * nCol)
+    require(nbBits % 4 == 0, "nbBits must be a multiple of 4")
+    val nbHexSymbols    = nbBits / 4
+    var flattenedUInt_A = ""
+
+    for (i <- 0 until nRow) {
+      for (j <- 0 until nCol) {
+        flattenedUInt_A = int2hex(nbHexSymbols, A(i * nCol + j)) + flattenedUInt_A
+      }
+    }
+
+    BigInt(flattenedUInt_A, 16)
+  }
+
+  /** Translate matrix to big bus for inputting to Chisel module The data type is Array[Byte] */
+  def MatrixArray2BigBus(nRow: Int, nCol: Int, A: Array[Byte], nbBits: Int): BigInt =
+    MatrixArray2BigBus(nRow, nCol, A.map(_.toInt), nbBits)
+
+  // Translate the Chisel output big data bus to matrix for checking with the golden results
+  def BigBus2Matrix(nRow: Int, nCol: Int, matrix: UInt) = {
+    val result = Array.ofDim[Int](nRow * nCol)
+    for (i <- 0 until nRow) {
+      for (j <- 0 until nCol) {
+        result(i + j * nRow) = matrix((i + j * nRow + 1) * 32, (i + j * nRow) * 32).litValue.toInt
+      }
+    }
+    result
+  }
+
+  /** Assert the Chisel output results equal golden vector. The equality check happens within the bus-domain, where each
+    * assertion checks a whole tile of the data.
+    */
+  def CheckResults[T: Integral](A: Array[T], B: Array[T]): Unit = {
+    val num = implicitly[Integral[T]]
+    for (i <- 0 until A.length) {
+      assert(num.equiv(A(i), B(i)), f"Error: ${A(i)} != ${B(i)} at index $i")
+    }
+  }
+
+  /** Matrix multiplication with one dimension Array[Byte] data type */
+  def MatrixMul_1D(
+    meshRow:       Int,
+    tileSize:      Int,
+    meshCol:       Int,
+    A:             Array[Byte],
+    B:             Array[Byte],
+    subtraction_a: Byte,
+    subtraction_b: Byte
+  ): Array[Int] = {
+    val golden = Array.ofDim[Int](meshRow * meshCol)
+    for (i <- 0 until meshRow) {
+      for (j <- 0 until meshCol) {
+        golden(i * meshCol + j) = 0
+        for (k <- 0 until tileSize) {
+          // assuming the matrix B is arranged as N data layout
+          golden(i * meshCol + j) =
+            golden(i * meshCol + j) + (A(i * tileSize + k) - subtraction_a) * (B(k + j * tileSize) - subtraction_b)
+        }
+      }
+    }
+    golden
+  }
+
+}

--- a/hw/chisel_acc/src/test/scala/snax_acc/utils/MatrixLibBlock.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/utils/MatrixLibBlock.scala
@@ -1,0 +1,178 @@
+package snax_acc.utils
+
+import scala.math.BigInt
+
+import snax_acc.gemm.GemmParams
+import snax_acc.gemm.TestParameters
+import snax_acc.utils.MatrixLibBase._
+
+/** Scala math submatrix multiplication library for Block Gemm verification Some functions are based on the
+  * MatrixLibBase
+  */
+object MatrixLibBlock {
+
+  /** Generate random M, K, N for testing the Block Gemm The test matrix are (M * meshRow, K * tileSize) and (K *
+    * tileSize, N * meshCol)
+    */
+  def GenRandSizeTest() = {
+    val rand = new scala.util.Random
+    val M    = rand.between(1, TestParameters.MatrixLibBlock_random_M_range + 1)
+    val K    = rand.between(1, TestParameters.MatrixLibBlock_random_K_range + 1)
+    val N    = rand.between(1, TestParameters.MatrixLibBlock_random_N_range + 1)
+    (M, K, N)
+  }
+
+  /** Generate the random test matrices A, B, C to compute D = A*B+C, with sizes:
+    *   - A: (M * meshRow, K * tileSize)
+    *   - B: (K * tileSize, N * meshCol)
+    *   - C: (M * meshRow, N * meshCol)
+    */
+  def GenBlockMatrices(M: Int, K: Int, N: Int, params: GemmParams) = {
+    val matrix_A = snax_acc.utils.MatrixLibBase.GenRandomMatrix(params.meshRow * M, params.tileSize * K)
+    val matrix_B = snax_acc.utils.MatrixLibBase.GenRandomMatrix(params.tileSize * K, params.meshCol * N)
+    val matrix_C =
+      snax_acc.utils.MatrixLibBase.GenRandomMatrix(params.meshRow * M, params.meshCol * N, negative = false)
+
+    (matrix_A, matrix_B, matrix_C)
+  }
+
+  /** Translate the large input matrixes to submatrices for inputting to Chisel module and golden result generation The
+    * matrixes are arranged according to submatrix multiplication rules
+    */
+  def SplitBlockMatrix(M: Int, K: Int, N: Int, A: Array[Byte], B: Array[Byte], C: Array[Byte], params: GemmParams) = {
+    val split_A = Array.ofDim[BigInt](M * K)
+    val split_B = Array.ofDim[BigInt](K * N)
+    val split_C = Array.ofDim[BigInt](M * N)
+
+    for (i <- 0 until M) {
+      for (j <- 0 until K) {
+        val subMatrix_A = A.slice(
+          (i * K + j) * params.meshRow * params.tileSize,
+          (i * K + j + 1) * params.meshRow * params.tileSize
+        )
+        split_A(i * K + j) = MatrixArray2BigBus(params.meshRow, params.tileSize, subMatrix_A, params.dataWidthA)
+      }
+    }
+
+    for (i <- 0 until K) {
+      for (j <- 0 until N) {
+        val submatrix_B = B.slice(
+          (i * N + j) * params.tileSize * params.meshCol,
+          (i * N + j + 1) * params.tileSize * params.meshCol
+        )
+        split_B(i * N + j) = MatrixArray2BigBus(params.tileSize, params.meshCol, submatrix_B, params.dataWidthB)
+      }
+    }
+
+    for (i <- 0 until M) {
+      for (j <- 0 until N) {
+        val submatrix_C = C.slice(
+          (i * N + j) * params.meshRow * params.meshCol,
+          (i * N + j + 1) * params.meshRow * params.meshCol
+        )
+        split_C(i * N + j) = MatrixArray2BigBus(params.meshRow, params.meshCol, submatrix_C, params.dataWidthC)
+      }
+    }
+
+    (split_A, split_B, split_C)
+  }
+
+  /** Translate the temporal index (i.e. the cycle) to spatial index (i.e. the matrix index).
+    *   - The temporal index ranges from 0 to (M*K*N - 1).
+    *   - Matrix A (size MxK) needs to be read in row major order, and is stored in row major order. (The testbench only
+    *     sees a 1D array of size M*K.)
+    *   - Matrix B (size KxN) needs to be read in column major order, and is stored in column major order.
+    *   - The temporal index follows the following loop ordering:
+    *     - for (m = 0 to M - 1);
+    *       - for (n = 0 to N - 1);
+    *         - for (k = 0 to K - 1);
+    *           - (do operation)
+    */
+  def temporalToSpatialIndicesAB(temporalIndex: Int, K: Int, N: Int): (Int, Int) = {
+    val m = temporalIndex / (K * N) // Row index of D
+    val n = (temporalIndex / K) % N // Column index of D
+    val k = temporalIndex       % K // Shared dimension index
+
+    val indexA = m * K + k
+    val indexB = n * K + k
+
+    (indexA, indexB)
+  }
+
+  /** Translate the temporal index (i.e. the cycle) to spatial index (i.e. the matrix index) Matrix D (size MxN) needs
+    * to be read in row major order, and is stored in row major order.
+    */
+  def temporalToSpatialIndexD(temporalIndex: Int, M: Int, N: Int): Int = {
+    require(temporalIndex < M * N)
+    val spatialIndex = temporalIndex
+    spatialIndex
+  }
+
+  /** Software model of hardware block matrix multiplication implementation according to submatrix multiplication rule.
+    * The matrix A and matrix B also needs to have a right data layout according to the submatrix multiplication rule
+    */
+  def BlockMatrixMul_1D(
+    M:      Int,
+    K:      Int,
+    N:      Int,
+    A:      Array[Byte],
+    B:      Array[Byte],
+    C:      Array[Byte],
+    params: GemmParams
+  ): Array[BigInt] = {
+    require(A.length == M * K * params.meshRow * params.tileSize)
+    require(B.length == K * N * params.tileSize * params.meshCol)
+    require(C.length == M * N * params.meshRow * params.meshCol)
+
+    val golden           = Array.ofDim[Int](M * N * params.meshRow * params.meshCol)
+    val golden_split_mat = Array.ofDim[BigInt](M * N)
+
+    for (m <- 0 until M) {
+      for (n <- 0 until N) {
+        for (k <- 0 until K) {
+
+          val tile_A = A.slice(
+            (m * K + k) * params.meshRow * params.tileSize,
+            (m * K + k + 1) * params.meshRow * params.tileSize
+          )
+          val tile_B = B.slice(
+            (n * K + k) * params.tileSize * params.meshCol,
+            (n * K + k + 1) * params.tileSize * params.meshCol
+          )
+
+          val submatrix_temp1 =
+            MatrixMul_1D(params.meshRow, params.tileSize, params.meshCol, tile_A, tile_B, 0, 0)
+
+          val submatrix_temp = golden // Size meshRow * meshCol
+            .slice(
+              (m * N + n) * params.meshRow * params.meshCol,
+              (m * N + n + 1) * params.meshRow * params.meshCol
+            )
+            .zip(submatrix_temp1)
+            .map { case (a, b) => a + b }
+
+          for (t <- 0 until params.meshRow * params.meshCol) {
+            golden((m * N + n) * params.meshRow * params.meshCol + t) = submatrix_temp(t)
+          }
+        }
+
+        // Add C
+        val tile_golden   = golden.slice(
+          (m * N + n) * params.meshRow * params.meshCol,
+          (m * N + n + 1) * params.meshRow * params.meshCol
+        )
+        val tile_C        = C.slice(
+          (m * N + n) * params.meshRow * params.meshCol,
+          (m * N + n + 1) * params.meshRow * params.meshCol
+        )
+        val tile_golden_C = tile_golden.zip(tile_C).map { case (a, b) => a + b }
+
+        // Pack full tile into bus
+        golden_split_mat(m * N + n) =
+          MatrixArray2BigBus(params.meshRow, params.meshCol, tile_golden_C, params.dataWidthAccum)
+      }
+    }
+    golden_split_mat
+  }
+
+}

--- a/hw/chisel_acc/src/test/scala/snax_acc/utils/ParallelSerialConverter.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/utils/ParallelSerialConverter.scala
@@ -105,7 +105,7 @@ class SerialToParallelSpec extends AnyFlatSpec with ChiselScalatestTester with M
       // We expect the parallel output to combine these 4 bytes: 0x34_12_CD_AB (little-endian accumulation)
       var expectedParallel = (0x34 << 24) | (0x12 << 16) | (0xcd << 8) | 0xab
 
-      for (i <- 0 to 1) {
+      for (_ <- 0 to 1) {
         for ((byteVal, idx) <- testData.zipWithIndex) {
           // Present the serial byte
           dut.io.in.valid.poke(true.B)
@@ -125,7 +125,7 @@ class SerialToParallelSpec extends AnyFlatSpec with ChiselScalatestTester with M
 
       expectedParallel = (0xcc << 24) | (0xbb << 16) | (0xaa << 8) | 0xef
 
-      for (i <- 0 to 1) {
+      for (_ <- 0 to 1) {
         for ((byteVal, idx) <- testData.zipWithIndex) {
           // Present the serial byte
           dut.io.in.valid.poke(true.B)


### PR DESCRIPTION
- Add testbench for BlockGemm and GemmArray
- Clean up .gitignore in `chisel` and `chisel-ssm`

Refactor/clean up BlockGemm code:
- Include `HasGemmParams` trait for easier syntax (access `someParam` directly instead of `params.someParam`)
- Use correct ScalaDoc style
- Make multi-line statements single-line if possible (after scamafmt PR, the line length is 120)