### PR TITLE
Add the XDMA to the snax cluster

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -34,6 +34,7 @@ dependencies:
   hypercorex:         { git: "https://github.com/KULeuven-MICAS/hypercorex.git", rev: main }
   dimc:               { git: "https://github.com/KULeuven-MICAS/snax-dimc.git", rev: main }
   cgra:               { git: "https://github.com/KULeuven-MICAS/snax_cgra.git", rev: main}
+  xdma_axi_adapter:   { git: https://github.com/Konste11ation/xdma_axi_adapter, rev: main}
 
 vendor_package:
   - name: musl

--- a/Bender.yml
+++ b/Bender.yml
@@ -415,7 +415,7 @@ sources:
   - target: snax_KUL_cluster
     files:
       - target/snitch_cluster/generated/snax_KUL_cluster_wrapper.sv
-  
+
   #---------------------------
   # Test harness declaration
   #---------------------------

--- a/Bender.yml
+++ b/Bender.yml
@@ -415,6 +415,7 @@ sources:
   - target: snax_KUL_cluster
     files:
       - target/snitch_cluster/generated/snax_KUL_cluster_wrapper.sv
+  
   #---------------------------
   # Test harness declaration
   #---------------------------

--- a/Bender.yml
+++ b/Bender.yml
@@ -34,7 +34,7 @@ dependencies:
   hypercorex:         { git: "https://github.com/KULeuven-MICAS/hypercorex.git", rev: main }
   dimc:               { git: "https://github.com/KULeuven-MICAS/snax-dimc.git", rev: main }
   cgra:               { git: "https://github.com/KULeuven-MICAS/snax_cgra.git", rev: main}
-  xdma_axi_adapter:   { git: https://github.com/Konste11ation/xdma_axi_adapter, rev: main}
+  xdma_axi_adapter:   { git: https://github.com/KULeuven-MICAS/xdma_axi_adapter.git, rev: main}
 
 vendor_package:
   - name: musl

--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -66,6 +66,15 @@
                 64
             ]
         },
+        "mmio_size": {
+            "type": "number",
+            "description": "Address region size reserved for the mmio in KiByte.",
+            "examples": [
+                32,
+                16
+            ],
+            "default": 16
+        },        
         "addr_width": {
             "type": "number",
             "description": "Length of the address, should be greater than 30. If the address is larger than 34 the data bus needs to be 64 bits in size.",

--- a/hw/snitch/src/snitch_pkg.sv
+++ b/hw/snitch/src/snitch_pkg.sv
@@ -140,13 +140,14 @@ package snitch_pkg;
   typedef enum int unsigned {
     TCDMDMA    = 0,
     SoCDMAOut  = 1,
-    ZeroMemory = 2
+    XDMAOut    = 2
   } cluster_slave_dma_e;
 
   typedef enum int unsigned {
-    SDMAMst  = 32'd0,
-    SoCDMAIn = 32'd1,
-    ICache   = 32'd2
+    SDMAMst  = 0,
+    SoCDMAIn = 1,
+    ICache   = 2,
+    XDMAIn   = 3
   } cluster_master_dma_e;
 
   /// Possible interconnect implementations.

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -47,7 +47,7 @@ module snitch_cluster
   /// Cluster peripheral address region size (in kB).
   parameter int unsigned ClusterPeriphSize  = 64,
   /// Cluster MMIO address region size (in kB).
-  parameter int unsigned ClusterMMIOSize    = 12,
+  parameter int unsigned ClusterMMIOSize    = 16,
   /// Cluster Addr Space (in KB)
   parameter int unsigned ClusterAddrSpace   = 1024,
   /// Number of TCDM Banks. It is recommended to have twice the number of banks

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -23,283 +23,284 @@
 module snitch_cluster
   import snitch_pkg::*;
 #(
-  /// Width of physical address.
-  parameter int unsigned PhysicalAddrWidth  = 48,
-  /// Width of regular data bus.
-  parameter int unsigned NarrowDataWidth    = 64,
-  /// Width of wide AXI port.
-  parameter int unsigned WideDataWidth      = 512,
-  /// AXI: id width in.
-  parameter int unsigned NarrowIdWidthIn    = 2,
-  /// AXI: dma id with in *currently not available*
-  parameter int unsigned WideIdWidthIn      = 2,
-  /// AXI: user width.
-  parameter int unsigned NarrowUserWidth    = 1,
-  /// AXI: dma user width.
-  parameter int unsigned WideUserWidth      = 1,
-  /// Address from which to fetch the first instructions.
-  /// Number of Hives. Each Hive can hold 1-many cores.
-  parameter int unsigned NrHives            = 1,
-  /// The total (not per Hive) amount of cores.
-  parameter int unsigned NrCores            = 8,
-  /// Data/TCDM memory depth per cut (in words).
-  parameter int unsigned TCDMDepth          = 1024,
-  /// Cluster peripheral address region size (in kB).
-  parameter int unsigned ClusterPeriphSize  = 64,
-  /// Cluster MMIO address region size (in kB).
-  parameter int unsigned ClusterMMIOSize    = 16,
-  /// Cluster Addr Space (in KB)
-  parameter int unsigned ClusterAddrSpace   = 1024,
-  /// Number of TCDM Banks. It is recommended to have twice the number of banks
-  /// as cores. If SSRs are enabled, we recommend 4 times the the number of
-  /// banks.
-  parameter int unsigned NrBanks            = NrCores,
-  /// Size of DMA AXI buffer.
-  parameter int unsigned DMAAxiReqFifoDepth = 3,
-  /// Size of DMA request fifo.
-  parameter int unsigned DMAReqFifoDepth    = 3,
-  /// Width of a single icache line.
-  parameter int unsigned ICacheLineWidth [NrHives] = '{default: 0},
-  /// Number of icache lines per set.
-  parameter int unsigned ICacheLineCount [NrHives] = '{default: 0},
-  /// Number of icache sets.
-  parameter int unsigned ICacheSets [NrHives]      = '{default: 0},
-  /// Enable virtual memory support.
-  parameter bit          VMSupport          = 1,
-  /// Per-core enabling of the standard `E` ISA reduced-register extension.
-  parameter bit [NrCores-1:0] RVE           = '0,
-  /// Per-core enabling of the standard `F` ISA extensions.
-  parameter bit [NrCores-1:0] RVF           = '0,
-  /// Per-core enabling of the standard `D` ISA extensions.
-  parameter bit [NrCores-1:0] RVD           = '0,
-  /// Per-core enabling of `XDivSqrt` ISA extensions.
-  parameter bit [NrCores-1:0] XDivSqrt      = '0,
-  // Small-float extensions
-  /// FP 16-bit
-  parameter bit [NrCores-1:0] XF16          = '0,
-  /// FP 16 alt a.k.a. brain-float
-  parameter bit [NrCores-1:0] XF16ALT       = '0,
-  /// FP 8-bit
-  parameter bit [NrCores-1:0] XF8           = '0,
-  /// FP 8-bit alt
-  parameter bit [NrCores-1:0] XF8ALT        = '0,
-  /// Enable SIMD support.
-  parameter bit [NrCores-1:0] XFVEC         = '0,
-  /// Enable DOTP support.
-  parameter bit [NrCores-1:0] XFDOTP        = '0,
-  /// Per-core enabling of the custom `Xdma` ISA extensions.
-  parameter bit [NrCores-1:0] Xdma          = '0,
-  /// Per-core enabling of the custom `Xssr` ISA extensions.
-  parameter bit [NrCores-1:0] Xssr          = '0,
-  /// Per-core enabling of the custom `Xfrep` ISA extensions.
-  parameter bit [NrCores-1:0] Xfrep         = '0,
-  /// # Core-global parameters
-  /// FPU configuration.
-  parameter fpnew_pkg::fpu_implementation_t FPUImplementation [NrCores] =
-    '{default: fpnew_pkg::fpu_implementation_t'(0)},
-  /// SNAX Acc initial narrow TCDM ports
-  parameter int unsigned SnaxNarrowTcdmPorts [NrCores] = '{default: 0},
-  /// SNAX Acc initial wide TCDM ports
-  parameter int unsigned SnaxWideTcdmPorts [NrCores] = '{default: 0},
-  /// SNAX Acc initial narrow TCDM ports
-  parameter int unsigned TotalSnaxNarrowTcdmPorts = 0,
-  /// SNAX Acc initial wide TCDM ports
-  parameter int unsigned TotalSnaxWideTcdmPorts = 0,
-  /// Total Number of SNAX TCDM ports
-  parameter int unsigned TotalSnaxTcdmPorts = TotalSnaxNarrowTcdmPorts + TotalSnaxWideTcdmPorts,
-  /// SNAX TCDM Custom Index Assignment
-  parameter bit          SnaxUseIdxTcdmAssign = 1'b0,
-  /// SNAX Number of Narrow Index Assignments
-  parameter int unsigned SnaxNumNarrowAssignIdx = 1,
-  /// SNAX Number of Wide Index Assignments
-  parameter int unsigned SnaxNumWideAssignIdx = 1,
-  /// SNAX Narrow Custom Index Assignment
-  parameter int unsigned SnaxNarrowStartIdx [SnaxNumNarrowAssignIdx] = '{default: 0},
-  parameter int unsigned SnaxNarrowEndIdx [SnaxNumNarrowAssignIdx] = '{default: 0},
-  /// SNAX Wide Custom Index Assignment
-  parameter int unsigned SnaxWideStartIdx [SnaxNumWideAssignIdx] = '{default: 0},
-  parameter int unsigned SnaxWideEndIdx [SnaxNumWideAssignIdx] = '{default: 0},
-  /// SNAX Use Custom Instruction Ports
-  parameter bit [NrCores-1:0] SnaxUseCustomPorts = 0,
-  /// Physical Memory Attribute Configuration
-  parameter snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '0,
-  /// # Per-core parameters
-  /// Per-core integer outstanding loads
-  parameter int unsigned NumIntOutstandingLoads [NrCores] = '{default: 0},
-  /// Per-core integer outstanding memory operations (load and stores)
-  parameter int unsigned NumIntOutstandingMem [NrCores] = '{default: 0},
-  /// Per-core floating-point outstanding loads
-  parameter int unsigned NumFPOutstandingLoads [NrCores] = '{default: 0},
-  /// Per-core floating-point outstanding memory operations (load and stores)
-  parameter int unsigned NumFPOutstandingMem [NrCores] = '{default: 0},
-  /// Per-core number of data TLB entries.
-  parameter int unsigned NumDTLBEntries [NrCores] = '{default: 0},
-  /// Per-core number of instruction TLB entries.
-  parameter int unsigned NumITLBEntries [NrCores] = '{default: 0},
-  /// Maximum number of SSRs per core.
-  parameter int unsigned NumSsrsMax = 0,
-  /// Per-core number of SSRs.
-  parameter int unsigned NumSsrs [NrCores] = '{default: 0},
-  /// Per-core depth of TCDM Mux unifying SSR 0 and Snitch requests.
-  parameter int unsigned SsrMuxRespDepth [NrCores] = '{default: 0},
-  /// index of ssr max to avoid its underflow (Error reported in Synopsys VCS)
-  parameter int SsrMaxIndex = (NumSsrsMax > 0) ? (NumSsrsMax - 1) : 0,
-  /// Per-core internal parameters for each SSR.
-  parameter snitch_ssr_pkg::ssr_cfg_t [SsrMaxIndex:0] SsrCfgs [NrCores] = '{default: '0},
-  /// Per-core register indices for each SSR.
-  parameter logic [SsrMaxIndex:0][4:0]  SsrRegs [NrCores] = '{default: 0},
-  /// Per-core amount of sequencer instructions for IPU and FPU if enabled.
-  parameter int unsigned NumSequencerInstr [NrCores] = '{default: 0},
-  /// Parent Hive id, a.k.a a mapping which core is assigned to which Hive.
-  parameter int unsigned Hive [NrCores] = '{default: 0},
-  /// TCDM Configuration.
-  parameter topo_e       Topology           = LogarithmicInterconnect,
-  /// Radix of the individual switch points of the network.
-  /// Currently supported are `32'd2` and `32'd4`.
-  parameter int unsigned Radix              = 32'd2,
-  /// ## Timing Tuning Parameters
-  /// Insert Pipeline registers into off-loading path (request)
-  parameter bit          RegisterOffloadReq = 1'b0,
-  /// Insert Pipeline registers into off-loading path (response)
-  parameter bit          RegisterOffloadRsp = 1'b0,
-  /// Insert Pipeline registers into data memory path (request)
-  parameter bit          RegisterCoreReq    = 1'b0,
-  /// Insert Pipeline registers into data memory path (response)
-  parameter bit          RegisterCoreRsp    = 1'b0,
-  /// Insert Pipeline registers after each memory cut
-  parameter bit          RegisterTCDMCuts   = 1'b0,
-  /// Decouple wide external AXI plug
-  parameter bit          RegisterExtWide    = 1'b0,
-  /// Decouple narrow external AXI plug
-  parameter bit          RegisterExtNarrow  = 1'b0,
-  /// Insert Pipeline register into the FPU data path (request)
-  parameter bit          RegisterFPUReq     = 1'b0,
-  /// Insert Pipeline registers after sequencer
-  parameter bit          RegisterSequencer  = 1'b0,
-  /// Insert Pipeline registers immediately before FPU datapath
-  parameter bit          RegisterFPUIn      = 0,
-  /// Insert Pipeline registers immediately after FPU datapath
-  parameter bit          RegisterFPUOut     = 0,
-  /// Run Snitch (the integer part) at half of the clock frequency
-  parameter bit          IsoCrossing        = 0,
-  parameter axi_pkg::xbar_latency_e NarrowXbarLatency = axi_pkg::CUT_ALL_PORTS,
-  parameter axi_pkg::xbar_latency_e WideXbarLatency = axi_pkg::CUT_ALL_PORTS,
-  /// Outstanding transactions on the wide network
-  parameter int unsigned WideMaxMstTrans    = 4,
-  parameter int unsigned WideMaxSlvTrans    = 4,
-  /// Outstanding transactions on the narrow network
-  parameter int unsigned NarrowMaxMstTrans  = 4,
-  parameter int unsigned NarrowMaxSlvTrans  = 4,
-  /// # Interface
-  /// AXI Ports
-  parameter type         narrow_in_req_t   = logic,
-  parameter type         narrow_in_resp_t  = logic,
-  parameter type         narrow_out_req_t  = logic,
-  parameter type         narrow_out_resp_t = logic,
-  parameter type         wide_out_req_t    = logic,
-  parameter type         wide_out_resp_t   = logic,
-  parameter type         wide_in_req_t     = logic,
-  parameter type         wide_in_resp_t    = logic,
-  // Memory configuration input types; these vary depending on implementation.
-  parameter type         sram_cfg_t        = logic,
-  parameter type         sram_cfgs_t       = logic,
-  // Accelerator typedef
-  parameter type         acc_req_t         = logic,
-  parameter type         acc_resp_t        = logic,
-  parameter type         tcdm_req_t        = logic,
-  parameter type         tcdm_rsp_t        = logic,
-  // Memory latency parameter. Most of the memories have a read latency of 1. In
-  // case you have memory macros which are pipelined you want to adjust this
-  // value here. This only applies to the TCDM. The instruction cache macros will break!
-  // In case you are using the `RegisterTCDMCuts` feature this adds an
-  // additional cycle latency, which is taken into account here.
-  parameter int unsigned MemoryMacroLatency = 1 + RegisterTCDMCuts,
-  /// Width of observable register
-  parameter int unsigned ObsWidth = 8,
-  /// Enable debug support.
-  parameter bit          DebugSupport = 1
+    /// Width of physical address.
+    parameter int unsigned PhysicalAddrWidth = 48,
+    /// Width of regular data bus.
+    parameter int unsigned NarrowDataWidth = 64,
+    /// Width of wide AXI port.
+    parameter int unsigned WideDataWidth = 512,
+    /// AXI: id width in.
+    parameter int unsigned NarrowIdWidthIn = 2,
+    /// AXI: dma id with in *currently not available*
+    parameter int unsigned WideIdWidthIn = 2,
+    /// AXI: user width.
+    parameter int unsigned NarrowUserWidth = 1,
+    /// AXI: dma user width.
+    parameter int unsigned WideUserWidth = 1,
+    /// Address from which to fetch the first instructions.
+    /// Number of Hives. Each Hive can hold 1-many cores.
+    parameter int unsigned NrHives = 1,
+    /// The total (not per Hive) amount of cores.
+    parameter int unsigned NrCores = 8,
+    /// Data/TCDM memory depth per cut (in words).
+    parameter int unsigned TCDMDepth = 1024,
+    /// Cluster peripheral address region size (in kB).
+    parameter int unsigned ClusterPeriphSize = 64,
+    /// Cluster MMIO address region size (in kB).
+    parameter int unsigned ClusterMMIOSize = 16,
+    /// Cluster Addr Space (in KB)
+    parameter int unsigned ClusterAddrSpace = 1024,
+    /// Number of TCDM Banks. It is recommended to have twice the number of banks
+    /// as cores. If SSRs are enabled, we recommend 4 times the the number of
+    /// banks.
+    parameter int unsigned NrBanks = NrCores,
+    /// Size of DMA AXI buffer.
+    parameter int unsigned DMAAxiReqFifoDepth = 3,
+    /// Size of DMA request fifo.
+    parameter int unsigned DMAReqFifoDepth = 3,
+    /// Width of a single icache line.
+    parameter int unsigned ICacheLineWidth[NrHives] = '{default: 0},
+    /// Number of icache lines per set.
+    parameter int unsigned ICacheLineCount[NrHives] = '{default: 0},
+    /// Number of icache sets.
+    parameter int unsigned ICacheSets[NrHives] = '{default: 0},
+    /// Enable virtual memory support.
+    parameter bit VMSupport = 1,
+    /// Per-core enabling of the standard `E` ISA reduced-register extension.
+    parameter bit [NrCores-1:0] RVE = '0,
+    /// Per-core enabling of the standard `F` ISA extensions.
+    parameter bit [NrCores-1:0] RVF = '0,
+    /// Per-core enabling of the standard `D` ISA extensions.
+    parameter bit [NrCores-1:0] RVD = '0,
+    /// Per-core enabling of `XDivSqrt` ISA extensions.
+    parameter bit [NrCores-1:0] XDivSqrt = '0,
+    // Small-float extensions
+    /// FP 16-bit
+    parameter bit [NrCores-1:0] XF16 = '0,
+    /// FP 16 alt a.k.a. brain-float
+    parameter bit [NrCores-1:0] XF16ALT = '0,
+    /// FP 8-bit
+    parameter bit [NrCores-1:0] XF8 = '0,
+    /// FP 8-bit alt
+    parameter bit [NrCores-1:0] XF8ALT = '0,
+    /// Enable SIMD support.
+    parameter bit [NrCores-1:0] XFVEC = '0,
+    /// Enable DOTP support.
+    parameter bit [NrCores-1:0] XFDOTP = '0,
+    /// Per-core enabling of the custom `Xdma` ISA extensions.
+    parameter bit [NrCores-1:0] Xdma = '0,
+    /// Per-core enabling of the custom `Xssr` ISA extensions.
+    parameter bit [NrCores-1:0] Xssr = '0,
+    /// Per-core enabling of the custom `Xfrep` ISA extensions.
+    parameter bit [NrCores-1:0] Xfrep = '0,
+    /// # Core-global parameters
+    /// FPU configuration.
+    parameter fpnew_pkg::fpu_implementation_t FPUImplementation[NrCores] = '{
+        default: fpnew_pkg::fpu_implementation_t'(0)
+    },
+    /// SNAX Acc initial narrow TCDM ports
+    parameter int unsigned SnaxNarrowTcdmPorts[NrCores] = '{default: 0},
+    /// SNAX Acc initial wide TCDM ports
+    parameter int unsigned SnaxWideTcdmPorts[NrCores] = '{default: 0},
+    /// SNAX Acc initial narrow TCDM ports
+    parameter int unsigned TotalSnaxNarrowTcdmPorts = 0,
+    /// SNAX Acc initial wide TCDM ports
+    parameter int unsigned TotalSnaxWideTcdmPorts = 0,
+    /// Total Number of SNAX TCDM ports
+    parameter int unsigned TotalSnaxTcdmPorts = TotalSnaxNarrowTcdmPorts + TotalSnaxWideTcdmPorts,
+    /// SNAX TCDM Custom Index Assignment
+    parameter bit SnaxUseIdxTcdmAssign = 1'b0,
+    /// SNAX Number of Narrow Index Assignments
+    parameter int unsigned SnaxNumNarrowAssignIdx = 1,
+    /// SNAX Number of Wide Index Assignments
+    parameter int unsigned SnaxNumWideAssignIdx = 1,
+    /// SNAX Narrow Custom Index Assignment
+    parameter int unsigned SnaxNarrowStartIdx[SnaxNumNarrowAssignIdx] = '{default: 0},
+    parameter int unsigned SnaxNarrowEndIdx[SnaxNumNarrowAssignIdx] = '{default: 0},
+    /// SNAX Wide Custom Index Assignment
+    parameter int unsigned SnaxWideStartIdx[SnaxNumWideAssignIdx] = '{default: 0},
+    parameter int unsigned SnaxWideEndIdx[SnaxNumWideAssignIdx] = '{default: 0},
+    /// SNAX Use Custom Instruction Ports
+    parameter bit [NrCores-1:0] SnaxUseCustomPorts = 0,
+    /// Physical Memory Attribute Configuration
+    parameter snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '0,
+    /// # Per-core parameters
+    /// Per-core integer outstanding loads
+    parameter int unsigned NumIntOutstandingLoads[NrCores] = '{default: 0},
+    /// Per-core integer outstanding memory operations (load and stores)
+    parameter int unsigned NumIntOutstandingMem[NrCores] = '{default: 0},
+    /// Per-core floating-point outstanding loads
+    parameter int unsigned NumFPOutstandingLoads[NrCores] = '{default: 0},
+    /// Per-core floating-point outstanding memory operations (load and stores)
+    parameter int unsigned NumFPOutstandingMem[NrCores] = '{default: 0},
+    /// Per-core number of data TLB entries.
+    parameter int unsigned NumDTLBEntries[NrCores] = '{default: 0},
+    /// Per-core number of instruction TLB entries.
+    parameter int unsigned NumITLBEntries[NrCores] = '{default: 0},
+    /// Maximum number of SSRs per core.
+    parameter int unsigned NumSsrsMax = 0,
+    /// Per-core number of SSRs.
+    parameter int unsigned NumSsrs[NrCores] = '{default: 0},
+    /// Per-core depth of TCDM Mux unifying SSR 0 and Snitch requests.
+    parameter int unsigned SsrMuxRespDepth[NrCores] = '{default: 0},
+    /// index of ssr max to avoid its underflow (Error reported in Synopsys VCS)
+    parameter int SsrMaxIndex = (NumSsrsMax > 0) ? (NumSsrsMax - 1) : 0,
+    /// Per-core internal parameters for each SSR.
+    parameter snitch_ssr_pkg::ssr_cfg_t [SsrMaxIndex:0] SsrCfgs[NrCores] = '{default: '0},
+    /// Per-core register indices for each SSR.
+    parameter logic [SsrMaxIndex:0][4:0] SsrRegs[NrCores] = '{default: 0},
+    /// Per-core amount of sequencer instructions for IPU and FPU if enabled.
+    parameter int unsigned NumSequencerInstr[NrCores] = '{default: 0},
+    /// Parent Hive id, a.k.a a mapping which core is assigned to which Hive.
+    parameter int unsigned Hive[NrCores] = '{default: 0},
+    /// TCDM Configuration.
+    parameter topo_e Topology = LogarithmicInterconnect,
+    /// Radix of the individual switch points of the network.
+    /// Currently supported are `32'd2` and `32'd4`.
+    parameter int unsigned Radix = 32'd2,
+    /// ## Timing Tuning Parameters
+    /// Insert Pipeline registers into off-loading path (request)
+    parameter bit RegisterOffloadReq = 1'b0,
+    /// Insert Pipeline registers into off-loading path (response)
+    parameter bit RegisterOffloadRsp = 1'b0,
+    /// Insert Pipeline registers into data memory path (request)
+    parameter bit RegisterCoreReq = 1'b0,
+    /// Insert Pipeline registers into data memory path (response)
+    parameter bit RegisterCoreRsp = 1'b0,
+    /// Insert Pipeline registers after each memory cut
+    parameter bit RegisterTCDMCuts = 1'b0,
+    /// Decouple wide external AXI plug
+    parameter bit RegisterExtWide = 1'b0,
+    /// Decouple narrow external AXI plug
+    parameter bit RegisterExtNarrow = 1'b0,
+    /// Insert Pipeline register into the FPU data path (request)
+    parameter bit RegisterFPUReq = 1'b0,
+    /// Insert Pipeline registers after sequencer
+    parameter bit RegisterSequencer = 1'b0,
+    /// Insert Pipeline registers immediately before FPU datapath
+    parameter bit RegisterFPUIn = 0,
+    /// Insert Pipeline registers immediately after FPU datapath
+    parameter bit RegisterFPUOut = 0,
+    /// Run Snitch (the integer part) at half of the clock frequency
+    parameter bit IsoCrossing = 0,
+    parameter axi_pkg::xbar_latency_e NarrowXbarLatency = axi_pkg::CUT_ALL_PORTS,
+    parameter axi_pkg::xbar_latency_e WideXbarLatency = axi_pkg::CUT_ALL_PORTS,
+    /// Outstanding transactions on the wide network
+    parameter int unsigned WideMaxMstTrans = 4,
+    parameter int unsigned WideMaxSlvTrans = 4,
+    /// Outstanding transactions on the narrow network
+    parameter int unsigned NarrowMaxMstTrans = 4,
+    parameter int unsigned NarrowMaxSlvTrans = 4,
+    /// # Interface
+    /// AXI Ports
+    parameter type narrow_in_req_t = logic,
+    parameter type narrow_in_resp_t = logic,
+    parameter type narrow_out_req_t = logic,
+    parameter type narrow_out_resp_t = logic,
+    parameter type wide_out_req_t = logic,
+    parameter type wide_out_resp_t = logic,
+    parameter type wide_in_req_t = logic,
+    parameter type wide_in_resp_t = logic,
+    // Memory configuration input types; these vary depending on implementation.
+    parameter type sram_cfg_t = logic,
+    parameter type sram_cfgs_t = logic,
+    // Accelerator typedef
+    parameter type acc_req_t = logic,
+    parameter type acc_resp_t = logic,
+    parameter type tcdm_req_t = logic,
+    parameter type tcdm_rsp_t = logic,
+    // Memory latency parameter. Most of the memories have a read latency of 1. In
+    // case you have memory macros which are pipelined you want to adjust this
+    // value here. This only applies to the TCDM. The instruction cache macros will break!
+    // In case you are using the `RegisterTCDMCuts` feature this adds an
+    // additional cycle latency, which is taken into account here.
+    parameter int unsigned MemoryMacroLatency = 1 + RegisterTCDMCuts,
+    /// Width of observable register
+    parameter int unsigned ObsWidth = 8,
+    /// Enable debug support.
+    parameter bit DebugSupport = 1
 ) (
-  /// System clock. If `IsoCrossing` is enabled this port is the _fast_ clock.
-  /// The slower, half-frequency clock, is derived internally.
-  input  logic                          clk_i,
-  /// Asynchronous active high reset. This signal is assumed to be _async_.
-  input  logic                          rst_ni,
-  /// Observability register for the cluster. This register is assumed to be
-  /// sticky and only useful for observing signals from the outside.
-  output logic [ObsWidth-1:0]           obs_o,
-  /// Per-core debug request signal. Asserting this signals puts the
-  /// corresponding core into debug mode. This signal is assumed to be _async_.
-  input  logic [NrCores-1:0]            debug_req_i,
-  /// Machine external interrupt pending. Usually those interrupts come from a
-  /// platform-level interrupt controller. This signal is assumed to be _async_.
-  input  logic [NrCores-1:0]            meip_i,
-  /// Machine timer interrupt pending. Usually those interrupts come from a
-  /// core-local interrupt controller such as a timer/RTC. This signal is
-  /// assumed to be _async_.
-  input  logic [NrCores-1:0]            mtip_i,
-  /// Core software interrupt pending. Usually those interrupts come from
-  /// another core to facilitate inter-processor-interrupts. This signal is
-  /// assumed to be _async_.
-  input  logic [NrCores-1:0]            msip_i,
-  /// First hartid of the cluster. Cores of a cluster are monotonically
-  /// increasing without a gap, i.e., a cluster with 8 cores and a
-  /// `hart_base_id_i` of 5 get the hartids 5 - 12.
-  input  logic [9:0]                    hart_base_id_i,
-  /// Base address of cluster. TCDM and cluster peripheral location are derived from
-  /// it. This signal is pseudo-static.
-  input  logic [PhysicalAddrWidth-1:0]  cluster_base_addr_i,
-  /// Boot address
-  input  logic [31:0]                   boot_addr_i,
-  /// Configuration inputs for the memory cuts used in implementation.
-  /// These signals are pseudo-static.
-  input  sram_cfgs_t                    sram_cfgs_i,
-  /// Bypass half-frequency clock. (`d2` = divide-by-two). This signal is
-  /// pseudo-static.
-  input  logic                          clk_d2_bypass_i,
-  /// SNAX Custom Instruction Ports
-  /// Request for custom instruction format
-  output acc_req_t  [NrCores-1:0]            snax_req_o,
-  output logic      [NrCores-1:0]            snax_qvalid_o,
-  input  logic      [NrCores-1:0]            snax_qready_i,
-  /// Response for custom instruction format
-  input  acc_resp_t [NrCores-1:0]            snax_resp_i,
-  input  logic      [NrCores-1:0]            snax_pvalid_i,
-  output logic      [NrCores-1:0]            snax_pready_o,
-  /// SNAX CSR Ports
-  /// Request for CSR format
-  output logic      [NrCores-1:0][31:0]      snax_csr_req_bits_data_o,
-  output logic      [NrCores-1:0][31:0]      snax_csr_req_bits_addr_o,
-  output logic      [NrCores-1:0]            snax_csr_req_bits_write_o,
-  output logic      [NrCores-1:0]            snax_csr_req_valid_o,
-  input  logic      [NrCores-1:0]            snax_csr_req_ready_i,
-  /// Response for CSR format
-  input  logic      [NrCores-1:0][31:0]      snax_csr_rsp_bits_data_i,
-  input  logic      [NrCores-1:0]            snax_csr_rsp_valid_i,
-  output logic      [NrCores-1:0]            snax_csr_rsp_ready_o,
-  /// SNAX barrier port
-  input  logic      [NrCores-1:0]            snax_barrier_i,
-  /// SNAX TCDM ports
-  input  tcdm_req_t [TotalSnaxTcdmPorts-1:0] snax_tcdm_req_i,
-  output tcdm_rsp_t [TotalSnaxTcdmPorts-1:0] snax_tcdm_rsp_o,
-  /// AXI Core cluster in-port.
-  input  narrow_in_req_t                narrow_in_req_i,
-  output narrow_in_resp_t               narrow_in_resp_o,
-  /// AXI Core cluster out-port.
-  output narrow_out_req_t               narrow_out_req_o,
-  input  narrow_out_resp_t              narrow_out_resp_i,
-  /// XDMA Out ports
-  output wide_out_req_t                 xdma_wide_out_req_o,
-  input  wide_out_resp_t                xdma_wide_out_resp_i,
-  /// XDMA In ports
-  input  wide_in_req_t                  xdma_wide_in_req_i,
-  output wide_in_resp_t                 xdma_wide_in_resp_o,
-  /// AXI DMA cluster out-port. Usually wider than the cluster ports so that the
-  /// DMA engine can efficiently transfer bulk of data.
-  output wide_out_req_t                 wide_out_req_o,
-  input  wide_out_resp_t                wide_out_resp_i,
-  /// AXI DMA cluster in-port.
-  input  wide_in_req_t                  wide_in_req_i,
-  output wide_in_resp_t                 wide_in_resp_o
+    /// System clock. If `IsoCrossing` is enabled this port is the _fast_ clock.
+    /// The slower, half-frequency clock, is derived internally.
+    input  logic                                            clk_i,
+    /// Asynchronous active high reset. This signal is assumed to be _async_.
+    input  logic                                            rst_ni,
+    /// Observability register for the cluster. This register is assumed to be
+    /// sticky and only useful for observing signals from the outside.
+    output logic             [          ObsWidth-1:0]       obs_o,
+    /// Per-core debug request signal. Asserting this signals puts the
+    /// corresponding core into debug mode. This signal is assumed to be _async_.
+    input  logic             [           NrCores-1:0]       debug_req_i,
+    /// Machine external interrupt pending. Usually those interrupts come from a
+    /// platform-level interrupt controller. This signal is assumed to be _async_.
+    input  logic             [           NrCores-1:0]       meip_i,
+    /// Machine timer interrupt pending. Usually those interrupts come from a
+    /// core-local interrupt controller such as a timer/RTC. This signal is
+    /// assumed to be _async_.
+    input  logic             [           NrCores-1:0]       mtip_i,
+    /// Core software interrupt pending. Usually those interrupts come from
+    /// another core to facilitate inter-processor-interrupts. This signal is
+    /// assumed to be _async_.
+    input  logic             [           NrCores-1:0]       msip_i,
+    /// First hartid of the cluster. Cores of a cluster are monotonically
+    /// increasing without a gap, i.e., a cluster with 8 cores and a
+    /// `hart_base_id_i` of 5 get the hartids 5 - 12.
+    input  logic             [                   9:0]       hart_base_id_i,
+    /// Base address of cluster. TCDM and cluster peripheral location are derived from
+    /// it. This signal is pseudo-static.
+    input  logic             [ PhysicalAddrWidth-1:0]       cluster_base_addr_i,
+    /// Boot address
+    input  logic             [                  31:0]       boot_addr_i,
+    /// Configuration inputs for the memory cuts used in implementation.
+    /// These signals are pseudo-static.
+    input  sram_cfgs_t                                      sram_cfgs_i,
+    /// Bypass half-frequency clock. (`d2` = divide-by-two). This signal is
+    /// pseudo-static.
+    input  logic                                            clk_d2_bypass_i,
+    /// SNAX Custom Instruction Ports
+    /// Request for custom instruction format
+    output acc_req_t         [           NrCores-1:0]       snax_req_o,
+    output logic             [           NrCores-1:0]       snax_qvalid_o,
+    input  logic             [           NrCores-1:0]       snax_qready_i,
+    /// Response for custom instruction format
+    input  acc_resp_t        [           NrCores-1:0]       snax_resp_i,
+    input  logic             [           NrCores-1:0]       snax_pvalid_i,
+    output logic             [           NrCores-1:0]       snax_pready_o,
+    /// SNAX CSR Ports
+    /// Request for CSR format
+    output logic             [           NrCores-1:0][31:0] snax_csr_req_bits_data_o,
+    output logic             [           NrCores-1:0][31:0] snax_csr_req_bits_addr_o,
+    output logic             [           NrCores-1:0]       snax_csr_req_bits_write_o,
+    output logic             [           NrCores-1:0]       snax_csr_req_valid_o,
+    input  logic             [           NrCores-1:0]       snax_csr_req_ready_i,
+    /// Response for CSR format
+    input  logic             [           NrCores-1:0][31:0] snax_csr_rsp_bits_data_i,
+    input  logic             [           NrCores-1:0]       snax_csr_rsp_valid_i,
+    output logic             [           NrCores-1:0]       snax_csr_rsp_ready_o,
+    /// SNAX barrier port
+    input  logic             [           NrCores-1:0]       snax_barrier_i,
+    /// SNAX TCDM ports
+    input  tcdm_req_t        [TotalSnaxTcdmPorts-1:0]       snax_tcdm_req_i,
+    output tcdm_rsp_t        [TotalSnaxTcdmPorts-1:0]       snax_tcdm_rsp_o,
+    /// AXI Core cluster in-port.
+    input  narrow_in_req_t                                  narrow_in_req_i,
+    output narrow_in_resp_t                                 narrow_in_resp_o,
+    /// AXI Core cluster out-port.
+    output narrow_out_req_t                                 narrow_out_req_o,
+    input  narrow_out_resp_t                                narrow_out_resp_i,
+    /// XDMA Out ports
+    output wide_out_req_t                                   xdma_wide_out_req_o,
+    input  wide_out_resp_t                                  xdma_wide_out_resp_i,
+    /// XDMA In ports
+    input  wide_in_req_t                                    xdma_wide_in_req_i,
+    output wide_in_resp_t                                   xdma_wide_in_resp_o,
+    /// AXI DMA cluster out-port. Usually wider than the cluster ports so that the
+    /// DMA engine can efficiently transfer bulk of data.
+    output wide_out_req_t                                   wide_out_req_o,
+    input  wide_out_resp_t                                  wide_out_resp_i,
+    /// AXI DMA cluster in-port.
+    input  wide_in_req_t                                    wide_in_req_i,
+    output wide_in_resp_t                                   wide_in_resp_o
 );
 
   //------------------
@@ -321,15 +322,15 @@ module snitch_cluster
   /// Minimum width to hold the core number.
   localparam int unsigned CoreIDWidth = cf_math_pkg::idx_width(NrCores);
   localparam int unsigned TCDMMemAddrWidth = $clog2(TCDMDepth);
-  localparam int unsigned TCDMSize = NrBanks * TCDMDepth * (NarrowDataWidth/8);
+  localparam int unsigned TCDMSize = NrBanks * TCDMDepth * (NarrowDataWidth / 8);
   localparam int unsigned TCDMAddrWidth = $clog2(TCDMSize);
   localparam int unsigned BanksPerSuperBank = WideDataWidth / NarrowDataWidth;
   localparam int unsigned NrSuperBanks = NrBanks / BanksPerSuperBank;
-  localparam int unsigned NumTotalBanks = BanksPerSuperBank*NrSuperBanks;
+  localparam int unsigned NumTotalBanks = BanksPerSuperBank * NrSuperBanks;
 
   localparam int unsigned NrTCDMPortsCores = get_tcdm_port_offs(NrCores);
   localparam int unsigned NumTCDMIn = NrTCDMPortsCores + 1;
-  localparam logic [PhysicalAddrWidth-1:0] TCDMMask = ~(TCDMSize-1);
+  localparam logic [PhysicalAddrWidth-1:0] TCDMMask = ~(TCDMSize - 1);
 
   // Core Requests, SoC Request, PTW.
   localparam int unsigned NrNarrowMasters = 3;
@@ -346,36 +347,36 @@ module snitch_cluster
 
   // AXI Configuration
   localparam axi_pkg::xbar_cfg_t ClusterXbarCfg = '{
-    NoSlvPorts: NrNarrowMasters,
-    NoMstPorts: NrSlaves,
-    MaxMstTrans: NarrowMaxMstTrans,
-    MaxSlvTrans: NarrowMaxSlvTrans,
-    FallThrough: 1'b0,
-    LatencyMode: NarrowXbarLatency,
-    PipelineStages: 0,
-    AxiIdWidthSlvPorts: NarrowIdWidthIn,
-    AxiIdUsedSlvPorts: NarrowIdWidthIn,
-    UniqueIds: 1'b0,
-    AxiAddrWidth: PhysicalAddrWidth,
-    AxiDataWidth: NarrowDataWidth,
-    NoAddrRules: NrRules
+      NoSlvPorts: NrNarrowMasters,
+      NoMstPorts: NrSlaves,
+      MaxMstTrans: NarrowMaxMstTrans,
+      MaxSlvTrans: NarrowMaxSlvTrans,
+      FallThrough: 1'b0,
+      LatencyMode: NarrowXbarLatency,
+      PipelineStages: 0,
+      AxiIdWidthSlvPorts: NarrowIdWidthIn,
+      AxiIdUsedSlvPorts: NarrowIdWidthIn,
+      UniqueIds: 1'b0,
+      AxiAddrWidth: PhysicalAddrWidth,
+      AxiDataWidth: NarrowDataWidth,
+      NoAddrRules: NrRules
   };
 
   // DMA configuration struct
   localparam axi_pkg::xbar_cfg_t DmaXbarCfg = '{
-    NoSlvPorts: NrWideMasters,
-    NoMstPorts: NrWideSlaves,
-    MaxMstTrans: WideMaxMstTrans,
-    MaxSlvTrans: WideMaxSlvTrans,
-    FallThrough: 1'b0,
-    LatencyMode: WideXbarLatency,
-    PipelineStages: 0,
-    AxiIdWidthSlvPorts: WideIdWidthIn,
-    AxiIdUsedSlvPorts: WideIdWidthIn,
-    UniqueIds: 1'b0,
-    AxiAddrWidth: PhysicalAddrWidth,
-    AxiDataWidth: WideDataWidth,
-    NoAddrRules: 2
+      NoSlvPorts: NrWideMasters,
+      NoMstPorts: NrWideSlaves,
+      MaxMstTrans: WideMaxMstTrans,
+      MaxSlvTrans: WideMaxSlvTrans,
+      FallThrough: 1'b0,
+      LatencyMode: WideXbarLatency,
+      PipelineStages: 0,
+      AxiIdWidthSlvPorts: WideIdWidthIn,
+      AxiIdUsedSlvPorts: WideIdWidthIn,
+      UniqueIds: 1'b0,
+      AxiAddrWidth: PhysicalAddrWidth,
+      AxiDataWidth: WideDataWidth,
+      NoAddrRules: 2
   };
 
   function automatic int unsigned get_hive_size(int unsigned current_hive);
@@ -397,19 +398,19 @@ module snitch_cluster
   // Typedefs
   // --------
   typedef logic [PhysicalAddrWidth-1:0] addr_t;
-  typedef logic [NarrowDataWidth-1:0]   data_t;
+  typedef logic [NarrowDataWidth-1:0] data_t;
   typedef logic [NarrowDataWidth/8-1:0] strb_t;
-  typedef logic [WideDataWidth-1:0]     data_dma_t;
-  typedef logic [WideDataWidth/8-1:0]   strb_dma_t;
-  typedef logic [NarrowIdWidthIn-1:0]   id_mst_t;
-  typedef logic [NarrowIdWidthOut-1:0]  id_slv_t;
-  typedef logic [WideIdWidthIn-1:0]     id_dma_mst_t;
-  typedef logic [WideIdWidthOut-1:0]    id_dma_slv_t;
-  typedef logic [NarrowUserWidth-1:0]   user_t;
-  typedef logic [WideUserWidth-1:0]     user_dma_t;
+  typedef logic [WideDataWidth-1:0] data_dma_t;
+  typedef logic [WideDataWidth/8-1:0] strb_dma_t;
+  typedef logic [NarrowIdWidthIn-1:0] id_mst_t;
+  typedef logic [NarrowIdWidthOut-1:0] id_slv_t;
+  typedef logic [WideIdWidthIn-1:0] id_dma_mst_t;
+  typedef logic [WideIdWidthOut-1:0] id_dma_slv_t;
+  typedef logic [NarrowUserWidth-1:0] user_t;
+  typedef logic [WideUserWidth-1:0] user_dma_t;
 
-  typedef logic [TCDMMemAddrWidth-1:0]  tcdm_mem_addr_t;
-  typedef logic [TCDMAddrWidth-1:0]     tcdm_addr_t;
+  typedef logic [TCDMMemAddrWidth-1:0] tcdm_mem_addr_t;
+  typedef logic [TCDMAddrWidth-1:0] tcdm_addr_t;
 
   typedef struct packed {
     logic [CoreIDWidth-1:0] core_id;
@@ -442,17 +443,16 @@ module snitch_cluster
 
   // Event counter increments for DMA.
   typedef struct packed {
-      logic aw_stall, ar_stall, r_stall, w_stall,
-                   buf_w_stall, buf_r_stall;
-      logic aw_valid, aw_ready, aw_done, aw_bw;
-      logic ar_valid, ar_ready, ar_done, ar_bw;
-      logic r_valid,  r_ready,  r_done, r_bw;
-      logic w_valid,  w_ready,  w_done, w_bw;
-      logic b_valid,  b_ready,  b_done;
-      logic dma_busy;
-      axi_pkg::len_t aw_len, ar_len;
-      axi_pkg::size_t aw_size, ar_size;
-      logic [$clog2(WideDataWidth/8):0] num_bytes_written;
+    logic aw_stall, ar_stall, r_stall, w_stall, buf_w_stall, buf_r_stall;
+    logic aw_valid, aw_ready, aw_done, aw_bw;
+    logic ar_valid, ar_ready, ar_done, ar_bw;
+    logic r_valid, r_ready, r_done, r_bw;
+    logic w_valid, w_ready, w_done, w_bw;
+    logic b_valid, b_ready, b_done;
+    logic dma_busy;
+    axi_pkg::len_t aw_len, ar_len;
+    axi_pkg::size_t aw_size, ar_size;
+    logic [$clog2(WideDataWidth/8):0] num_bytes_written;
   } dma_events_t;
 
   typedef struct packed {
@@ -510,23 +510,23 @@ module snitch_cluster
   // The MMIO is at the end of each cluster
   addr_t xdma_mmio_start_address, xdma_mmio_end_address;
   assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024 - ClusterMMIOSize * 1024;
-  assign xdma_mmio_end_address = cluster_base_addr_i + ClusterAddrSpace * 1024 ;
+  assign xdma_mmio_end_address = cluster_base_addr_i + ClusterAddrSpace * 1024;
 
   // ----------------
   // Wire Definitions
   // ----------------
   // 1. AXI
-  axi_slv_req_t  [NrSlaves-1:0] narrow_axi_slv_req;
+  axi_slv_req_t [NrSlaves-1:0] narrow_axi_slv_req;
   axi_slv_resp_t [NrSlaves-1:0] narrow_axi_slv_rsp;
 
-  axi_mst_req_t  [NrNarrowMasters-1:0] narrow_axi_mst_req;
+  axi_mst_req_t [NrNarrowMasters-1:0] narrow_axi_mst_req;
   axi_mst_resp_t [NrNarrowMasters-1:0] narrow_axi_mst_rsp;
 
   // DMA AXI buses
-  axi_mst_dma_req_t  [NrWideMasters-1:0] wide_axi_mst_req;
+  axi_mst_dma_req_t [NrWideMasters-1:0] wide_axi_mst_req;
   axi_mst_dma_resp_t [NrWideMasters-1:0] wide_axi_mst_rsp;
-  axi_slv_dma_req_t  [NrWideSlaves-1 :0] wide_axi_slv_req;
-  axi_slv_dma_resp_t [NrWideSlaves-1 :0] wide_axi_slv_rsp;
+  axi_slv_dma_req_t [NrWideSlaves-1 : 0] wide_axi_slv_req;
+  axi_slv_dma_resp_t [NrWideSlaves-1 : 0] wide_axi_slv_rsp;
 
   // 2. Memory Subsystem (Banks)
   mem_req_t [NrSuperBanks-1:0][BanksPerSuperBank-1:0] ic_req;
@@ -547,8 +547,8 @@ module snitch_cluster
   tcdm_rsp_t [NrTCDMPortsCores-1:0] tcdm_rsp;
 
   core_events_t [NrCores-1:0] core_events;
-  tcdm_events_t               tcdm_events;
-  dma_events_t                dma_events;
+  tcdm_events_t tcdm_events;
+  dma_events_t dma_events;
   snitch_icache_pkg::icache_l0_events_t [NrCores-1:0] icache_events;
 
   // 4. Memory Subsystem (Core side).
@@ -566,7 +566,7 @@ module snitch_cluster
   logic [NrCores-1:0] cl_interrupt;
   logic [NrCores-1:0] barrier_in;
   logic barrier_out;
-  logic [ObsWidth-1:0] obs_signal [NrCores];
+  logic [ObsWidth-1:0] obs_signal[NrCores];
 
   //--------------
   // Observability register
@@ -579,39 +579,39 @@ module snitch_cluster
   // -------------
   // Optionally decouple the external wide AXI master port.
   axi_cut #(
-    .Bypass (!RegisterExtWide),
-    .aw_chan_t (axi_slv_dma_aw_chan_t),
-    .w_chan_t (axi_slv_dma_w_chan_t),
-    .b_chan_t (axi_slv_dma_b_chan_t),
-    .ar_chan_t (axi_slv_dma_ar_chan_t),
-    .r_chan_t (axi_slv_dma_r_chan_t),
-    .axi_req_t (axi_slv_dma_req_t),
-    .axi_resp_t (axi_slv_dma_resp_t)
+      .Bypass(!RegisterExtWide),
+      .aw_chan_t(axi_slv_dma_aw_chan_t),
+      .w_chan_t(axi_slv_dma_w_chan_t),
+      .b_chan_t(axi_slv_dma_b_chan_t),
+      .ar_chan_t(axi_slv_dma_ar_chan_t),
+      .r_chan_t(axi_slv_dma_r_chan_t),
+      .axi_req_t(axi_slv_dma_req_t),
+      .axi_resp_t(axi_slv_dma_resp_t)
   ) i_cut_ext_wide_out (
-    .clk_i (clk_i),
-    .rst_ni (rst_ni),
-    .slv_req_i (wide_axi_slv_req[SoCDMAOut]),
-    .slv_resp_o (wide_axi_slv_rsp[SoCDMAOut]),
-    .mst_req_o (wide_out_req_o),
-    .mst_resp_i (wide_out_resp_i)
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(wide_axi_slv_req[SoCDMAOut]),
+      .slv_resp_o(wide_axi_slv_rsp[SoCDMAOut]),
+      .mst_req_o(wide_out_req_o),
+      .mst_resp_i(wide_out_resp_i)
   );
 
   axi_cut #(
-    .Bypass (!RegisterExtWide),
-    .aw_chan_t (axi_mst_dma_aw_chan_t),
-    .w_chan_t (axi_mst_dma_w_chan_t),
-    .b_chan_t (axi_mst_dma_b_chan_t),
-    .ar_chan_t (axi_mst_dma_ar_chan_t),
-    .r_chan_t (axi_mst_dma_r_chan_t),
-    .axi_req_t (axi_mst_dma_req_t),
-    .axi_resp_t (axi_mst_dma_resp_t)
+      .Bypass(!RegisterExtWide),
+      .aw_chan_t(axi_mst_dma_aw_chan_t),
+      .w_chan_t(axi_mst_dma_w_chan_t),
+      .b_chan_t(axi_mst_dma_b_chan_t),
+      .ar_chan_t(axi_mst_dma_ar_chan_t),
+      .r_chan_t(axi_mst_dma_r_chan_t),
+      .axi_req_t(axi_mst_dma_req_t),
+      .axi_resp_t(axi_mst_dma_resp_t)
   ) i_cut_ext_wide_in (
-    .clk_i (clk_i),
-    .rst_ni (rst_ni),
-    .slv_req_i (wide_in_req_i),
-    .slv_resp_o (wide_in_resp_o),
-    .mst_req_o (wide_axi_mst_req[SoCDMAIn]),
-    .mst_resp_i (wide_axi_mst_rsp[SoCDMAIn])
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(wide_in_req_i),
+      .slv_resp_o(wide_in_resp_o),
+      .mst_req_o(wide_axi_mst_req[SoCDMAIn]),
+      .mst_resp_i(wide_axi_mst_rsp[SoCDMAIn])
   );
   // -------------
   // XDMA Ports
@@ -628,78 +628,70 @@ module snitch_cluster
 
   assign dma_xbar_default_port = '{default: SoCDMAOut};
   assign dma_xbar_rule = '{
-    '{
-      idx:        TCDMDMA,
-      start_addr: tcdm_start_address,
-      end_addr:   tcdm_end_address
-    },
-    '{
-      idx:        XDMAOut,
-      start_addr: xdma_mmio_start_address,
-      end_addr:   xdma_mmio_end_address
-    }
-  };
+          '{idx: TCDMDMA, start_addr: tcdm_start_address, end_addr: tcdm_end_address},
+          '{idx: XDMAOut, start_addr: xdma_mmio_start_address, end_addr: xdma_mmio_end_address}
+      };
   localparam bit [DmaXbarCfg.NoSlvPorts-1:0] DMAEnableDefaultMstPort = '1;
   axi_xbar #(
-    .Cfg (DmaXbarCfg),
-    .ATOPs (0),
-    .slv_aw_chan_t (axi_mst_dma_aw_chan_t),
-    .mst_aw_chan_t (axi_slv_dma_aw_chan_t),
-    .w_chan_t (axi_mst_dma_w_chan_t),
-    .slv_b_chan_t (axi_mst_dma_b_chan_t),
-    .mst_b_chan_t (axi_slv_dma_b_chan_t),
-    .slv_ar_chan_t (axi_mst_dma_ar_chan_t),
-    .mst_ar_chan_t (axi_slv_dma_ar_chan_t),
-    .slv_r_chan_t (axi_mst_dma_r_chan_t),
-    .mst_r_chan_t (axi_slv_dma_r_chan_t),
-    .slv_req_t (axi_mst_dma_req_t),
-    .slv_resp_t (axi_mst_dma_resp_t),
-    .mst_req_t (axi_slv_dma_req_t),
-    .mst_resp_t (axi_slv_dma_resp_t),
-    .rule_t (xbar_rule_t)
+      .Cfg(DmaXbarCfg),
+      .ATOPs(0),
+      .slv_aw_chan_t(axi_mst_dma_aw_chan_t),
+      .mst_aw_chan_t(axi_slv_dma_aw_chan_t),
+      .w_chan_t(axi_mst_dma_w_chan_t),
+      .slv_b_chan_t(axi_mst_dma_b_chan_t),
+      .mst_b_chan_t(axi_slv_dma_b_chan_t),
+      .slv_ar_chan_t(axi_mst_dma_ar_chan_t),
+      .mst_ar_chan_t(axi_slv_dma_ar_chan_t),
+      .slv_r_chan_t(axi_mst_dma_r_chan_t),
+      .mst_r_chan_t(axi_slv_dma_r_chan_t),
+      .slv_req_t(axi_mst_dma_req_t),
+      .slv_resp_t(axi_mst_dma_resp_t),
+      .mst_req_t(axi_slv_dma_req_t),
+      .mst_resp_t(axi_slv_dma_resp_t),
+      .rule_t(xbar_rule_t)
   ) i_axi_dma_xbar (
-    .clk_i (clk_i),
-    .rst_ni (rst_ni),
-    .test_i (1'b0),
-    .slv_ports_req_i (wide_axi_mst_req),
-    .slv_ports_resp_o (wide_axi_mst_rsp),
-    .mst_ports_req_o (wide_axi_slv_req),
-    .mst_ports_resp_i (wide_axi_slv_rsp),
-    .addr_map_i (dma_xbar_rule),
-    .en_default_mst_port_i (DMAEnableDefaultMstPort),
-    .default_mst_port_i (dma_xbar_default_port)
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .test_i(1'b0),
+      .slv_ports_req_i(wide_axi_mst_req),
+      .slv_ports_resp_o(wide_axi_mst_rsp),
+      .mst_ports_req_o(wide_axi_slv_req),
+      .mst_ports_resp_i(wide_axi_slv_rsp),
+      .addr_map_i(dma_xbar_rule),
+      .en_default_mst_port_i(DMAEnableDefaultMstPort),
+      .default_mst_port_i(dma_xbar_default_port)
   );
 
   addr_t ext_dma_req_q_addr_nontrunc;
 
   axi_to_mem_interleaved #(
-    .axi_req_t (axi_slv_dma_req_t),
-    .axi_resp_t (axi_slv_dma_resp_t),
-    .AddrWidth (PhysicalAddrWidth),
-    .DataWidth (WideDataWidth),
-    .IdWidth (WideIdWidthOut),
-    .NumBanks (1),
-    .BufDepth (MemoryMacroLatency + 1)
+      .axi_req_t(axi_slv_dma_req_t),
+      .axi_resp_t(axi_slv_dma_resp_t),
+      .AddrWidth(PhysicalAddrWidth),
+      .DataWidth(WideDataWidth),
+      .IdWidth(WideIdWidthOut),
+      .NumBanks(1),
+      .BufDepth(MemoryMacroLatency + 1)
   ) i_axi_to_mem_dma (
-    .clk_i,
-    .rst_ni,
-    .busy_o (),
-    .test_i (1'b0),
-    .axi_req_i (wide_axi_slv_req[TCDMDMA]),
-    .axi_resp_o (wide_axi_slv_rsp[TCDMDMA]),
-    .mem_req_o (ext_dma_req.q_valid),
-    .mem_gnt_i (ext_dma_rsp.q_ready),
-    .mem_addr_o (ext_dma_req_q_addr_nontrunc),
-    .mem_wdata_o (ext_dma_req.q.data),
-    .mem_strb_o (ext_dma_req.q.strb),
-    .mem_atop_o (/* The DMA does not support atomics */),
-    .mem_we_o (ext_dma_req.q.write),
-    .mem_rvalid_i (ext_dma_rsp.p_valid),
-    .mem_rdata_i (ext_dma_rsp.p.data)
+      .clk_i,
+      .rst_ni,
+      .busy_o(),
+      .test_i(1'b0),
+      .axi_req_i(wide_axi_slv_req[TCDMDMA]),
+      .axi_resp_o(wide_axi_slv_rsp[TCDMDMA]),
+      .mem_req_o(ext_dma_req.q_valid),
+      .mem_gnt_i(ext_dma_rsp.q_ready),
+      .mem_addr_o(ext_dma_req_q_addr_nontrunc),
+      .mem_wdata_o(ext_dma_req.q.data),
+      .mem_strb_o(ext_dma_req.q.strb),
+      .mem_atop_o(  /* The DMA does not support atomics */),
+      .mem_we_o(ext_dma_req.q.write),
+      .mem_rvalid_i(ext_dma_rsp.p_valid),
+      .mem_rdata_i(ext_dma_rsp.p.data)
   );
 
   assign ext_dma_req.q.addr = tcdm_addr_t'(ext_dma_req_q_addr_nontrunc);
-  assign ext_dma_req.q.amo = reqrsp_pkg::AMONone;
+  assign ext_dma_req.q.amo  = reqrsp_pkg::AMONone;
   assign ext_dma_req.q.user = '0;
 
   //------------------------
@@ -712,14 +704,14 @@ module snitch_cluster
   // It needs to be divided by 8 because each narrow TCDM port is 64 bits wide
 
   tcdm_req_t [TotalSnaxNarrowTcdmPorts-1:0] snax_tcdm_req_narrow;
-  tcdm_req_t [TotalSnaxWideTcdmPorts-1:0] snax_tcdm_req_wide;
+  tcdm_req_t [  TotalSnaxWideTcdmPorts-1:0] snax_tcdm_req_wide;
 
   tcdm_rsp_t [TotalSnaxNarrowTcdmPorts-1:0] snax_tcdm_rsp_narrow;
-  tcdm_rsp_t [TotalSnaxWideTcdmPorts-1:0] snax_tcdm_rsp_wide;
+  tcdm_rsp_t [  TotalSnaxWideTcdmPorts-1:0] snax_tcdm_rsp_wide;
 
   localparam int unsigned NumSnaxWideTcdmPorts = TotalSnaxWideTcdmPorts / 8;
 
-  if ((NumSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_narrow_wide_map
+  if ((NumSnaxWideTcdmPorts > 0) && (TotalSnaxNarrowTcdmPorts > 0)) begin : gen_narrow_wide_map
 
     integer total_offset, wide_offset, narrow_offset, curr_wide, curr_narrow;
 
@@ -732,14 +724,14 @@ module snitch_cluster
     // That is the technique used in the procedural block below
     //------------------------
 
-    if (SnaxUseIdxTcdmAssign) begin: gen_custom_tcdm_assign
+    if (SnaxUseIdxTcdmAssign) begin : gen_custom_tcdm_assign
 
       integer start_wide_idx, end_wide_idx, wide_len;
       integer start_narrow_idx, end_narrow_idx, narrow_len;
 
       always_comb begin
 
-        wide_offset = 0;
+        wide_offset   = 0;
         narrow_offset = 0;
 
         // Re-map the custom wide ports
@@ -755,7 +747,7 @@ module snitch_cluster
           end_wide_idx = SnaxWideEndIdx[i];
           wide_len = end_wide_idx - start_wide_idx + 1;
 
-          for (int j =0; j < wide_len; j++) begin
+          for (int j = 0; j < wide_len; j++) begin
             snax_tcdm_req_wide[j+wide_offset] = snax_tcdm_req_i[j+start_wide_idx];
             snax_tcdm_rsp_o[j+start_wide_idx] = snax_tcdm_rsp_wide[j+wide_offset];
           end
@@ -772,9 +764,9 @@ module snitch_cluster
           end_narrow_idx = SnaxNarrowEndIdx[i];
           narrow_len = end_narrow_idx - start_narrow_idx + 1;
 
-          for (int j =0; j < narrow_len; j++) begin
+          for (int j = 0; j < narrow_len; j++) begin
             snax_tcdm_req_narrow[j+narrow_offset] = snax_tcdm_req_i[j+start_narrow_idx];
-            snax_tcdm_rsp_o[j+start_narrow_idx] = snax_tcdm_rsp_narrow[j+narrow_offset];
+            snax_tcdm_rsp_o[j+start_narrow_idx]   = snax_tcdm_rsp_narrow[j+narrow_offset];
           end
 
           narrow_offset += narrow_len;
@@ -782,27 +774,27 @@ module snitch_cluster
         end
 
       end
-    end else begin: gen_non_custom_tcdm_assign
+    end else begin : gen_non_custom_tcdm_assign
 
       always_comb begin
 
-        total_offset = 0;
-        wide_offset = 0;
+        total_offset  = 0;
+        wide_offset   = 0;
         narrow_offset = 0;
 
         for (int i = 0; i < NrCores; i++) begin
 
-          curr_wide = SnaxWideTcdmPorts[i];
+          curr_wide   = SnaxWideTcdmPorts[i];
           curr_narrow = SnaxNarrowTcdmPorts[i];
 
           // Wide re-mapping
-          for(int j = 0; j < curr_wide; j++) begin
+          for (int j = 0; j < curr_wide; j++) begin
             snax_tcdm_req_wide[j+wide_offset] = snax_tcdm_req_i[j+total_offset];
-            snax_tcdm_rsp_o[j+total_offset] = snax_tcdm_rsp_wide[j+wide_offset];
+            snax_tcdm_rsp_o[j+total_offset]   = snax_tcdm_rsp_wide[j+wide_offset];
           end
 
           // Narrow re-mapping
-          for(int j = 0; j < curr_narrow; j++) begin
+          for (int j = 0; j < curr_narrow; j++) begin
             snax_tcdm_req_narrow[j+narrow_offset] = snax_tcdm_req_i[j+curr_wide+total_offset];
             snax_tcdm_rsp_o[j+curr_wide+total_offset] = snax_tcdm_rsp_narrow[j+narrow_offset];
           end
@@ -815,26 +807,26 @@ module snitch_cluster
       end
     end
 
-  end else if (NumSnaxWideTcdmPorts > 0) begin: gen_wide_only_map
+  end else if (NumSnaxWideTcdmPorts > 0) begin : gen_wide_only_map
     // For wide only connection ports
     always_comb begin
       snax_tcdm_req_wide = snax_tcdm_req_i;
       snax_tcdm_rsp_o    = snax_tcdm_rsp_wide;
     end
-  end else if (TotalSnaxNarrowTcdmPorts > 0) begin: gen_narrow_only_map
+  end else if (TotalSnaxNarrowTcdmPorts > 0) begin : gen_narrow_only_map
     // For narrow only connection ports
     always_comb begin
       snax_tcdm_req_narrow = snax_tcdm_req_i;
       snax_tcdm_rsp_o      = snax_tcdm_rsp_narrow;
     end
-  end else begin: gen_no_snax_map
+  end else begin : gen_no_snax_map
     // When there are no accelerators in the system
     always_comb begin
       snax_tcdm_rsp_o = '0;
     end
   end
 
-  if (NumSnaxWideTcdmPorts > 0) begin: gen_yes_wide_acc_connect
+  if (NumSnaxWideTcdmPorts > 0) begin : gen_yes_wide_acc_connect
 
     // First declare the wide SNAX tcdm ports
     tcdm_dma_req_t [NumSnaxWideTcdmPorts-1:0] snax_wide_req;
@@ -846,30 +838,30 @@ module snitch_cluster
     always_comb begin
       for (int i = 0; i < NumSnaxWideTcdmPorts; i++) begin
         // Request ports
-        snax_wide_req[i].q.addr  = snax_tcdm_req_wide[i*8].q.addr ;
+        snax_wide_req[i].q.addr = snax_tcdm_req_wide[i*8].q.addr;
         snax_wide_req[i].q.write = snax_tcdm_req_wide[i*8].q.write;
-        snax_wide_req[i].q.amo   = reqrsp_pkg::AMONone;
-        snax_wide_req[i].q.data  = {
-                                      snax_tcdm_req_wide[i*8+7].q.data,
-                                      snax_tcdm_req_wide[i*8+6].q.data,
-                                      snax_tcdm_req_wide[i*8+5].q.data,
-                                      snax_tcdm_req_wide[i*8+4].q.data,
-                                      snax_tcdm_req_wide[i*8+3].q.data,
-                                      snax_tcdm_req_wide[i*8+2].q.data,
-                                      snax_tcdm_req_wide[i*8+1].q.data,
-                                      snax_tcdm_req_wide[i*8].q.data
-                                    };
-        snax_wide_req[i].q.strb  = {
-                                      snax_tcdm_req_wide[i*8+7].q.strb,
-                                      snax_tcdm_req_wide[i*8+6].q.strb,
-                                      snax_tcdm_req_wide[i*8+5].q.strb,
-                                      snax_tcdm_req_wide[i*8+4].q.strb,
-                                      snax_tcdm_req_wide[i*8+3].q.strb,
-                                      snax_tcdm_req_wide[i*8+2].q.strb,
-                                      snax_tcdm_req_wide[i*8+1].q.strb,
-                                      snax_tcdm_req_wide[i*8].q.strb
-                                    };
-        snax_wide_req[i].q.user  = '0;
+        snax_wide_req[i].q.amo = reqrsp_pkg::AMONone;
+        snax_wide_req[i].q.data = {
+          snax_tcdm_req_wide[i*8+7].q.data,
+          snax_tcdm_req_wide[i*8+6].q.data,
+          snax_tcdm_req_wide[i*8+5].q.data,
+          snax_tcdm_req_wide[i*8+4].q.data,
+          snax_tcdm_req_wide[i*8+3].q.data,
+          snax_tcdm_req_wide[i*8+2].q.data,
+          snax_tcdm_req_wide[i*8+1].q.data,
+          snax_tcdm_req_wide[i*8].q.data
+        };
+        snax_wide_req[i].q.strb = {
+          snax_tcdm_req_wide[i*8+7].q.strb,
+          snax_tcdm_req_wide[i*8+6].q.strb,
+          snax_tcdm_req_wide[i*8+5].q.strb,
+          snax_tcdm_req_wide[i*8+4].q.strb,
+          snax_tcdm_req_wide[i*8+3].q.strb,
+          snax_tcdm_req_wide[i*8+2].q.strb,
+          snax_tcdm_req_wide[i*8+1].q.strb,
+          snax_tcdm_req_wide[i*8].q.strb
+        };
+        snax_wide_req[i].q.user = '0;
         snax_wide_req[i].q_valid = &{
                                       snax_tcdm_req_wide[i*8+7].q_valid,
                                       snax_tcdm_req_wide[i*8+6].q_valid,
@@ -914,45 +906,45 @@ module snitch_cluster
     end
 
     snitch_tcdm_interconnect #(
-      .NumInp (1 + NumSnaxWideTcdmPorts),
-      .NumOut (NrSuperBanks),
-      .tcdm_req_t (tcdm_dma_req_t),
-      .tcdm_rsp_t (tcdm_dma_rsp_t),
-      .mem_req_t (mem_dma_req_t),
-      .mem_rsp_t (mem_dma_rsp_t),
-      .user_t (logic),
-      .MemAddrWidth (TCDMMemAddrWidth),
-      .DataWidth (WideDataWidth),
-      .MemoryResponseLatency (MemoryMacroLatency)
+        .NumInp(1 + NumSnaxWideTcdmPorts),
+        .NumOut(NrSuperBanks),
+        .tcdm_req_t(tcdm_dma_req_t),
+        .tcdm_rsp_t(tcdm_dma_rsp_t),
+        .mem_req_t(mem_dma_req_t),
+        .mem_rsp_t(mem_dma_rsp_t),
+        .user_t(logic),
+        .MemAddrWidth(TCDMMemAddrWidth),
+        .DataWidth(WideDataWidth),
+        .MemoryResponseLatency(MemoryMacroLatency)
     ) i_dma_interconnect (
-      .clk_i,
-      .rst_ni,
-      .req_i ({ext_dma_req,snax_wide_req}),
-      .rsp_o ({ext_dma_rsp,snax_wide_rsp}),
-      .mem_req_o (sb_dma_req),
-      .mem_rsp_i (sb_dma_rsp)
+        .clk_i,
+        .rst_ni,
+        .req_i({ext_dma_req, snax_wide_req}),
+        .rsp_o({ext_dma_rsp, snax_wide_rsp}),
+        .mem_req_o(sb_dma_req),
+        .mem_rsp_i(sb_dma_rsp)
     );
 
-  end else begin: gen_no_wide_acc_connect
+  end else begin : gen_no_wide_acc_connect
 
     snitch_tcdm_interconnect #(
-      .NumInp (1),
-      .NumOut (NrSuperBanks),
-      .tcdm_req_t (tcdm_dma_req_t),
-      .tcdm_rsp_t (tcdm_dma_rsp_t),
-      .mem_req_t (mem_dma_req_t),
-      .mem_rsp_t (mem_dma_rsp_t),
-      .user_t (logic),
-      .MemAddrWidth (TCDMMemAddrWidth),
-      .DataWidth (WideDataWidth),
-      .MemoryResponseLatency (MemoryMacroLatency)
+        .NumInp(1),
+        .NumOut(NrSuperBanks),
+        .tcdm_req_t(tcdm_dma_req_t),
+        .tcdm_rsp_t(tcdm_dma_rsp_t),
+        .mem_req_t(mem_dma_req_t),
+        .mem_rsp_t(mem_dma_rsp_t),
+        .user_t(logic),
+        .MemAddrWidth(TCDMMemAddrWidth),
+        .DataWidth(WideDataWidth),
+        .MemoryResponseLatency(MemoryMacroLatency)
     ) i_dma_interconnect (
-      .clk_i,
-      .rst_ni,
-      .req_i (ext_dma_req),
-      .rsp_o (ext_dma_rsp),
-      .mem_req_o (sb_dma_req),
-      .mem_rsp_i (sb_dma_rsp)
+        .clk_i,
+        .rst_ni,
+        .req_i(ext_dma_req),
+        .rsp_o(ext_dma_rsp),
+        .mem_req_o(sb_dma_req),
+        .mem_rsp_i(sb_dma_rsp)
     );
   end
 
@@ -968,25 +960,25 @@ module snitch_cluster
   data_t          [NumTotalBanks-1:0] mem_rdata;
 
   snitch_data_mem #(
-    .TCDMDepth        ( TCDMDepth       ),
-    .NarrowDataWidth  ( NarrowDataWidth ),
-    .NumTotalBanks    ( NumTotalBanks   ),
-    .sram_cfg_t       ( sram_cfg_t      ),
-    .sram_cfgs_t      ( sram_cfgs_t     ),
-    .tcdm_mem_addr_t  ( tcdm_mem_addr_t ),
-    .strb_t           ( strb_t          ),
-    .data_t           ( data_t          )
+      .TCDMDepth      (TCDMDepth),
+      .NarrowDataWidth(NarrowDataWidth),
+      .NumTotalBanks  (NumTotalBanks),
+      .sram_cfg_t     (sram_cfg_t),
+      .sram_cfgs_t    (sram_cfgs_t),
+      .tcdm_mem_addr_t(tcdm_mem_addr_t),
+      .strb_t         (strb_t),
+      .data_t         (data_t)
   ) i_snitch_data_mem (
-    .clk_i            ( clk_i           ),
-    .rst_ni           ( rst_ni          ),
-    .sram_cfgs_i      ( sram_cfgs_i     ),
-    .mem_cs_i         ( mem_cs          ),
-    .mem_add_i        ( mem_add         ),
-    .mem_wen_i        ( mem_wen         ),
+      .clk_i      (clk_i),
+      .rst_ni     (rst_ni),
+      .sram_cfgs_i(sram_cfgs_i),
+      .mem_cs_i   (mem_cs),
+      .mem_add_i  (mem_add),
+      .mem_wen_i  (mem_wen),
 
-    .mem_be_i         ( mem_be          ),
-    .mem_wdata_i      ( mem_wdata       ),
-    .mem_rdata_o      ( mem_rdata       )
+      .mem_be_i   (mem_be),
+      .mem_wdata_i(mem_wdata),
+      .mem_rdata_o(mem_rdata)
   );
 
   for (genvar i = 0; i < NrSuperBanks; i++) begin : gen_tcdm_super_bank
@@ -995,22 +987,22 @@ module snitch_cluster
     mem_rsp_t [BanksPerSuperBank-1:0] amo_rsp;
 
     mem_wide_narrow_mux #(
-      .NarrowDataWidth (NarrowDataWidth),
-      .WideDataWidth (WideDataWidth),
-      .mem_narrow_req_t (mem_req_t),
-      .mem_narrow_rsp_t (mem_rsp_t),
-      .mem_wide_req_t (mem_dma_req_t),
-      .mem_wide_rsp_t (mem_dma_rsp_t)
+        .NarrowDataWidth(NarrowDataWidth),
+        .WideDataWidth(WideDataWidth),
+        .mem_narrow_req_t(mem_req_t),
+        .mem_narrow_rsp_t(mem_rsp_t),
+        .mem_wide_req_t(mem_dma_req_t),
+        .mem_wide_rsp_t(mem_dma_rsp_t)
     ) i_tcdm_mux (
-      .clk_i,
-      .rst_ni,
-      .in_narrow_req_i (ic_req [i]),
-      .in_narrow_rsp_o (ic_rsp [i]),
-      .in_wide_req_i (sb_dma_req [i]),
-      .in_wide_rsp_o (sb_dma_rsp [i]),
-      .out_req_o (amo_req),
-      .out_rsp_i (amo_rsp),
-      .sel_wide_i (sb_dma_req[i].q_valid)
+        .clk_i,
+        .rst_ni,
+        .in_narrow_req_i(ic_req[i]),
+        .in_narrow_rsp_o(ic_rsp[i]),
+        .in_wide_req_i(sb_dma_req[i]),
+        .in_wide_rsp_o(sb_dma_rsp[i]),
+        .out_req_o(amo_req),
+        .out_rsp_i(amo_rsp),
+        .sel_wide_i(sb_dma_req[i].q_valid)
     );
 
     // generate banks of the superbank
@@ -1020,37 +1012,42 @@ module snitch_cluster
 
       // TODO(zarubaf): Share atomic units between mutltiple cuts
       snitch_amo_shim #(
-        .AddrMemWidth ( TCDMMemAddrWidth ),
-        .DataWidth ( NarrowDataWidth ),
-        .CoreIDWidth ( CoreIDWidth )
+          .AddrMemWidth(TCDMMemAddrWidth),
+          .DataWidth(NarrowDataWidth),
+          .CoreIDWidth(CoreIDWidth)
       ) i_amo_shim (
-        .clk_i,
-        .rst_ni ( rst_ni ),
-        .valid_i ( amo_req[j].q_valid ),
-        .ready_o ( amo_rsp[j].q_ready ),
-        .addr_i ( amo_req[j].q.addr ),
-        .write_i ( amo_req[j].q.write ),
-        .wdata_i ( amo_req[j].q.data ),
-        .wstrb_i ( amo_req[j].q.strb ),
-        .core_id_i ( amo_req[j].q.user.core_id ),
-        .is_core_i ( amo_req[j].q.user.is_core ),
-        .rdata_o ( amo_rdata_local ),
-        .amo_i ( amo_req[j].q.amo ),
-        .mem_req_o ( mem_cs[i*BanksPerSuperBank+j] ),
-        .mem_add_o ( mem_add [i*BanksPerSuperBank+j]),
-        .mem_wen_o ( mem_wen[i*BanksPerSuperBank+j] ),
-        .mem_wdata_o ( mem_wdata[i*BanksPerSuperBank+j] ),
-        .mem_be_o ( mem_be[i*BanksPerSuperBank+j] ),
-        .mem_rdata_i ( mem_rdata[i*BanksPerSuperBank+j] ),
-        .dma_access_i ( sb_dma_req[i].q_valid ),
-        // TODO(zarubaf): Signal AMO conflict somewhere. Socregs?
-        .amo_conflict_o (  )
+          .clk_i,
+          .rst_ni(rst_ni),
+          .valid_i(amo_req[j].q_valid),
+          .ready_o(amo_rsp[j].q_ready),
+          .addr_i(amo_req[j].q.addr),
+          .write_i(amo_req[j].q.write),
+          .wdata_i(amo_req[j].q.data),
+          .wstrb_i(amo_req[j].q.strb),
+          .core_id_i(amo_req[j].q.user.core_id),
+          .is_core_i(amo_req[j].q.user.is_core),
+          .rdata_o(amo_rdata_local),
+          .amo_i(amo_req[j].q.amo),
+          .mem_req_o(mem_cs[i*BanksPerSuperBank+j]),
+          .mem_add_o(mem_add[i*BanksPerSuperBank+j]),
+          .mem_wen_o(mem_wen[i*BanksPerSuperBank+j]),
+          .mem_wdata_o(mem_wdata[i*BanksPerSuperBank+j]),
+          .mem_be_o(mem_be[i*BanksPerSuperBank+j]),
+          .mem_rdata_i(mem_rdata[i*BanksPerSuperBank+j]),
+          .dma_access_i(sb_dma_req[i].q_valid),
+          // TODO(zarubaf): Signal AMO conflict somewhere. Socregs?
+          .amo_conflict_o()
       );
 
       // Insert a pipeline register at the output of each SRAM.
-      shift_reg #( .dtype (data_t), .Depth (RegisterTCDMCuts)) i_sram_pipe (
-        .clk_i, .rst_ni,
-        .d_i (amo_rdata_local), .d_o (amo_rsp[j].p.data)
+      shift_reg #(
+          .dtype(data_t),
+          .Depth(RegisterTCDMCuts)
+      ) i_sram_pipe (
+          .clk_i,
+          .rst_ni,
+          .d_i(amo_rdata_local),
+          .d_o(amo_rsp[j].p.data)
       );
     end
   end
@@ -1058,54 +1055,52 @@ module snitch_cluster
   // generate TCDM for snax if any of the cores has SNAX enabled
   // Make ConnectSnaxAccWide a switcher for now that all accelerators connect to wide
   // if this happens
-  if( (TotalSnaxNarrowTcdmPorts > 0)) begin: gen_yes_snax_tcdm_interconnect
+  if ((TotalSnaxNarrowTcdmPorts > 0)) begin : gen_yes_snax_tcdm_interconnect
 
     snitch_tcdm_interconnect #(
-      .NumInp (NumTCDMIn + TotalSnaxNarrowTcdmPorts),
-      .NumOut (NrBanks),
-      .tcdm_req_t (tcdm_req_t),
-      .tcdm_rsp_t (tcdm_rsp_t),
-      .mem_req_t (mem_req_t),
-      .mem_rsp_t (mem_rsp_t),
-      .MemAddrWidth (TCDMMemAddrWidth),
-      .DataWidth (NarrowDataWidth),
-      .user_t (tcdm_user_t),
-      .MemoryResponseLatency (1 + RegisterTCDMCuts),
-      .Radix (Radix),
-      .Topology (Topology)
+        .NumInp(NumTCDMIn + TotalSnaxNarrowTcdmPorts),
+        .NumOut(NrBanks),
+        .tcdm_req_t(tcdm_req_t),
+        .tcdm_rsp_t(tcdm_rsp_t),
+        .mem_req_t(mem_req_t),
+        .mem_rsp_t(mem_rsp_t),
+        .MemAddrWidth(TCDMMemAddrWidth),
+        .DataWidth(NarrowDataWidth),
+        .user_t(tcdm_user_t),
+        .MemoryResponseLatency(1 + RegisterTCDMCuts),
+        .Radix(Radix),
+        .Topology(Topology)
     ) i_tcdm_interconnect (
-      .clk_i,
-      .rst_ni,
-      .req_i ({axi_soc_req,
-               tcdm_req,
-               snax_tcdm_req_narrow}),
-               //snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]}),
-      .rsp_o ({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_narrow}),
-      .mem_req_o (ic_req),
-      .mem_rsp_i (ic_rsp)
+        .clk_i,
+        .rst_ni,
+        .req_i({axi_soc_req, tcdm_req, snax_tcdm_req_narrow}),
+        //snax_tcdm_req_i[TotalSnaxTcdmPorts-1:TotalSnaxTcdmPorts-TotalSnaxNarrowTcdmPorts]}),
+        .rsp_o({axi_soc_rsp, tcdm_rsp, snax_tcdm_rsp_narrow}),
+        .mem_req_o(ic_req),
+        .mem_rsp_i(ic_rsp)
     );
-  end else begin: gen_no_snax_tcdm_interconnect
+  end else begin : gen_no_snax_tcdm_interconnect
 
     snitch_tcdm_interconnect #(
-      .NumInp (NumTCDMIn),
-      .NumOut (NrBanks),
-      .tcdm_req_t (tcdm_req_t),
-      .tcdm_rsp_t (tcdm_rsp_t),
-      .mem_req_t (mem_req_t),
-      .mem_rsp_t (mem_rsp_t),
-      .MemAddrWidth (TCDMMemAddrWidth),
-      .DataWidth (NarrowDataWidth),
-      .user_t (tcdm_user_t),
-      .MemoryResponseLatency (1 + RegisterTCDMCuts),
-      .Radix (Radix),
-      .Topology (Topology)
+        .NumInp(NumTCDMIn),
+        .NumOut(NrBanks),
+        .tcdm_req_t(tcdm_req_t),
+        .tcdm_rsp_t(tcdm_rsp_t),
+        .mem_req_t(mem_req_t),
+        .mem_rsp_t(mem_rsp_t),
+        .MemAddrWidth(TCDMMemAddrWidth),
+        .DataWidth(NarrowDataWidth),
+        .user_t(tcdm_user_t),
+        .MemoryResponseLatency(1 + RegisterTCDMCuts),
+        .Radix(Radix),
+        .Topology(Topology)
     ) i_tcdm_interconnect (
-      .clk_i,
-      .rst_ni,
-      .req_i ({axi_soc_req, tcdm_req}),
-      .rsp_o ({axi_soc_rsp, tcdm_rsp}),
-      .mem_req_o (ic_req),
-      .mem_rsp_i (ic_rsp)
+        .clk_i,
+        .rst_ni,
+        .req_i({axi_soc_req, tcdm_req}),
+        .rsp_o({axi_soc_rsp, tcdm_rsp}),
+        .mem_req_o(ic_req),
+        .mem_rsp_i(ic_rsp)
     );
   end
 
@@ -1113,62 +1108,62 @@ module snitch_cluster
 
   if (IsoCrossing) begin : gen_clk_divider
     snitch_clkdiv2 i_snitch_clkdiv2 (
-      .clk_i,
-      .test_mode_i (1'b0),
-      .bypass_i ( clk_d2_bypass_i ),
-      .clk_o (clk_d2)
+        .clk_i,
+        .test_mode_i(1'b0),
+        .bypass_i(clk_d2_bypass_i),
+        .clk_o(clk_d2)
     );
   end else begin : gen_no_clk_divider
     assign clk_d2 = clk_i;
   end
 
-  hive_req_t [NrCores-1:0] hive_req;
-  hive_rsp_t [NrCores-1:0] hive_rsp;
+  hive_req_t [NrCores-1:0]       hive_req;
+  hive_rsp_t [NrCores-1:0]       hive_rsp;
 
   //-------------------------------
   // SNAX Control Signals
   //-------------------------------
-  acc_req_t [NrCores-1:0]       snax_req;
-  logic     [NrCores-1:0]       snax_qvalid;
-  logic     [NrCores-1:0]       snax_qready;
+  acc_req_t  [NrCores-1:0]       snax_req;
+  logic      [NrCores-1:0]       snax_qvalid;
+  logic      [NrCores-1:0]       snax_qready;
 
   acc_resp_t [NrCores-1:0]       snax_resp;
-  logic     [NrCores-1:0]       snax_pvalid;
-  logic     [NrCores-1:0]       snax_pready;
+  logic      [NrCores-1:0]       snax_pvalid;
+  logic      [NrCores-1:0]       snax_pready;
 
-  logic     [NrCores-1:0][31:0] snax_csr_req_bits_data;
-  logic     [NrCores-1:0][31:0] snax_csr_req_bits_addr;
-  logic     [NrCores-1:0]       snax_csr_req_bits_write;
-  logic     [NrCores-1:0]       snax_csr_req_valid;
-  logic     [NrCores-1:0]       snax_csr_req_ready;
+  logic      [NrCores-1:0][31:0] snax_csr_req_bits_data;
+  logic      [NrCores-1:0][31:0] snax_csr_req_bits_addr;
+  logic      [NrCores-1:0]       snax_csr_req_bits_write;
+  logic      [NrCores-1:0]       snax_csr_req_valid;
+  logic      [NrCores-1:0]       snax_csr_req_ready;
 
-  logic     [NrCores-1:0][31:0] snax_csr_rsp_bits_data;
-  logic     [NrCores-1:0]       snax_csr_rsp_valid;
-  logic     [NrCores-1:0]       snax_csr_rsp_ready;
+  logic      [NrCores-1:0][31:0] snax_csr_rsp_bits_data;
+  logic      [NrCores-1:0]       snax_csr_rsp_valid;
+  logic      [NrCores-1:0]       snax_csr_rsp_ready;
 
   // Re-mapping of custom instruction ports
-  for (genvar i = 0; i < NrCores; i++) begin: gen_snax_control_connection
+  for (genvar i = 0; i < NrCores; i++) begin : gen_snax_control_connection
 
     // or CSR ports
-    if ( SnaxUseCustomPorts[i] ) begin: gen_snax_use_custom_ports
+    if (SnaxUseCustomPorts[i]) begin : gen_snax_use_custom_ports
 
       always_comb begin
         // SNAX Custom ports
         // Request
-        snax_req_o   [i] = snax_req     [i];
-        snax_qvalid_o[i] = snax_qvalid  [i];
-        snax_qready  [i] = snax_qready_i[i];
+        snax_req_o[i]                = snax_req[i];
+        snax_qvalid_o[i]             = snax_qvalid[i];
+        snax_qready[i]               = snax_qready_i[i];
         // Response
-        snax_resp    [i] = snax_resp_i  [i];
-        snax_pvalid  [i] = snax_pvalid_i[i];
-        snax_pready_o[i] = snax_pready  [i];
+        snax_resp[i]                 = snax_resp_i[i];
+        snax_pvalid[i]               = snax_pvalid_i[i];
+        snax_pready_o[i]             = snax_pready[i];
 
         // Unused SNAX CSR ports
         // Request
-        snax_csr_req_bits_data_o  [i] = '0;
-        snax_csr_req_bits_addr_o  [i] = '0;
-        snax_csr_req_bits_write_o [i] = '0;
-        snax_csr_req_valid_o      [i] = '0;
+        snax_csr_req_bits_data_o[i]  = '0;
+        snax_csr_req_bits_addr_o[i]  = '0;
+        snax_csr_req_bits_write_o[i] = '0;
+        snax_csr_req_valid_o[i]      = '0;
         // snax_csr_req_ready     = unconnected
 
         // Response
@@ -1177,71 +1172,71 @@ module snitch_cluster
         snax_csr_rsp_ready_o[i]      = '0;
       end
 
-    end else begin: gen_snax_use_csr_ports
+    end else begin : gen_snax_use_csr_ports
 
       always_comb begin
         // Unused SNAX Custom ports
         // Request
-        snax_req_o   [i] = '0;
-        snax_qvalid_o[i] = '0;
+        snax_req_o[i]                = '0;
+        snax_qvalid_o[i]             = '0;
         // snax_qready   = unconnected
         // Response
         // snax_resp     = unconnected
         // snax_pvalid   = unconnected
-        snax_pready_o[i] = '0;
+        snax_pready_o[i]             = '0;
 
         // SNAX CSR ports
         // Request
-        snax_csr_req_bits_data_o [i] = snax_csr_req_bits_data  [i];
-        snax_csr_req_bits_addr_o [i] = snax_csr_req_bits_addr  [i];
-        snax_csr_req_bits_write_o[i] = snax_csr_req_bits_write [i];
-        snax_csr_req_valid_o     [i] = snax_csr_req_valid      [i];
-        snax_csr_req_ready       [i] = snax_csr_req_ready_i    [i];
+        snax_csr_req_bits_data_o[i]  = snax_csr_req_bits_data[i];
+        snax_csr_req_bits_addr_o[i]  = snax_csr_req_bits_addr[i];
+        snax_csr_req_bits_write_o[i] = snax_csr_req_bits_write[i];
+        snax_csr_req_valid_o[i]      = snax_csr_req_valid[i];
+        snax_csr_req_ready[i]        = snax_csr_req_ready_i[i];
 
         // Response
-        snax_csr_rsp_bits_data   [i] = snax_csr_rsp_bits_data_i[i];
-        snax_csr_rsp_valid       [i] = snax_csr_rsp_valid_i    [i];
-        snax_csr_rsp_ready_o     [i] = snax_csr_rsp_ready      [i];
+        snax_csr_rsp_bits_data[i]    = snax_csr_rsp_bits_data_i[i];
+        snax_csr_rsp_valid[i]        = snax_csr_rsp_valid_i[i];
+        snax_csr_rsp_ready_o[i]      = snax_csr_rsp_ready[i];
       end
 
       snax_intf_translator #(
-        .acc_req_t     ( acc_req_t ),
-        .acc_rsp_t     ( acc_resp_t ),
-        // Careful! Sensitive parameter that depends
-        // On the offset of where the CSRs are placed
-        .CsrAddrOffset ( 32'h3c0   )
+          .acc_req_t    (acc_req_t),
+          .acc_rsp_t    (acc_resp_t),
+          // Careful! Sensitive parameter that depends
+          // On the offset of where the CSRs are placed
+          .CsrAddrOffset(32'h3c0)
       ) i_snax_intf_translator (
-        //-------------------------------
-        // Clocks and reset
-        //-------------------------------
-        .clk_i  ( clk_i ),
-        .rst_ni ( rst_ni),
-        //-------------------------------
-        // Request
-        //-------------------------------
-        .snax_req_i    ( snax_req   [i] ),
-        .snax_qvalid_i ( snax_qvalid[i] ),
-        .snax_qready_o ( snax_qready[i] ),
-        //-------------------------------
-        // Response
-        //-------------------------------
-        .snax_resp_o   ( snax_resp  [i] ),
-        .snax_pvalid_o ( snax_pvalid[i] ),
-        .snax_pready_i ( snax_pready[i] ),
-        //-----------------------------
-        // Simplified CSR control ports
-        //-----------------------------
-        // Request
-        .snax_csr_req_bits_data_o  ( snax_csr_req_bits_data [i] ),
-        .snax_csr_req_bits_addr_o  ( snax_csr_req_bits_addr [i] ),
-        .snax_csr_req_bits_write_o ( snax_csr_req_bits_write[i] ),
-        .snax_csr_req_valid_o      ( snax_csr_req_valid     [i] ),
-        .snax_csr_req_ready_i      ( snax_csr_req_ready     [i] ),
+          //-------------------------------
+          // Clocks and reset
+          //-------------------------------
+          .clk_i                    (clk_i),
+          .rst_ni                   (rst_ni),
+          //-------------------------------
+          // Request
+          //-------------------------------
+          .snax_req_i               (snax_req[i]),
+          .snax_qvalid_i            (snax_qvalid[i]),
+          .snax_qready_o            (snax_qready[i]),
+          //-------------------------------
+          // Response
+          //-------------------------------
+          .snax_resp_o              (snax_resp[i]),
+          .snax_pvalid_o            (snax_pvalid[i]),
+          .snax_pready_i            (snax_pready[i]),
+          //-----------------------------
+          // Simplified CSR control ports
+          //-----------------------------
+          // Request
+          .snax_csr_req_bits_data_o (snax_csr_req_bits_data[i]),
+          .snax_csr_req_bits_addr_o (snax_csr_req_bits_addr[i]),
+          .snax_csr_req_bits_write_o(snax_csr_req_bits_write[i]),
+          .snax_csr_req_valid_o     (snax_csr_req_valid[i]),
+          .snax_csr_req_ready_i     (snax_csr_req_ready[i]),
 
-        // Response
-        .snax_csr_rsp_bits_data_i  ( snax_csr_rsp_bits_data [i] ),
-        .snax_csr_rsp_valid_i      ( snax_csr_rsp_valid     [i] ),
-        .snax_csr_rsp_ready_o      ( snax_csr_rsp_ready     [i] )
+          // Response
+          .snax_csr_rsp_bits_data_i(snax_csr_rsp_bits_data[i]),
+          .snax_csr_rsp_valid_i    (snax_csr_rsp_valid[i]),
+          .snax_csr_rsp_ready_o    (snax_csr_rsp_ready[i])
       );
     end
   end
@@ -1251,179 +1246,203 @@ module snitch_cluster
     localparam int unsigned TcdmPorts = get_tcdm_ports(i);
     localparam int unsigned TcdmPortsOffs = get_tcdm_port_offs(i);
 
-    axi_mst_dma_req_t   axi_dma_req;
-    axi_mst_dma_resp_t  axi_dma_res;
-    interrupts_t irq;
-    dma_events_t        dma_core_events;
+    axi_mst_dma_req_t  axi_dma_req;
+    axi_mst_dma_resp_t axi_dma_res;
+    interrupts_t       irq;
+    dma_events_t       dma_core_events;
 
-    sync #(.STAGES (2))
-      i_sync_debug (.clk_i, .rst_ni, .serial_i (debug_req_i[i]), .serial_o (irq.debug));
-    sync #(.STAGES (2))
-      i_sync_meip  (.clk_i, .rst_ni, .serial_i (meip_i[i]), .serial_o (irq.meip));
-    sync #(.STAGES (2))
-      i_sync_mtip  (.clk_i, .rst_ni, .serial_i (mtip_i[i]), .serial_o (irq.mtip));
-    sync #(.STAGES (2))
-      i_sync_msip  (.clk_i, .rst_ni, .serial_i (msip_i[i]), .serial_o (irq.msip));
+    sync #(
+        .STAGES(2)
+    ) i_sync_debug (
+        .clk_i,
+        .rst_ni,
+        .serial_i(debug_req_i[i]),
+        .serial_o(irq.debug)
+    );
+    sync #(
+        .STAGES(2)
+    ) i_sync_meip (
+        .clk_i,
+        .rst_ni,
+        .serial_i(meip_i[i]),
+        .serial_o(irq.meip)
+    );
+    sync #(
+        .STAGES(2)
+    ) i_sync_mtip (
+        .clk_i,
+        .rst_ni,
+        .serial_i(mtip_i[i]),
+        .serial_o(irq.mtip)
+    );
+    sync #(
+        .STAGES(2)
+    ) i_sync_msip (
+        .clk_i,
+        .rst_ni,
+        .serial_i(msip_i[i]),
+        .serial_o(irq.msip)
+    );
     assign irq.mcip = cl_interrupt[i];
 
-      tcdm_req_t [TcdmPorts-1:0] tcdm_req_wo_user;
+    tcdm_req_t [TcdmPorts-1:0] tcdm_req_wo_user;
 
-      snitch_cc #(
-        .AddrWidth (PhysicalAddrWidth),
-        .DataWidth (NarrowDataWidth),
-        .DMADataWidth (WideDataWidth),
-        .DMAIdWidth (WideIdWidthIn),
-        .SnitchPMACfg (SnitchPMACfg),
-        .DMAAxiReqFifoDepth (DMAAxiReqFifoDepth),
-        .DMAReqFifoDepth (DMAReqFifoDepth),
-        .dreq_t (reqrsp_req_t),
-        .drsp_t (reqrsp_rsp_t),
-        .tcdm_req_t (tcdm_req_t),
-        .tcdm_rsp_t (tcdm_rsp_t),
-        .tcdm_user_t (tcdm_user_t),
-        .axi_req_t (axi_mst_dma_req_t),
-        .axi_rsp_t (axi_mst_dma_resp_t),
-        .hive_req_t (hive_req_t),
-        .hive_rsp_t (hive_rsp_t),
-        .acc_req_t (acc_req_t),
-        .acc_resp_t (acc_resp_t),
-        .dma_events_t (dma_events_t),
-        .RVE (RVE[i]),
-        .RVF (RVF[i]),
-        .RVD (RVD[i]),
-        .XDivSqrt (XDivSqrt[i]),
-        .XF16 (XF16[i]),
-        .XF16ALT (XF16ALT[i]),
-        .XF8 (XF8[i]),
-        .XF8ALT (XF8ALT[i]),
-        .XFVEC (XFVEC[i]),
-        .XFDOTP (XFDOTP[i]),
-        .Xdma (Xdma[i]),
-        .IsoCrossing (IsoCrossing),
-        .Xfrep (Xfrep[i]),
-        .Xssr (Xssr[i]),
-        .Xipu (1'b0),
-        .VMSupport (VMSupport),
-        .NumIntOutstandingLoads (NumIntOutstandingLoads[i]),
-        .NumIntOutstandingMem (NumIntOutstandingMem[i]),
-        .NumFPOutstandingLoads (NumFPOutstandingLoads[i]),
-        .NumFPOutstandingMem (NumFPOutstandingMem[i]),
-        .FPUImplementation (FPUImplementation[i]),
-        .NumDTLBEntries (NumDTLBEntries[i]),
-        .NumITLBEntries (NumITLBEntries[i]),
-        .NumSequencerInstr (NumSequencerInstr[i]),
-        .NumSsrs (NumSsrs[i]),
-        .SsrMuxRespDepth (SsrMuxRespDepth[i]),
-        .SsrCfgs (SsrCfgs[i][NumSsrs[i]-1:0]),
-        .SsrRegs (SsrRegs[i][NumSsrs[i]-1:0]),
-        .RegisterOffloadReq (RegisterOffloadReq),
-        .RegisterOffloadRsp (RegisterOffloadRsp),
-        .RegisterCoreReq (RegisterCoreReq),
-        .RegisterCoreRsp (RegisterCoreRsp),
-        .RegisterFPUReq (RegisterFPUReq),
-        .RegisterSequencer (RegisterSequencer),
-        .RegisterFPUIn (RegisterFPUIn),
-        .RegisterFPUOut (RegisterFPUOut),
-        .TCDMAddrWidth (TCDMAddrWidth),
-        .DebugSupport (DebugSupport)
-      ) i_snitch_cc (
+    snitch_cc #(
+        .AddrWidth(PhysicalAddrWidth),
+        .DataWidth(NarrowDataWidth),
+        .DMADataWidth(WideDataWidth),
+        .DMAIdWidth(WideIdWidthIn),
+        .SnitchPMACfg(SnitchPMACfg),
+        .DMAAxiReqFifoDepth(DMAAxiReqFifoDepth),
+        .DMAReqFifoDepth(DMAReqFifoDepth),
+        .dreq_t(reqrsp_req_t),
+        .drsp_t(reqrsp_rsp_t),
+        .tcdm_req_t(tcdm_req_t),
+        .tcdm_rsp_t(tcdm_rsp_t),
+        .tcdm_user_t(tcdm_user_t),
+        .axi_req_t(axi_mst_dma_req_t),
+        .axi_rsp_t(axi_mst_dma_resp_t),
+        .hive_req_t(hive_req_t),
+        .hive_rsp_t(hive_rsp_t),
+        .acc_req_t(acc_req_t),
+        .acc_resp_t(acc_resp_t),
+        .dma_events_t(dma_events_t),
+        .RVE(RVE[i]),
+        .RVF(RVF[i]),
+        .RVD(RVD[i]),
+        .XDivSqrt(XDivSqrt[i]),
+        .XF16(XF16[i]),
+        .XF16ALT(XF16ALT[i]),
+        .XF8(XF8[i]),
+        .XF8ALT(XF8ALT[i]),
+        .XFVEC(XFVEC[i]),
+        .XFDOTP(XFDOTP[i]),
+        .Xdma(Xdma[i]),
+        .IsoCrossing(IsoCrossing),
+        .Xfrep(Xfrep[i]),
+        .Xssr(Xssr[i]),
+        .Xipu(1'b0),
+        .VMSupport(VMSupport),
+        .NumIntOutstandingLoads(NumIntOutstandingLoads[i]),
+        .NumIntOutstandingMem(NumIntOutstandingMem[i]),
+        .NumFPOutstandingLoads(NumFPOutstandingLoads[i]),
+        .NumFPOutstandingMem(NumFPOutstandingMem[i]),
+        .FPUImplementation(FPUImplementation[i]),
+        .NumDTLBEntries(NumDTLBEntries[i]),
+        .NumITLBEntries(NumITLBEntries[i]),
+        .NumSequencerInstr(NumSequencerInstr[i]),
+        .NumSsrs(NumSsrs[i]),
+        .SsrMuxRespDepth(SsrMuxRespDepth[i]),
+        .SsrCfgs(SsrCfgs[i][NumSsrs[i]-1:0]),
+        .SsrRegs(SsrRegs[i][NumSsrs[i]-1:0]),
+        .RegisterOffloadReq(RegisterOffloadReq),
+        .RegisterOffloadRsp(RegisterOffloadRsp),
+        .RegisterCoreReq(RegisterCoreReq),
+        .RegisterCoreRsp(RegisterCoreRsp),
+        .RegisterFPUReq(RegisterFPUReq),
+        .RegisterSequencer(RegisterSequencer),
+        .RegisterFPUIn(RegisterFPUIn),
+        .RegisterFPUOut(RegisterFPUOut),
+        .TCDMAddrWidth(TCDMAddrWidth),
+        .DebugSupport(DebugSupport)
+    ) i_snitch_cc (
         .clk_i,
-        .clk_d2_i (clk_d2),
+        .clk_d2_i(clk_d2),
         .rst_ni,
-        .rst_int_ss_ni (1'b1),
-        .rst_fp_ss_ni (1'b1),
-        .hart_id_i (hart_base_id_i + i),
-        .cluster_core_id_i ({NrCores[15:0], i[15:0]}),
-        .hive_req_o (hive_req[i]),
-        .hive_rsp_i (hive_rsp[i]),
-        .boot_addr_i  (boot_addr_i),
-        .irq_i (irq),
-        .data_req_o (core_req[i]),
-        .data_rsp_i (core_rsp[i]),
-        .tcdm_req_o (tcdm_req_wo_user),
-        .tcdm_rsp_i (tcdm_rsp[TcdmPortsOffs+:TcdmPorts]),
-        .axi_dma_req_o (axi_dma_req),
-        .axi_dma_res_i (axi_dma_res),
-        .axi_dma_busy_o (),
-        .axi_dma_perf_o (),
-        .axi_dma_events_o (dma_core_events),
-        .snax_req_o (snax_req[i]),
-        .snax_qvalid_o (snax_qvalid[i]),
-        .snax_qready_i (snax_qready[i]),
-        .snax_resp_i (snax_resp[i]),
-        .snax_pvalid_i (snax_pvalid[i]),
-        .snax_pready_o (snax_pready[i]),
-        .core_events_o (core_events[i]),
-        .tcdm_addr_base_i (tcdm_start_address),
-        .obs_o (obs_signal[i]),
-        .snax_barrier_i (snax_barrier_i[i]),
-        .barrier_o (barrier_in[i]),
-        .barrier_i (barrier_out)
-      );
-      for (genvar j = 0; j < TcdmPorts; j++) begin : gen_tcdm_user
-        always_comb begin
-          tcdm_req[TcdmPortsOffs+j] = tcdm_req_wo_user[j];
-          tcdm_req[TcdmPortsOffs+j].q.user.core_id = i;
-          tcdm_req[TcdmPortsOffs+j].q.user.is_core = 1;
-        end
+        .rst_int_ss_ni(1'b1),
+        .rst_fp_ss_ni(1'b1),
+        .hart_id_i(hart_base_id_i + i),
+        .cluster_core_id_i({NrCores[15:0], i[15:0]}),
+        .hive_req_o(hive_req[i]),
+        .hive_rsp_i(hive_rsp[i]),
+        .boot_addr_i(boot_addr_i),
+        .irq_i(irq),
+        .data_req_o(core_req[i]),
+        .data_rsp_i(core_rsp[i]),
+        .tcdm_req_o(tcdm_req_wo_user),
+        .tcdm_rsp_i(tcdm_rsp[TcdmPortsOffs+:TcdmPorts]),
+        .axi_dma_req_o(axi_dma_req),
+        .axi_dma_res_i(axi_dma_res),
+        .axi_dma_busy_o(),
+        .axi_dma_perf_o(),
+        .axi_dma_events_o(dma_core_events),
+        .snax_req_o(snax_req[i]),
+        .snax_qvalid_o(snax_qvalid[i]),
+        .snax_qready_i(snax_qready[i]),
+        .snax_resp_i(snax_resp[i]),
+        .snax_pvalid_i(snax_pvalid[i]),
+        .snax_pready_o(snax_pready[i]),
+        .core_events_o(core_events[i]),
+        .tcdm_addr_base_i(tcdm_start_address),
+        .obs_o(obs_signal[i]),
+        .snax_barrier_i(snax_barrier_i[i]),
+        .barrier_o(barrier_in[i]),
+        .barrier_i(barrier_out)
+    );
+    for (genvar j = 0; j < TcdmPorts; j++) begin : gen_tcdm_user
+      always_comb begin
+        tcdm_req[TcdmPortsOffs+j] = tcdm_req_wo_user[j];
+        tcdm_req[TcdmPortsOffs+j].q.user.core_id = i;
+        tcdm_req[TcdmPortsOffs+j].q.user.is_core = 1;
       end
-      if (Xdma[i]) begin : gen_dma_connection
-        assign wide_axi_mst_req[SDMAMst] = axi_dma_req;
-        assign axi_dma_res = wide_axi_mst_rsp[SDMAMst];
-        assign dma_events = dma_core_events;
-      end
+    end
+    if (Xdma[i]) begin : gen_dma_connection
+      assign wide_axi_mst_req[SDMAMst] = axi_dma_req;
+      assign axi_dma_res = wide_axi_mst_rsp[SDMAMst];
+      assign dma_events = dma_core_events;
+    end
   end
 
   for (genvar i = 0; i < NrHives; i++) begin : gen_hive
-      localparam int unsigned HiveSize = get_hive_size(i);
+    localparam int unsigned HiveSize = get_hive_size(i);
 
-      hive_req_t [HiveSize-1:0] hive_req_reshape;
-      hive_rsp_t [HiveSize-1:0] hive_rsp_reshape;
+    hive_req_t [HiveSize-1:0] hive_req_reshape;
+    hive_rsp_t [HiveSize-1:0] hive_rsp_reshape;
 
-      snitch_icache_pkg::icache_l0_events_t [HiveSize-1:0] icache_events_reshape;
+    snitch_icache_pkg::icache_l0_events_t [HiveSize-1:0] icache_events_reshape;
 
-      for (genvar j = 0; j < NrCores; j++) begin : gen_hive_matrix
-        // Check whether the core actually belongs to the current hive.
-        if (Hive[j] == i) begin : gen_hive_connection
-          localparam int unsigned HivePosition = get_core_position(i, j);
-          assign hive_req_reshape[HivePosition] = hive_req[j];
-          assign hive_rsp[j] = hive_rsp_reshape[HivePosition];
-          assign icache_events[j] = icache_events_reshape[HivePosition];
-        end
+    for (genvar j = 0; j < NrCores; j++) begin : gen_hive_matrix
+      // Check whether the core actually belongs to the current hive.
+      if (Hive[j] == i) begin : gen_hive_connection
+        localparam int unsigned HivePosition = get_core_position(i, j);
+        assign hive_req_reshape[HivePosition] = hive_req[j];
+        assign hive_rsp[j] = hive_rsp_reshape[HivePosition];
+        assign icache_events[j] = icache_events_reshape[HivePosition];
       end
+    end
 
-      snitch_hive #(
-        .AddrWidth (PhysicalAddrWidth),
-        .NarrowDataWidth (NarrowDataWidth),
-        .WideDataWidth (WideDataWidth),
-        .VMSupport (VMSupport),
-        .dreq_t (reqrsp_req_t),
-        .drsp_t (reqrsp_rsp_t),
-        .hive_req_t (hive_req_t),
-        .hive_rsp_t (hive_rsp_t),
-        .CoreCount (HiveSize),
-        .ICacheLineWidth (ICacheLineWidth[i]),
-        .ICacheLineCount (ICacheLineCount[i]),
-        .ICacheSets (ICacheSets[i]),
-        .IsoCrossing (IsoCrossing),
-        .sram_cfg_t  (sram_cfg_t),
-        .sram_cfgs_t (sram_cfgs_t),
-        .axi_req_t (axi_mst_dma_req_t),
-        .axi_rsp_t (axi_mst_dma_resp_t)
-      ) i_snitch_hive (
+    snitch_hive #(
+        .AddrWidth(PhysicalAddrWidth),
+        .NarrowDataWidth(NarrowDataWidth),
+        .WideDataWidth(WideDataWidth),
+        .VMSupport(VMSupport),
+        .dreq_t(reqrsp_req_t),
+        .drsp_t(reqrsp_rsp_t),
+        .hive_req_t(hive_req_t),
+        .hive_rsp_t(hive_rsp_t),
+        .CoreCount(HiveSize),
+        .ICacheLineWidth(ICacheLineWidth[i]),
+        .ICacheLineCount(ICacheLineCount[i]),
+        .ICacheSets(ICacheSets[i]),
+        .IsoCrossing(IsoCrossing),
+        .sram_cfg_t(sram_cfg_t),
+        .sram_cfgs_t(sram_cfgs_t),
+        .axi_req_t(axi_mst_dma_req_t),
+        .axi_rsp_t(axi_mst_dma_resp_t)
+    ) i_snitch_hive (
         .clk_i,
-        .clk_d2_i (clk_d2),
+        .clk_d2_i(clk_d2),
         .rst_ni,
-        .hive_req_i (hive_req_reshape),
-        .hive_rsp_o (hive_rsp_reshape),
-        .ptw_data_req_o (ptw_req[i]),
-        .ptw_data_rsp_i (ptw_rsp[i]),
-        .axi_req_o (wide_axi_mst_req[ICache+i]),
-        .axi_rsp_i (wide_axi_mst_rsp[ICache+i]),
-        .icache_prefetch_enable_i (icache_prefetch_enable),
+        .hive_req_i(hive_req_reshape),
+        .hive_rsp_o(hive_rsp_reshape),
+        .ptw_data_req_o(ptw_req[i]),
+        .ptw_data_rsp_i(ptw_rsp[i]),
+        .axi_req_o(wide_axi_mst_req[ICache+i]),
+        .axi_rsp_i(wide_axi_mst_rsp[ICache+i]),
+        .icache_prefetch_enable_i(icache_prefetch_enable),
         .icache_events_o(icache_events_reshape),
         .sram_cfgs_i
-      );
+    );
   end
 
   // --------
@@ -1433,37 +1452,37 @@ module snitch_cluster
   reqrsp_rsp_t ptw_to_axi_rsp;
 
   reqrsp_mux #(
-    .NrPorts (NrHives),
-    .AddrWidth (PhysicalAddrWidth),
-    .DataWidth (NarrowDataWidth),
-    .req_t (reqrsp_req_t),
-    .rsp_t (reqrsp_rsp_t),
-    .RespDepth (2)
+      .NrPorts(NrHives),
+      .AddrWidth(PhysicalAddrWidth),
+      .DataWidth(NarrowDataWidth),
+      .req_t(reqrsp_req_t),
+      .rsp_t(reqrsp_rsp_t),
+      .RespDepth(2)
   ) i_reqrsp_mux_ptw (
-    .clk_i,
-    .rst_ni,
-    .slv_req_i (ptw_req),
-    .slv_rsp_o (ptw_rsp),
-    .mst_req_o (ptw_to_axi_req),
-    .mst_rsp_i (ptw_to_axi_rsp),
-    .idx_o (/*not connected*/)
+      .clk_i,
+      .rst_ni,
+      .slv_req_i(ptw_req),
+      .slv_rsp_o(ptw_rsp),
+      .mst_req_o(ptw_to_axi_req),
+      .mst_rsp_i(ptw_to_axi_rsp),
+      .idx_o(  /*not connected*/)
   );
 
   reqrsp_to_axi #(
-    .DataWidth (NarrowDataWidth),
-    .UserWidth (NarrowUserWidth),
-    .reqrsp_req_t (reqrsp_req_t),
-    .reqrsp_rsp_t (reqrsp_rsp_t),
-    .axi_req_t (axi_mst_req_t),
-    .axi_rsp_t (axi_mst_resp_t)
+      .DataWidth(NarrowDataWidth),
+      .UserWidth(NarrowUserWidth),
+      .reqrsp_req_t(reqrsp_req_t),
+      .reqrsp_rsp_t(reqrsp_rsp_t),
+      .axi_req_t(axi_mst_req_t),
+      .axi_rsp_t(axi_mst_resp_t)
   ) i_reqrsp_to_axi_ptw (
-    .clk_i,
-    .rst_ni,
-    .user_i ('0),
-    .reqrsp_req_i (ptw_to_axi_req),
-    .reqrsp_rsp_o (ptw_to_axi_rsp),
-    .axi_req_o (narrow_axi_mst_req[PTW]),
-    .axi_rsp_i (narrow_axi_mst_rsp[PTW])
+      .clk_i,
+      .rst_ni,
+      .user_i('0),
+      .reqrsp_req_i(ptw_to_axi_req),
+      .reqrsp_rsp_o(ptw_to_axi_rsp),
+      .axi_req_o(narrow_axi_mst_req[PTW]),
+      .axi_rsp_i(narrow_axi_mst_rsp[PTW])
   );
 
   // --------
@@ -1471,12 +1490,12 @@ module snitch_cluster
   // --------
 
   snitch_barrier #(
-    .NrCores(NrCores)
+      .NrCores(NrCores)
   ) i_snitch_barrier (
-    .clk_i,
-    .rst_ni,
-    .barrier_i(barrier_in),
-    .barrier_o(barrier_out)
+      .clk_i,
+      .rst_ni,
+      .barrier_i(barrier_in),
+      .barrier_o(barrier_out)
   );
 
   reqrsp_req_t core_to_axi_req;
@@ -1484,107 +1503,104 @@ module snitch_cluster
   user_t cluster_user;
   // Atomic ID, needs to be unique ID of cluster
   // cluster_id + HartIdOffset + 1 (because 0 is for non-atomic masters)
-  assign cluster_user = (hart_base_id_i / NrCores) +  (hart_base_id_i % NrCores) + 1'b1;
+  assign cluster_user = (hart_base_id_i / NrCores) + (hart_base_id_i % NrCores) + 1'b1;
 
   reqrsp_mux #(
-    .NrPorts (NrCores),
-    .AddrWidth (PhysicalAddrWidth),
-    .DataWidth (NarrowDataWidth),
-    .req_t (reqrsp_req_t),
-    .rsp_t (reqrsp_rsp_t),
-    .RespDepth (2)
+      .NrPorts(NrCores),
+      .AddrWidth(PhysicalAddrWidth),
+      .DataWidth(NarrowDataWidth),
+      .req_t(reqrsp_req_t),
+      .rsp_t(reqrsp_rsp_t),
+      .RespDepth(2)
   ) i_reqrsp_mux_core (
-    .clk_i,
-    .rst_ni,
-    .slv_req_i (core_req),
-    .slv_rsp_o (core_rsp),
-    .mst_req_o (core_to_axi_req),
-    .mst_rsp_i (core_to_axi_rsp),
-    .idx_o (/*unused*/)
+      .clk_i,
+      .rst_ni,
+      .slv_req_i(core_req),
+      .slv_rsp_o(core_rsp),
+      .mst_req_o(core_to_axi_req),
+      .mst_rsp_i(core_to_axi_rsp),
+      .idx_o(  /*unused*/)
   );
 
   reqrsp_to_axi #(
-    .DataWidth (NarrowDataWidth),
-    .UserWidth (NarrowUserWidth),
-    .reqrsp_req_t (reqrsp_req_t),
-    .reqrsp_rsp_t (reqrsp_rsp_t),
-    .axi_req_t (axi_mst_req_t),
-    .axi_rsp_t (axi_mst_resp_t)
+      .DataWidth(NarrowDataWidth),
+      .UserWidth(NarrowUserWidth),
+      .reqrsp_req_t(reqrsp_req_t),
+      .reqrsp_rsp_t(reqrsp_rsp_t),
+      .axi_req_t(axi_mst_req_t),
+      .axi_rsp_t(axi_mst_resp_t)
   ) i_reqrsp_to_axi_core (
-    .clk_i,
-    .rst_ni,
-    .user_i (cluster_user),
-    .reqrsp_req_i (core_to_axi_req),
-    .reqrsp_rsp_o (core_to_axi_rsp),
-    .axi_req_o (narrow_axi_mst_req[CoreReq]),
-    .axi_rsp_i (narrow_axi_mst_rsp[CoreReq])
+      .clk_i,
+      .rst_ni,
+      .user_i(cluster_user),
+      .reqrsp_req_i(core_to_axi_req),
+      .reqrsp_rsp_o(core_to_axi_rsp),
+      .axi_req_o(narrow_axi_mst_req[CoreReq]),
+      .axi_rsp_i(narrow_axi_mst_rsp[CoreReq])
   );
 
-  logic [ClusterXbarCfg.NoSlvPorts-1:0][$clog2(ClusterXbarCfg.NoMstPorts)-1:0]
-    cluster_xbar_default_port;
+  logic [ClusterXbarCfg.NoSlvPorts-1:0][$clog2(
+ClusterXbarCfg.NoMstPorts
+)-1:0] cluster_xbar_default_port;
   xbar_rule_t [NrRules-1:0] cluster_xbar_rules;
 
   assign cluster_xbar_rules = '{
-    '{
-      idx:        TCDM,
-      start_addr: tcdm_start_address,
-      end_addr:   tcdm_end_address
-    },
-    '{
-      idx:        ClusterPeripherals,
-      start_addr: cluster_periph_start_address,
-      end_addr:   cluster_periph_end_address
-    }
-  };
+          '{idx: TCDM, start_addr: tcdm_start_address, end_addr: tcdm_end_address},
+          '{
+              idx: ClusterPeripherals,
+              start_addr: cluster_periph_start_address,
+              end_addr: cluster_periph_end_address
+          }
+      };
 
   localparam bit [ClusterXbarCfg.NoSlvPorts-1:0] ClusterEnableDefaultMstPort = '1;
   axi_xbar #(
-    .Cfg (ClusterXbarCfg),
-    .slv_aw_chan_t (axi_mst_aw_chan_t),
-    .mst_aw_chan_t (axi_slv_aw_chan_t),
-    .w_chan_t (axi_mst_w_chan_t),
-    .slv_b_chan_t (axi_mst_b_chan_t),
-    .mst_b_chan_t (axi_slv_b_chan_t),
-    .slv_ar_chan_t (axi_mst_ar_chan_t),
-    .mst_ar_chan_t (axi_slv_ar_chan_t),
-    .slv_r_chan_t (axi_mst_r_chan_t),
-    .mst_r_chan_t (axi_slv_r_chan_t),
-    .slv_req_t (axi_mst_req_t),
-    .slv_resp_t (axi_mst_resp_t),
-    .mst_req_t (axi_slv_req_t),
-    .mst_resp_t (axi_slv_resp_t),
-    .rule_t (xbar_rule_t)
+      .Cfg(ClusterXbarCfg),
+      .slv_aw_chan_t(axi_mst_aw_chan_t),
+      .mst_aw_chan_t(axi_slv_aw_chan_t),
+      .w_chan_t(axi_mst_w_chan_t),
+      .slv_b_chan_t(axi_mst_b_chan_t),
+      .mst_b_chan_t(axi_slv_b_chan_t),
+      .slv_ar_chan_t(axi_mst_ar_chan_t),
+      .mst_ar_chan_t(axi_slv_ar_chan_t),
+      .slv_r_chan_t(axi_mst_r_chan_t),
+      .mst_r_chan_t(axi_slv_r_chan_t),
+      .slv_req_t(axi_mst_req_t),
+      .slv_resp_t(axi_mst_resp_t),
+      .mst_req_t(axi_slv_req_t),
+      .mst_resp_t(axi_slv_resp_t),
+      .rule_t(xbar_rule_t)
   ) i_cluster_xbar (
-    .clk_i,
-    .rst_ni,
-    .test_i (1'b0),
-    .slv_ports_req_i (narrow_axi_mst_req),
-    .slv_ports_resp_o (narrow_axi_mst_rsp),
-    .mst_ports_req_o (narrow_axi_slv_req),
-    .mst_ports_resp_i (narrow_axi_slv_rsp),
-    .addr_map_i (cluster_xbar_rules),
-    .en_default_mst_port_i (ClusterEnableDefaultMstPort),
-    .default_mst_port_i (cluster_xbar_default_port)
+      .clk_i,
+      .rst_ni,
+      .test_i(1'b0),
+      .slv_ports_req_i(narrow_axi_mst_req),
+      .slv_ports_resp_o(narrow_axi_mst_rsp),
+      .mst_ports_req_o(narrow_axi_slv_req),
+      .mst_ports_resp_i(narrow_axi_slv_rsp),
+      .addr_map_i(cluster_xbar_rules),
+      .en_default_mst_port_i(ClusterEnableDefaultMstPort),
+      .default_mst_port_i(cluster_xbar_default_port)
   );
   assign cluster_xbar_default_port = '{default: SoC};
 
   // Optionally decouple the external narrow AXI slave port.
   axi_cut #(
-    .Bypass (!RegisterExtNarrow),
-    .aw_chan_t (axi_mst_aw_chan_t),
-    .w_chan_t (axi_mst_w_chan_t),
-    .b_chan_t (axi_mst_b_chan_t),
-    .ar_chan_t (axi_mst_ar_chan_t),
-    .r_chan_t (axi_mst_r_chan_t),
-    .axi_req_t (axi_mst_req_t),
-    .axi_resp_t (axi_mst_resp_t)
+      .Bypass(!RegisterExtNarrow),
+      .aw_chan_t(axi_mst_aw_chan_t),
+      .w_chan_t(axi_mst_w_chan_t),
+      .b_chan_t(axi_mst_b_chan_t),
+      .ar_chan_t(axi_mst_ar_chan_t),
+      .r_chan_t(axi_mst_r_chan_t),
+      .axi_req_t(axi_mst_req_t),
+      .axi_resp_t(axi_mst_resp_t)
   ) i_cut_ext_narrow_slv (
-    .clk_i,
-    .rst_ni,
-    .slv_req_i (narrow_in_req_i),
-    .slv_resp_o (narrow_in_resp_o),
-    .mst_req_o (narrow_axi_mst_req[AXISoC]),
-    .mst_resp_i (narrow_axi_mst_rsp[AXISoC])
+      .clk_i,
+      .rst_ni,
+      .slv_req_i (narrow_in_req_i),
+      .slv_resp_o(narrow_in_resp_o),
+      .mst_req_o (narrow_axi_mst_req[AXISoC]),
+      .mst_resp_i(narrow_axi_mst_rsp[AXISoC])
   );
 
   // ---------
@@ -1593,110 +1609,110 @@ module snitch_cluster
   // 1. TCDM
   // Add an adapter that allows access from AXI to the TCDM.
   axi_to_tcdm #(
-    .axi_req_t (axi_slv_req_t),
-    .axi_rsp_t (axi_slv_resp_t),
-    .tcdm_req_t (tcdm_req_t),
-    .tcdm_rsp_t (tcdm_rsp_t),
-    .AddrWidth (PhysicalAddrWidth),
-    .DataWidth (NarrowDataWidth),
-    .IdWidth (NarrowIdWidthOut),
-    .BufDepth (MemoryMacroLatency + 1)
+      .axi_req_t(axi_slv_req_t),
+      .axi_rsp_t(axi_slv_resp_t),
+      .tcdm_req_t(tcdm_req_t),
+      .tcdm_rsp_t(tcdm_rsp_t),
+      .AddrWidth(PhysicalAddrWidth),
+      .DataWidth(NarrowDataWidth),
+      .IdWidth(NarrowIdWidthOut),
+      .BufDepth(MemoryMacroLatency + 1)
   ) i_axi_to_tcdm (
-    .clk_i,
-    .rst_ni,
-    .axi_req_i (narrow_axi_slv_req[TCDM]),
-    .axi_rsp_o (narrow_axi_slv_rsp[TCDM]),
-    .tcdm_req_o (axi_soc_req),
-    .tcdm_rsp_i (axi_soc_rsp)
+      .clk_i,
+      .rst_ni,
+      .axi_req_i (narrow_axi_slv_req[TCDM]),
+      .axi_rsp_o (narrow_axi_slv_rsp[TCDM]),
+      .tcdm_req_o(axi_soc_req),
+      .tcdm_rsp_i(axi_soc_rsp)
   );
 
   // 2. Peripherals
   axi_to_reg #(
-    .ADDR_WIDTH (PhysicalAddrWidth),
-    .DATA_WIDTH (NarrowDataWidth),
-    .AXI_MAX_WRITE_TXNS (1),
-    .AXI_MAX_READ_TXNS (1),
-    .DECOUPLE_W (1),
-    .ID_WIDTH (NarrowIdWidthOut),
-    .USER_WIDTH (NarrowUserWidth),
-    .axi_req_t (axi_slv_req_t),
-    .axi_rsp_t (axi_slv_resp_t),
-    .reg_req_t (reg_req_t),
-    .reg_rsp_t (reg_rsp_t)
+      .ADDR_WIDTH(PhysicalAddrWidth),
+      .DATA_WIDTH(NarrowDataWidth),
+      .AXI_MAX_WRITE_TXNS(1),
+      .AXI_MAX_READ_TXNS(1),
+      .DECOUPLE_W(1),
+      .ID_WIDTH(NarrowIdWidthOut),
+      .USER_WIDTH(NarrowUserWidth),
+      .axi_req_t(axi_slv_req_t),
+      .axi_rsp_t(axi_slv_resp_t),
+      .reg_req_t(reg_req_t),
+      .reg_rsp_t(reg_rsp_t)
   ) i_axi_to_reg (
-    .clk_i,
-    .rst_ni,
-    .testmode_i (1'b0),
-    .axi_req_i (narrow_axi_slv_req[ClusterPeripherals]),
-    .axi_rsp_o (narrow_axi_slv_rsp[ClusterPeripherals]),
-    .reg_req_o (reg_req),
-    .reg_rsp_i (reg_rsp)
+      .clk_i,
+      .rst_ni,
+      .testmode_i(1'b0),
+      .axi_req_i (narrow_axi_slv_req[ClusterPeripherals]),
+      .axi_rsp_o (narrow_axi_slv_rsp[ClusterPeripherals]),
+      .reg_req_o (reg_req),
+      .reg_rsp_i (reg_rsp)
   );
 
   snitch_cluster_peripheral #(
-    .AddrWidth (PhysicalAddrWidth),
-    .reg_req_t (reg_req_t),
-    .reg_rsp_t (reg_rsp_t),
-    .tcdm_events_t (tcdm_events_t),
-    .dma_events_t (dma_events_t),
-    .NrCores (NrCores)
+      .AddrWidth(PhysicalAddrWidth),
+      .reg_req_t(reg_req_t),
+      .reg_rsp_t(reg_rsp_t),
+      .tcdm_events_t(tcdm_events_t),
+      .dma_events_t(dma_events_t),
+      .NrCores(NrCores)
   ) i_snitch_cluster_peripheral (
-    .clk_i,
-    .rst_ni,
-    .reg_req_i (reg_req),
-    .reg_rsp_o (reg_rsp),
-    /// The TCDM always starts at the cluster base.
-    .tcdm_start_address_i (tcdm_start_address),
-    .tcdm_end_address_i (tcdm_end_address),
-    .icache_prefetch_enable_o (icache_prefetch_enable),
-    .cl_clint_o (cl_interrupt),
-    .cluster_hart_base_id_i (hart_base_id_i),
-    .core_events_i (core_events),
-    .tcdm_events_i (tcdm_events),
-    .dma_events_i (dma_events),
-    .icache_events_i (icache_events)
+      .clk_i,
+      .rst_ni,
+      .reg_req_i(reg_req),
+      .reg_rsp_o(reg_rsp),
+      /// The TCDM always starts at the cluster base.
+      .tcdm_start_address_i(tcdm_start_address),
+      .tcdm_end_address_i(tcdm_end_address),
+      .icache_prefetch_enable_o(icache_prefetch_enable),
+      .cl_clint_o(cl_interrupt),
+      .cluster_hart_base_id_i(hart_base_id_i),
+      .core_events_i(core_events),
+      .tcdm_events_i(tcdm_events),
+      .dma_events_i(dma_events),
+      .icache_events_i(icache_events)
   );
 
   // Optionally decouple the external narrow AXI master ports.
   axi_cut #(
-    .Bypass     ( !RegisterExtNarrow ),
-    .aw_chan_t  ( axi_slv_aw_chan_t ),
-    .w_chan_t   ( axi_slv_w_chan_t ),
-    .b_chan_t   ( axi_slv_b_chan_t ),
-    .ar_chan_t  ( axi_slv_ar_chan_t ),
-    .r_chan_t   ( axi_slv_r_chan_t ),
-    .axi_req_t  ( axi_slv_req_t ),
-    .axi_resp_t ( axi_slv_resp_t )
+      .Bypass    (!RegisterExtNarrow),
+      .aw_chan_t (axi_slv_aw_chan_t),
+      .w_chan_t  (axi_slv_w_chan_t),
+      .b_chan_t  (axi_slv_b_chan_t),
+      .ar_chan_t (axi_slv_ar_chan_t),
+      .r_chan_t  (axi_slv_r_chan_t),
+      .axi_req_t (axi_slv_req_t),
+      .axi_resp_t(axi_slv_resp_t)
   ) i_cut_ext_narrow_mst (
-    .clk_i      ( clk_i           ),
-    .rst_ni     ( rst_ni          ),
-    .slv_req_i  ( narrow_axi_slv_req[SoC] ),
-    .slv_resp_o ( narrow_axi_slv_rsp[SoC] ),
-    .mst_req_o  ( narrow_out_req_o   ),
-    .mst_resp_i ( narrow_out_resp_i   )
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .slv_req_i (narrow_axi_slv_req[SoC]),
+      .slv_resp_o(narrow_axi_slv_rsp[SoC]),
+      .mst_req_o (narrow_out_req_o),
+      .mst_resp_i(narrow_out_resp_i)
   );
 
   // --------------------
   // TCDM event counters
   // --------------------
   logic [NrTCDMPortsCores-1:0] flat_acc, flat_con;
-  for (genvar i = 0; i < NrTCDMPortsCores; i++) begin  : gen_event_counter
+  for (genvar i = 0; i < NrTCDMPortsCores; i++) begin : gen_event_counter
     `FFARN(flat_acc[i], tcdm_req[i].q_valid, '0, clk_i, rst_ni)
     `FFARN(flat_con[i], tcdm_req[i].q_valid & ~tcdm_rsp[i].q_ready, '0, clk_i, rst_ni)
   end
 
   popcount #(
-    .INPUT_WIDTH ( NrTCDMPortsCores )
+      .INPUT_WIDTH(NrTCDMPortsCores)
   ) i_popcount_req (
-    .data_i      ( flat_acc                  ),
-    .popcount_o  ( tcdm_events.inc_accessed  )
+      .data_i    (flat_acc),
+      .popcount_o(tcdm_events.inc_accessed)
   );
 
   popcount #(
-    .INPUT_WIDTH ( NrTCDMPortsCores )
+      .INPUT_WIDTH(NrTCDMPortsCores)
   ) i_popcount_con (
-    .data_i      ( flat_con                  ),
-    .popcount_o  ( tcdm_events.inc_congested )
+      .data_i    (flat_con),
+      .popcount_o(tcdm_events.inc_congested)
   );
 
   // -------------

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -510,7 +510,7 @@ module snitch_cluster
   // The MMIO is at the end of each cluster
   addr_t xdma_mmio_start_address, xdma_mmio_end_address;
   assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024  -
-                                   ClusterPeriphSize * 1024;
+                                   ClusterMMIOSize * 1024;
   assign xdma_mmio_end_address = cluster_base_addr_i + ClusterAddrSpace * 1024;
 
   // ----------------

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -509,7 +509,8 @@ module snitch_cluster
 
   // The MMIO is at the end of each cluster
   addr_t xdma_mmio_start_address, xdma_mmio_end_address;
-  assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024 - ClusterMMIOSize * 1024;
+  assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024  -
+                                   ClusterPeriphSize * 1024;
   assign xdma_mmio_end_address = cluster_base_addr_i + ClusterAddrSpace * 1024;
 
   // ----------------

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -509,7 +509,7 @@ module snitch_cluster
 
   // The MMIO is at the end of each cluster
   addr_t xdma_mmio_start_address, xdma_mmio_end_address;
-  assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024 - ClusterMMIOSize * 1024
+  assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024 - ClusterMMIOSize * 1024;
   assign xdma_mmio_end_address = cluster_base_addr_i + ClusterAddrSpace * 1024 ;
 
   // ----------------
@@ -637,7 +637,7 @@ module snitch_cluster
       idx:        XDMAOut,
       start_addr: xdma_mmio_start_address,
       end_addr:   xdma_mmio_end_address
-    },    
+    }
   };
   localparam bit [DmaXbarCfg.NoSlvPorts-1:0] DMAEnableDefaultMstPort = '1;
   axi_xbar #(

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -617,8 +617,8 @@ module snitch_cluster
   // XDMA Ports
   // -------------
   assign xdma_wide_out_req_o = wide_axi_slv_req[XDMAOut];
-  assign xdma_wide_out_resp_i = wide_axi_slv_rsp[XDMAOut];
-  assign xdma_wide_in_req_i = wide_axi_mst_req[XDMAIn];
+  assign wide_axi_slv_rsp[XDMAOut] = xdma_wide_out_resp_i;
+  assign wide_axi_mst_req[XDMAIn] = xdma_wide_in_req_i;
   assign xdma_wide_in_resp_o = wide_axi_mst_rsp[XDMAIn];
   // -------------
   // DMA XBAR Rule

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -555,6 +555,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .NrCores (${cfg['nr_cores']}),
     .TCDMDepth (${cfg['pkg_name']}::TCDMDepth),
     .ClusterPeriphSize (${cfg['cluster_periph_size']}),
+    .ClusterMMIOSize(${cfg['mmio_size']}),
     .ClusterAddrSpace (${cfg['cluster_base_offset']/1024}),
     .NrBanks (${cfg['pkg_name']}::NrBanks),
     .DMAAxiReqFifoDepth (${cfg['dma_axi_req_fifo_depth']}),

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -554,7 +554,6 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .NrHives (${cfg['nr_hives']}),
     .NrCores (${cfg['nr_cores']}),
     .TCDMDepth (${cfg['pkg_name']}::TCDMDepth),
-    .ZeroMemorySize (${cfg['zero_mem_size']}),
     .ClusterPeriphSize (${cfg['cluster_periph_size']}),
     .ClusterAddrSpace (${cfg['cluster_base_offset']/1024}),
     .NrBanks (${cfg['pkg_name']}::NrBanks),
@@ -937,6 +936,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
   ${cfg['name']}_xdma_wrapper # (
     .tcdm_req_t       ( ${cfg['pkg_name']}::tcdm_req_t     ),
     .tcdm_rsp_t       ( ${cfg['pkg_name']}::tcdm_rsp_t     ),
+    .wide_slv_id_t    ( ${cfg['pkg_name']}::wide_out_id_t  ),
     .wide_out_req_t   ( ${cfg['pkg_name']}::wide_out_req_t ),
     .wide_out_resp_t  ( ${cfg['pkg_name']}::wide_out_resp_t),
     .wide_in_req_t    ( ${cfg['pkg_name']}::wide_in_req_t  ),

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -556,7 +556,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .TCDMDepth (${cfg['pkg_name']}::TCDMDepth),
     .ClusterPeriphSize (${cfg['cluster_periph_size']}),
     .ClusterMMIOSize(${cfg['mmio_size']}),
-    .ClusterAddrSpace (${cfg['cluster_base_offset']/1024}),
+    .ClusterAddrSpace (${int(cfg['cluster_base_offset']/1024)}),
     .NrBanks (${cfg['pkg_name']}::NrBanks),
     .DMAAxiReqFifoDepth (${cfg['dma_axi_req_fifo_depth']}),
     .DMAReqFifoDepth (${cfg['dma_req_fifo_depth']}),
@@ -941,7 +941,10 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .wide_out_req_t   ( ${cfg['pkg_name']}::wide_in_req_t ),
     .wide_out_resp_t  ( ${cfg['pkg_name']}::wide_in_resp_t),
     .wide_in_req_t    ( ${cfg['pkg_name']}::wide_out_req_t  ),
-    .wide_in_resp_t   ( ${cfg['pkg_name']}::wide_out_resp_t )
+    .wide_in_resp_t   ( ${cfg['pkg_name']}::wide_out_resp_t ),
+    .ClusterBaseAddr  ( ${cfg['pkg_name']}::ClusterBaseAddr),
+    .ClusterAddressSpace(${to_sv_hex(cfg['cluster_base_offset'], cfg['addr_width'])}),
+    .MMIOSize(${cfg['mmio_size']})
   ) ${jdx_key}  (
     //-----------------------------
     // Clock and reset

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -78,7 +78,7 @@ package ${cfg['name']}_pkg;
   localparam int unsigned NrMasters = 3;
   localparam int unsigned NarrowIdWidthOut = $clog2(NrMasters) + NarrowIdWidthIn;
 
-  localparam int unsigned NrDmaMasters = 2 + ${cfg['nr_hives']};
+  localparam int unsigned NrDmaMasters = 3 + ${cfg['nr_hives']};
   localparam int unsigned WideIdWidthIn = ${cfg['dma_id_width_in']};
   localparam int unsigned WideIdWidthOut = $clog2(NrDmaMasters) + WideIdWidthIn;
 
@@ -522,6 +522,18 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
   //-----------------------------
   logic [${cfg['pkg_name']}::NrCores-1:0] snax_barrier;
 
+% if snax_xdma_flag:
+  //-----------------------------
+  // XDMA Wire
+  //-----------------------------
+  ${cfg['pkg_name']}::wide_out_req_t xdma_wide_out_req;
+  ${cfg['pkg_name']}::wide_out_resp_t xdma_wide_out_resp;
+  ${cfg['pkg_name']}::wide_in_req_t xdma_wide_in_req;
+  ${cfg['pkg_name']}::wide_in_resp_t xdma_wide_in_resp;
+%endif
+
+
+
   // Snitch cluster under test.
   snitch_cluster #(
     .PhysicalAddrWidth (${cfg['addr_width']}),
@@ -544,6 +556,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .TCDMDepth (${cfg['pkg_name']}::TCDMDepth),
     .ZeroMemorySize (${cfg['zero_mem_size']}),
     .ClusterPeriphSize (${cfg['cluster_periph_size']}),
+    .ClusterAddrSpace (${cfg['cluster_base_offset']/1024}),
     .NrBanks (${cfg['pkg_name']}::NrBanks),
     .DMAAxiReqFifoDepth (${cfg['dma_axi_req_fifo_depth']}),
     .DMAReqFifoDepth (${cfg['dma_req_fifo_depth']}),
@@ -710,6 +723,20 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .narrow_in_resp_o   ( narrow_in_resp_o  ),
     .narrow_out_req_o   ( narrow_out_req_o  ),
     .narrow_out_resp_i  ( narrow_out_resp_i ),
+    //-----------------------------
+    // XDMA
+    //-----------------------------
+% if snax_xdma_flag:
+    .xdma_wide_out_req_o  (xdma_wide_out_req ),
+    .xdma_wide_out_resp_i (xdma_wide_out_resp),
+    .xdma_wide_in_req_i   (xdma_wide_in_req  ),
+    .xdma_wide_in_resp_o  (xdma_wide_in_resp ),
+% else:
+    .xdma_wide_out_req_o  (                  ),
+    .xdma_wide_out_resp_i ('0                ),
+    .xdma_wide_in_req_i   ('0                ),
+    .xdma_wide_in_resp_o  (                  ),    
+%endif
     //-----------------------------
     // Wide AXI ports
     //-----------------------------
@@ -908,8 +935,12 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     % for jdx, jdx_key in enumerate(snax_core_acc[idx_key]['snax_acc_dict']):
   // Instantiation of xdma wrapper
   ${cfg['name']}_xdma_wrapper # (
-    .tcdm_req_t       ( ${cfg['pkg_name']}::tcdm_req_t ),
-    .tcdm_rsp_t       ( ${cfg['pkg_name']}::tcdm_rsp_t )
+    .tcdm_req_t       ( ${cfg['pkg_name']}::tcdm_req_t     ),
+    .tcdm_rsp_t       ( ${cfg['pkg_name']}::tcdm_rsp_t     ),
+    .wide_out_req_t   ( ${cfg['pkg_name']}::wide_out_req_t ),
+    .wide_out_resp_t  ( ${cfg['pkg_name']}::wide_out_resp_t),
+    .wide_in_req_t    ( ${cfg['pkg_name']}::wide_in_req_t  ),
+    .wide_in_resp_t   ( ${cfg['pkg_name']}::wide_in_resp_t )
   ) ${jdx_key}  (
     //-----------------------------
     // Clock and reset
@@ -936,6 +967,14 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     //-----------------------------
     // Hardware barrier is not supported by xdma at the moment
     //-----------------------------
+
+    //-----------------------------
+    // XDMA Intercluster Ports
+    //-----------------------------
+    .xdma_wide_out_req_o (xdma_wide_in_req  ),
+    .xdma_wide_out_resp_i(xdma_wide_in_resp ),
+    .xdma_wide_in_req_i  (xdma_wide_out_req ),
+    .xdma_wide_in_resp_o (xdma_wide_out_resp),
     //-----------------------------
     // TCDM ports
     //-----------------------------

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -937,10 +937,10 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     .tcdm_req_t       ( ${cfg['pkg_name']}::tcdm_req_t     ),
     .tcdm_rsp_t       ( ${cfg['pkg_name']}::tcdm_rsp_t     ),
     .wide_slv_id_t    ( ${cfg['pkg_name']}::wide_out_id_t  ),
-    .wide_out_req_t   ( ${cfg['pkg_name']}::wide_out_req_t ),
-    .wide_out_resp_t  ( ${cfg['pkg_name']}::wide_out_resp_t),
-    .wide_in_req_t    ( ${cfg['pkg_name']}::wide_in_req_t  ),
-    .wide_in_resp_t   ( ${cfg['pkg_name']}::wide_in_resp_t )
+    .wide_out_req_t   ( ${cfg['pkg_name']}::wide_in_req_t ),
+    .wide_out_resp_t  ( ${cfg['pkg_name']}::wide_in_resp_t),
+    .wide_in_req_t    ( ${cfg['pkg_name']}::wide_out_req_t  ),
+    .wide_in_resp_t   ( ${cfg['pkg_name']}::wide_out_resp_t )
   ) ${jdx_key}  (
     //-----------------------------
     // Clock and reset

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -121,7 +121,8 @@ import xdma_pkg::*;
   ///---------------------------------------------------------------
   // XDMA Intercluster Signals
   ///---------------------------------------------------------------
-
+  xdma_pkg::data_t                   xdma_to_remote_cfg_bits;
+  xdma_pkg::data_t                   xdma_from_remote_cfg_bits;
   ///---------------------
   /// TO REMOTE
   ///---------------------
@@ -167,6 +168,8 @@ import xdma_pkg::*;
   ///---------------------------------------------------------------
   // Assign Signals
   ///---------------------------------------------------------------
+  assign xdma_to_remote_cfg = xdma_pkg::xdma_inter_cluster_cfg_t'(xdma_to_remote_cfg_bits);
+  assign xdma_from_remote_cfg_bits = xdma_pkg::data_t'(xdma_from_remote_cfg);
   assign xdma_to_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
     dma_id:            xdma_to_remote_data_accompany_cfg_dma_id,
     dma_type:          xdma_to_remote_data_accompany_cfg_dma_type,
@@ -286,11 +289,11 @@ import xdma_pkg::*;
     // 512 bit Cfg
     .io_remoteXDMACfg_fromRemote_valid                         (xdma_from_remote_cfg_valid),
     .io_remoteXDMACfg_fromRemote_ready                         (xdma_from_remote_cfg_ready),
-    .io_remoteXDMACfg_fromRemote_bits                          (xdma_from_remote_cfg),
+    .io_remoteXDMACfg_fromRemote_bits                          (xdma_from_remote_cfg_bits ),
 
-    .io_remoteXDMACfg_toRemote_ready                           (xdma_to_remote_cfg_ready),
-    .io_remoteXDMACfg_toRemote_valid                           (xdma_to_remote_cfg_valid),
-    .io_remoteXDMACfg_toRemote_bits                            (xdma_to_remote_cfg      )
+    .io_remoteXDMACfg_toRemote_ready                           (xdma_to_remote_cfg_ready  ),
+    .io_remoteXDMACfg_toRemote_valid                           (xdma_to_remote_cfg_valid  ),
+    .io_remoteXDMACfg_toRemote_bits                            (xdma_to_remote_cfg_bits   )
   );
 
 

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -163,8 +163,10 @@ import xdma_pkg::*;
   xdma_pkg::addr_t                   xdma_from_remote_data_accompany_cfg_dst_addr;
   xdma_pkg::len_t                    xdma_from_remote_data_accompany_cfg_dma_length;
   logic                              xdma_from_remote_data_accompany_cfg_ready_to_transfer;
-
-
+  ///---------------------
+  /// FINISH
+  ///---------------------
+  logic                              xdma_finish;
   ///---------------------------------------------------------------
   // Assign Signals
   ///---------------------------------------------------------------
@@ -248,25 +250,25 @@ import xdma_pkg::*;
     //-----------------------------
 
     // RemoteTask finished Pin
-    .io_remoteTaskFinished('0),
+    .io_remoteTaskFinished                                     (xdma_finish                ),
 
     // fromRemote data
     .io_remoteXDMAData_fromRemote_valid                        (xdma_from_remote_data_valid),
     .io_remoteXDMAData_fromRemote_ready                        (xdma_from_remote_data_ready),
-    .io_remoteXDMAData_fromRemote_bits                         (xdma_from_remote_data),
+    .io_remoteXDMAData_fromRemote_bits                         (xdma_from_remote_data      ),
 
     // fromRemote Accompanied Cfg
     // readyToTransfer = 0 -> 1: XDMA is ready for the next task
     .io_remoteXDMAData_fromRemoteAccompaniedCfg_readyToTransfer(xdma_from_remote_data_accompany_cfg_ready_to_transfer),
     // taskID: 8 bit signal to track each tasks
-    .io_remoteXDMAData_fromRemoteAccompaniedCfg_taskID         (xdma_from_remote_data_accompany_cfg_dma_id),
+    .io_remoteXDMAData_fromRemoteAccompaniedCfg_taskID         (xdma_from_remote_data_accompany_cfg_dma_id           ),
     // length: 19 bit signal to indicate the total number of beats in this task
-    .io_remoteXDMAData_fromRemoteAccompaniedCfg_length         (xdma_from_remote_data_accompany_cfg_dma_length),
+    .io_remoteXDMAData_fromRemoteAccompaniedCfg_length         (xdma_from_remote_data_accompany_cfg_dma_length       ),
     // taskType: 1 is Local Write, Remote Read; 0 is Local Read, Remote Write
-    .io_remoteXDMAData_fromRemoteAccompaniedCfg_taskType       (xdma_from_remote_data_accompany_cfg_dma_type),
+    .io_remoteXDMAData_fromRemoteAccompaniedCfg_taskType       (xdma_from_remote_data_accompany_cfg_dma_type         ),
     // Addresses: 48 bit signal to indicate the src and dst of the task
-    .io_remoteXDMAData_fromRemoteAccompaniedCfg_src            (xdma_from_remote_data_accompany_cfg_src_addr),
-    .io_remoteXDMAData_fromRemoteAccompaniedCfg_dst            (xdma_from_remote_data_accompany_cfg_dst_addr),
+    .io_remoteXDMAData_fromRemoteAccompaniedCfg_src            (xdma_from_remote_data_accompany_cfg_src_addr         ),
+    .io_remoteXDMAData_fromRemoteAccompaniedCfg_dst            (xdma_from_remote_data_accompany_cfg_dst_addr         ),
 
     // toRemote data
     .io_remoteXDMAData_toRemote_ready                          (xdma_to_remote_data_ready),
@@ -322,34 +324,36 @@ import xdma_pkg::*;
     ) i_xdma_axi_adapter (
         .clk_i                           (clk_i),
         .rst_ni                          (rst_ni),
-        .cluster_base_addr_i             (cluster_base_addr_i),
+        .cluster_base_addr_i             (cluster_base_addr_i                ),
         // To remote cfg
-        .to_remote_cfg_i                 (xdma_to_remote_cfg),
-        .to_remote_cfg_valid_i           (xdma_to_remote_cfg_valid),
-        .to_remote_cfg_ready_o           (xdma_to_remote_cfg_ready),
+        .to_remote_cfg_i                 (xdma_to_remote_cfg                 ),
+        .to_remote_cfg_valid_i           (xdma_to_remote_cfg_valid           ),
+        .to_remote_cfg_ready_o           (xdma_to_remote_cfg_ready           ),
         // to remote data
-        .to_remote_data_i                (xdma_to_remote_data),
-        .to_remote_data_valid_i          (xdma_to_remote_data_valid),
-        .to_remote_data_ready_o          (xdma_to_remote_data_ready),
+        .to_remote_data_i                (xdma_to_remote_data                ),
+        .to_remote_data_valid_i          (xdma_to_remote_data_valid          ),
+        .to_remote_data_ready_o          (xdma_to_remote_data_ready          ),
         // to remote data accompany cfg
-        .to_remote_data_accompany_cfg_i  (xdma_to_remote_data_accompany_cfg),
+        .to_remote_data_accompany_cfg_i  (xdma_to_remote_data_accompany_cfg  ),
         // from remote cfg
-        .from_remote_cfg_o               (xdma_from_remote_cfg),
-        .from_remote_cfg_last_o          (xdma_from_remote_cfg_last),
-        .from_remote_cfg_valid_o         (xdma_from_remote_cfg_valid),
-        .from_remote_cfg_ready_i         (xdma_from_remote_cfg_ready),
+        .from_remote_cfg_o               (xdma_from_remote_cfg               ),
+        .from_remote_cfg_last_o          (xdma_from_remote_cfg_last          ),
+        .from_remote_cfg_valid_o         (xdma_from_remote_cfg_valid         ),
+        .from_remote_cfg_ready_i         (xdma_from_remote_cfg_ready         ),
         // from remote data
-        .from_remote_data_o              (xdma_from_remote_data),
-        .from_remote_data_last_o         (xdma_from_remote_data_last),
-        .from_remote_data_valid_o        (xdma_from_remote_data_valid),
-        .from_remote_data_ready_i        (xdma_from_remote_data_ready),
+        .from_remote_data_o              (xdma_from_remote_data              ),
+        .from_remote_data_last_o         (xdma_from_remote_data_last         ),
+        .from_remote_data_valid_o        (xdma_from_remote_data_valid        ),
+        .from_remote_data_ready_i        (xdma_from_remote_data_ready        ),
         // from remote data accompany cfg
         .from_remote_data_accompany_cfg_i(xdma_from_remote_data_accompany_cfg),
+        // finish
+        .xdma_finish_o                   (xdma_finish                        ),
         // AXI interface
-        .axi_xdma_wide_out_req_o         (xdma_wide_out_req_o ),
-        .axi_xdma_wide_out_resp_i        (xdma_wide_out_resp_i),
-        .axi_xdma_wide_in_req_i          (xdma_wide_in_req_i  ),
-        .axi_xdma_wide_in_resp_o         (xdma_wide_in_resp_o )
+        .axi_xdma_wide_out_req_o         (xdma_wide_out_req_o                ),
+        .axi_xdma_wide_out_resp_i        (xdma_wide_out_resp_i               ),
+        .axi_xdma_wide_in_req_i          (xdma_wide_in_req_i                 ),
+        .axi_xdma_wide_in_resp_o         (xdma_wide_in_resp_o                )
     );
 
 

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -62,10 +62,10 @@ import xdma_pkg::*;
   //-----------------------------
   // XDMA Intercluster Ports
   //-----------------------------
-  wide_out_req_t      xdma_wide_out_req_o,
-  wide_out_resp_t     xdma_wide_out_resp_i,
-  wide_in_req_t       xdma_wide_in_req_i,
-  wide_in_resp_t      xdma_wide_in_resp_o
+  output wide_out_req_t      xdma_wide_out_req_o,
+  input  wide_out_resp_t     xdma_wide_out_resp_i,
+  input  wide_in_req_t       xdma_wide_in_req_i,
+  output wide_in_resp_t      xdma_wide_in_resp_o
 );
   
   //-----------------------------

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -147,12 +147,10 @@ import xdma_pkg::*;
   ///---------------------
   // from remote cfg
   xdma_pkg::xdma_inter_cluster_cfg_t xdma_from_remote_cfg;
-  logic                              xdma_from_remote_cfg_last;
   logic                              xdma_from_remote_cfg_valid;
   logic                              xdma_from_remote_cfg_ready;
   // from remote data
   xdma_pkg::xdma_from_remote_data_t  xdma_from_remote_data;
-  logic                              xdma_from_remote_data_last;
   logic                              xdma_from_remote_data_valid;
   logic                              xdma_from_remote_data_ready;
   // from remote data accompany cfg
@@ -337,12 +335,10 @@ import xdma_pkg::*;
         .to_remote_data_accompany_cfg_i  (xdma_to_remote_data_accompany_cfg  ),
         // from remote cfg
         .from_remote_cfg_o               (xdma_from_remote_cfg               ),
-        .from_remote_cfg_last_o          (xdma_from_remote_cfg_last          ),
         .from_remote_cfg_valid_o         (xdma_from_remote_cfg_valid         ),
         .from_remote_cfg_ready_i         (xdma_from_remote_cfg_ready         ),
         // from remote data
         .from_remote_data_o              (xdma_from_remote_data              ),
-        .from_remote_data_last_o         (xdma_from_remote_data_last         ),
         .from_remote_data_valid_o        (xdma_from_remote_data_valid        ),
         .from_remote_data_ready_i        (xdma_from_remote_data_ready        ),
         // from remote data accompany cfg

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -328,7 +328,7 @@ import xdma_pkg::*;
         .ClusterBaseAddr                      (ClusterBaseAddr),
         .ClusterAddressSpace                  (ClusterAddressSpace),
         .MainMemBaseAddr                      (MainMemBaseAddr),
-        .MainMemEndAddr                       (MainMemEndAddr)
+        .MainMemEndAddr                       (MainMemEndAddr),
         .MMIOSize                             (MMIOSize)
     ) i_xdma_axi_adapter (
         .clk_i                           (clk_i),

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -16,18 +16,20 @@
 module ${cfg["name"]}_xdma_wrapper
 import xdma_pkg::*;
 #(
+  // Address width
+  parameter int unsigned PhysicalAddrWidth = cfg["addr_width"],
   // TCDM typedefs
-  parameter type         tcdm_req_t    = logic,
-  parameter type         tcdm_rsp_t    = logic,
+  parameter type         tcdm_req_t        = logic,
+  parameter type         tcdm_rsp_t        = logic,
   // AXI type
-  parameter type         wide_out_req_t  = logic,
-  parameter type         wide_out_resp_t = logic,
-  parameter type         wide_in_req_t   = logic,
-  parameter type         wide_in_resp_t  = logic,
+  parameter type         wide_out_req_t    = logic,
+  parameter type         wide_out_resp_t   = logic,
+  parameter type         wide_in_req_t     = logic,
+  parameter type         wide_in_resp_t    = logic,
   // Parameters related to TCDM
-  parameter int unsigned TCDMDataWidth = ${cfg["data_width"]},
-  parameter int unsigned TCDMNumPorts  = ${num_tcdm_ports},
-  parameter int unsigned TCDMAddrWidth = ${tcdm_addr_width}
+  parameter int unsigned TCDMDataWidth     = ${cfg["data_width"]},
+  parameter int unsigned TCDMNumPorts      = ${num_tcdm_ports},
+  parameter int unsigned TCDMAddrWidth     = ${tcdm_addr_width}
 )(
   //-----------------------------
   // Clocks and reset
@@ -129,7 +131,7 @@ import xdma_pkg::*;
   // to remote data
   xdma_pkg::xdma_to_remote_data_t    xdma_to_remote_data;
   logic                              xdma_to_remote_data_valid;
-  logic                              xdma_to_remote_data_ready
+  logic                              xdma_to_remote_data_ready;
   // to remote accompany cfg
   xdma_pkg::xdma_accompany_cfg_t     xdma_to_remote_data_accompany_cfg;
   xdma_pkg::id_t                     xdma_to_remote_data_accompany_cfg_dma_id;
@@ -152,7 +154,7 @@ import xdma_pkg::*;
   logic                              xdma_from_remote_data_valid;
   logic                              xdma_from_remote_data_ready;
   // from remote data accompany cfg
-  xdma_pkg::xdma_accompany_cfg_t     xdma_from_remote_data_accompany_cfg
+  xdma_pkg::xdma_accompany_cfg_t     xdma_from_remote_data_accompany_cfg;
   xdma_pkg::id_t                     xdma_from_remote_data_accompany_cfg_dma_id;
   logic                              xdma_from_remote_data_accompany_cfg_dma_type;
   xdma_pkg::addr_t                   xdma_from_remote_data_accompany_cfg_src_addr;
@@ -164,7 +166,7 @@ import xdma_pkg::*;
   ///---------------------------------------------------------------
   // Assign Signals
   ///---------------------------------------------------------------
-  xdma_to_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
+  assign xdma_to_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
     dma_id:            xdma_to_remote_data_accompany_cfg_dma_id,
     dma_type:          xdma_to_remote_data_accompany_cfg_dma_type,
     src_addr:          xdma_to_remote_data_accompany_cfg_src_addr,
@@ -172,7 +174,7 @@ import xdma_pkg::*;
     dma_length:        xdma_to_remote_data_accompany_cfg_dma_length,
     ready_to_transfer: xdma_to_remote_data_accompany_cfg_ready_to_transfer
   }
-  xdma_from_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
+  assign xdma_from_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
     dma_id:            xdma_from_remote_data_accompany_cfg_dma_id,
     dma_type:          xdma_from_remote_data_accompany_cfg_dma_type,
     src_addr:          xdma_from_remote_data_accompany_cfg_src_addr,
@@ -316,7 +318,7 @@ import xdma_pkg::*;
     ) i_xdma_axi_adapter (
         .clk_i                           (clk),
         .rst_ni                          (rst_n),
-        .cluster_base_addr_i             (xdma_pkg::ClusterBaseAddr),
+        .cluster_base_addr_i             (cluster_base_addr_i),
         // To remote cfg
         .to_remote_cfg_i                 (xdma_to_remote_cfg),
         .to_remote_cfg_valid_i           (xdma_to_remote_cfg_valid),

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -17,7 +17,7 @@ module ${cfg["name"]}_xdma_wrapper
 import xdma_pkg::*;
 #(
   // Address width
-  parameter int unsigned PhysicalAddrWidth = cfg["addr_width"],
+  parameter int unsigned PhysicalAddrWidth = ${cfg["addr_width"]},
   // TCDM typedefs
   parameter type         tcdm_req_t        = logic,
   parameter type         tcdm_rsp_t        = logic,

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -317,8 +317,8 @@ import xdma_pkg::*;
         .xdma_from_remote_data_t              (xdma_pkg::xdma_from_remote_data_t ),
         .xdma_from_remote_data_accompany_cfg_t(xdma_pkg::xdma_accompany_cfg_t    )
     ) i_xdma_axi_adapter (
-        .clk_i                           (clk),
-        .rst_ni                          (rst_n),
+        .clk_i                           (clk_i),
+        .rst_ni                          (rst_ni),
         .cluster_base_addr_i             (cluster_base_addr_i),
         // To remote cfg
         .to_remote_cfg_i                 (xdma_to_remote_cfg),

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -22,6 +22,7 @@ import xdma_pkg::*;
   parameter type         tcdm_req_t        = logic,
   parameter type         tcdm_rsp_t        = logic,
   // AXI type
+  parameter type         wide_slv_id_t     = logic,
   parameter type         wide_out_req_t    = logic,
   parameter type         wide_out_resp_t   = logic,
   parameter type         wide_in_req_t     = logic,
@@ -173,7 +174,7 @@ import xdma_pkg::*;
     dst_addr:          xdma_to_remote_data_accompany_cfg_dst_addr,
     dma_length:        xdma_to_remote_data_accompany_cfg_dma_length,
     ready_to_transfer: xdma_to_remote_data_accompany_cfg_ready_to_transfer
-  }
+  };
   assign xdma_from_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
     dma_id:            xdma_from_remote_data_accompany_cfg_dma_id,
     dma_type:          xdma_from_remote_data_accompany_cfg_dma_type,
@@ -181,7 +182,7 @@ import xdma_pkg::*;
     dst_addr:          xdma_from_remote_data_accompany_cfg_dst_addr,
     dma_length:        xdma_from_remote_data_accompany_cfg_dma_length,
     ready_to_transfer: xdma_from_remote_data_accompany_cfg_ready_to_transfer
-  }
+  };
 
   // Streamer module that is generated
   // with template mechanics
@@ -294,27 +295,27 @@ import xdma_pkg::*;
 
 
     xdma_axi_adapter_top #(
-        .axi_id_t       (id_dma_slv_t),
-        .axi_out_req_t  (axi_mst_dma_req_t ),
-        .axi_out_resp_t (axi_mst_dma_resp_t),
-        .axi_in_req_t   (axi_slv_dma_req_t ),
-        .axi_in_resp_t  (axi_slv_dma_resp_t),
-        .reqrsp_req_t   (xdma_pkg::reqrsp_req_t),
-        .reqrsp_rsp_t   (xdma_pkg::reqrsp_rsp_t),
-        .data_t         (xdma_pkg::data_t),
-        .strb_t         (xdma_pkg::strb_t),
-        .addr_t         (xdma_pkg::addr_t),
-        .len_t          (xdma_pkg::len_t),
-        .xdma_to_remote_cfg_t (xdma_pkg::xdma_inter_cluster_cfg_t),
-        .xdma_to_remote_data_t(xdma_pkg::xdma_to_remote_data_t),
-        .xdma_to_remote_data_accompany_cfg_t(xdma_pkg::xdma_accompany_cfg_t),
-        .xdma_req_desc_t(xdma_pkg::xdma_req_desc_t),
-        .xdma_req_meta_t(xdma_pkg::xdma_req_meta_t),
-        .xdma_to_remote_grant_t(xdma_pkg::xdma_to_remote_grant_t),
-        .xdma_from_remote_grant_t(xdma_pkg::xdma_from_remote_grant_t),
-        .xdma_from_remote_cfg_t(xdma_pkg::xdma_inter_cluster_cfg_t),
-        .xdma_from_remote_data_t(xdma_pkg::xdma_from_remote_data_t),
-        .xdma_from_remote_data_accompany_cfg_t(xdma_pkg::xdma_accompany_cfg_t)
+        .axi_id_t                             (wide_slv_id_t                     ),
+        .axi_out_req_t                        (wide_out_req_t                    ),
+        .axi_out_resp_t                       (wide_out_resp_t                   ),
+        .axi_in_req_t                         (wide_in_req_t                     ),
+        .axi_in_resp_t                        (wide_in_resp_t                    ),
+        .reqrsp_req_t                         (xdma_pkg::reqrsp_req_t            ),
+        .reqrsp_rsp_t                         (xdma_pkg::reqrsp_rsp_t            ),
+        .data_t                               (xdma_pkg::data_t                  ),
+        .strb_t                               (xdma_pkg::strb_t                  ),
+        .addr_t                               (xdma_pkg::addr_t                  ),
+        .len_t                                (xdma_pkg::len_t                   ),
+        .xdma_to_remote_cfg_t                 (xdma_pkg::xdma_inter_cluster_cfg_t),
+        .xdma_to_remote_data_t                (xdma_pkg::xdma_to_remote_data_t   ),
+        .xdma_to_remote_data_accompany_cfg_t  (xdma_pkg::xdma_accompany_cfg_t    ),
+        .xdma_req_desc_t                      (xdma_pkg::xdma_req_desc_t         ),
+        .xdma_req_meta_t                      (xdma_pkg::xdma_req_meta_t         ),
+        .xdma_to_remote_grant_t               (xdma_pkg::xdma_to_remote_grant_t  ),
+        .xdma_from_remote_grant_t             (xdma_pkg::xdma_from_remote_grant_t),
+        .xdma_from_remote_cfg_t               (xdma_pkg::xdma_inter_cluster_cfg_t),
+        .xdma_from_remote_data_t              (xdma_pkg::xdma_from_remote_data_t ),
+        .xdma_from_remote_data_accompany_cfg_t(xdma_pkg::xdma_accompany_cfg_t    )
     ) i_xdma_axi_adapter (
         .clk_i                           (clk),
         .rst_ni                          (rst_n),

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -30,7 +30,13 @@ import xdma_pkg::*;
   // Parameters related to TCDM
   parameter int unsigned TCDMDataWidth     = ${cfg["data_width"]},
   parameter int unsigned TCDMNumPorts      = ${num_tcdm_ports},
-  parameter int unsigned TCDMAddrWidth     = ${tcdm_addr_width}
+  parameter int unsigned TCDMAddrWidth     = ${tcdm_addr_width},
+  // Cluster Addr
+  parameter logic [PhysicalAddrWidth-1:0]  ClusterBaseAddr = 48'h1000_0000,
+  parameter logic [PhysicalAddrWidth-1:0]  ClusterAddressSpace = 48'h0010_0000,
+  parameter logic [PhysicalAddrWidth-1:0]  MainMemBaseAddr = 48'h8000_0000,
+  parameter logic [PhysicalAddrWidth-1:0]  MainMemEndAddr = 48'h1_0000_0000,
+  parameter int                            MMIOSize = 16
 )(
   //-----------------------------
   // Clocks and reset
@@ -318,7 +324,12 @@ import xdma_pkg::*;
         .xdma_from_remote_grant_t             (xdma_pkg::xdma_from_remote_grant_t),
         .xdma_from_remote_cfg_t               (xdma_pkg::xdma_inter_cluster_cfg_t),
         .xdma_from_remote_data_t              (xdma_pkg::xdma_from_remote_data_t ),
-        .xdma_from_remote_data_accompany_cfg_t(xdma_pkg::xdma_accompany_cfg_t    )
+        .xdma_from_remote_data_accompany_cfg_t(xdma_pkg::xdma_accompany_cfg_t    ),
+        .ClusterBaseAddr                      (ClusterBaseAddr),
+        .ClusterAddressSpace                  (ClusterAddressSpace),
+        .MainMemBaseAddr                      (MainMemBaseAddr),
+        .MainMemEndAddr                       (MainMemEndAddr)
+        .MMIOSize                             (MMIOSize)
     ) i_xdma_axi_adapter (
         .clk_i                           (clk_i),
         .rst_ni                          (rst_ni),

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -59,34 +59,6 @@ static inline void snrt_init_tls() {
         }
     }
 
-    // // To avoid contentions in main memory, and take advantage of the
-    // // bandwidth of the DMA, the DM core initializes the TLS section
-    // // for every core in a cluster.
-    // if (snrt_is_dm_core()) {
-    //     size = (size_t)(&__tdata_end) - (size_t)(&__tdata_start);
-
-    //     // First initialize the DM core's .tdata section from main memory
-    //     asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
-    //     snrt_dma_start_1d((void *)tls_ptr, (void *)(&__tdata_start), size);
-
-    //     // Then initialize all other cores' .tdata sections from the DM
-    //     // core's. The offset between the TLS section of successive cores
-    //     // is defined in start.S
-    //     size_t tls_offset = (1 << SNRT_LOG2_STACK_SIZE) + 8;
-    //     for (int i = 1; i < snrt_cluster_core_num(); i++) {
-    //         snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
-    //                           (void *)tls_ptr, size);
-    //     }
-
-    //     // Initialize all cores' .tbss sections
-    //     tls_ptr += size;
-    //     size = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
-    //     for (int i = 0; i < snrt_cluster_core_num(); i++) {
-    //         snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
-    //                           (void *)(snrt_zero_memory_ptr()), size);
-    //     }
-    // }
-
     snrt_cluster_hw_barrier();
 }
 #endif
@@ -106,11 +78,6 @@ static inline void snrt_init_bss() {
             *p = 0U; 
         }
     }
-    // if (snrt_cluster_idx() == 0 && snrt_is_dm_core()) {
-    //     size_t size = (size_t)(&__bss_end) - (size_t)(&__bss_start);
-    //     snrt_dma_start_1d((void *)(&__bss_start),
-    //                       (void *)(snrt_zero_memory_ptr()), size);
-    // }
 }
 #endif
 
@@ -142,20 +109,6 @@ static inline void snrt_init_cls() {
         }
 
     }
-    // // Only one core per cluster has to do this
-    // if (snrt_is_dm_core()) {
-    //     void *ptr = (void *)snrt_cls_base_addr();
-    //     size_t size;
-
-    //     // Copy cdata section to base of the TCDM
-    //     size = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
-    //     snrt_dma_start_1d(ptr, (void *)(&__cdata_start), size);
-
-    //     // Clear cbss section
-    //     ptr = (void *)((uint32_t)ptr + size);
-    //     size = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
-    //     snrt_dma_start_1d(ptr, (void *)(snrt_zero_memory_ptr()), size);
-    // }
 }
 #endif
 

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -15,9 +15,9 @@ static inline uint32_t snrt_cls_base_addr() {
     return l1_end_addr - cdata_size - cbss_size;
 }
 #endif
-    // In the future we will remove the idma in the cluster
-    // Hence we remove the init code that using DMA to init
-    // We use the CPU to init 
+// In the future we will remove the idma in the cluster
+// Hence we remove the init code that using DMA to init
+// We use the CPU to init
 #ifdef SNRT_INIT_TLS
 static inline void snrt_init_tls() {
     extern volatile uint32_t __tdata_start, __tdata_end;
@@ -34,16 +34,16 @@ static inline void snrt_init_tls() {
         asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
         uint8_t* tls_dst = (uint8_t*)tls_ptr;
         for (size_t i = 0; i < size; i++) {
-            tls_dst[i] = tdata_src[i];  
+            tls_dst[i] = tdata_src[i];
         }
         // Then initialize all other cores' .tdata sections from the DM
         // core's. The offset between the TLS section of successive cores
         // is defined in start.S
         size_t tls_offset = (1 << SNRT_LOG2_STACK_SIZE) + 8;
-        for (int i = 1; i < snrt_cluster_core_num(); i++) { 
+        for (int i = 1; i < snrt_cluster_core_num(); i++) {
             uint8_t* dst = (uint8_t*)(tls_ptr + i * tls_offset);
             for (size_t j = 0; j < size; j++) {
-                dst[j] = tls_dst[j];  
+                dst[j] = tls_dst[j];
             }
         }
         // Initialize all cores' .tbss sections
@@ -54,7 +54,7 @@ static inline void snrt_init_tls() {
         for (int i = 0; i < snrt_cluster_core_num(); i++) {
             uint8_t* tbss_dst = tls_tbss_base + i * tls_offset;
             for (size_t j = 0; j < tbss_size; j++) {
-                tbss_dst[j] = 0; 
+                tbss_dst[j] = 0;
             }
         }
     }
@@ -75,7 +75,7 @@ static inline void snrt_init_bss() {
         volatile uint8_t* bss_end = (volatile uint8_t*)&__bss_end;
         size_t size = bss_end - bss_start;
         for (volatile uint8_t* p = bss_start; p < bss_end; p++) {
-            *p = 0U; 
+            *p = 0U;
         }
     }
 }
@@ -86,7 +86,7 @@ static inline void snrt_init_cls() {
     extern volatile uint32_t __cdata_start, __cdata_end;
     extern volatile uint32_t __cbss_start, __cbss_end;
 
-    _cls_ptr = (cls_t *)snrt_cls_base_addr();
+    _cls_ptr = (cls_t*)snrt_cls_base_addr();
     if (snrt_is_dm_core()) {
         volatile uint8_t* tcdm_base = (volatile uint8_t*)snrt_cls_base_addr();
         size_t size;
@@ -94,11 +94,11 @@ static inline void snrt_init_cls() {
         volatile uint8_t* cdata_src = (volatile uint8_t*)&__cdata_start;
         volatile uint8_t* cdata_end = (volatile uint8_t*)&__cdata_end;
         size = cdata_end - cdata_src;
-    
+
         for (size_t i = 0; i < size; i++) {
             tcdm_base[i] = cdata_src[i];
         }
-    
+
         volatile uint8_t* cbss_start = (volatile uint8_t*)&__cbss_start;
         volatile uint8_t* cbss_end = (volatile uint8_t*)&__cbss_end;
         size_t cbss_size = cbss_end - cbss_start;
@@ -107,7 +107,6 @@ static inline void snrt_init_cls() {
         for (size_t i = 0; i < cbss_size; i++) {
             cbss_dst[i] = 0U;
         }
-
     }
 }
 #endif

--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -15,7 +15,9 @@ static inline uint32_t snrt_cls_base_addr() {
     return l1_end_addr - cdata_size - cbss_size;
 }
 #endif
-
+    // In the future we will remove the idma in the cluster
+    // Hence we remove the init code that using DMA to init
+    // We use the CPU to init 
 #ifdef SNRT_INIT_TLS
 static inline void snrt_init_tls() {
     extern volatile uint32_t __tdata_start, __tdata_end;
@@ -24,33 +26,66 @@ static inline void snrt_init_tls() {
     size_t size;
     volatile uint32_t tls_ptr;
 
-    // To avoid contentions in main memory, and take advantage of the
-    // bandwidth of the DMA, the DM core initializes the TLS section
-    // for every core in a cluster.
+    uint8_t* tdata_src = (uint8_t*)&__tdata_start;
+    uint8_t* tdata_end = (uint8_t*)&__tdata_end;
     if (snrt_is_dm_core()) {
         size = (size_t)(&__tdata_end) - (size_t)(&__tdata_start);
-
         // First initialize the DM core's .tdata section from main memory
         asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
-        snrt_dma_start_1d((void *)tls_ptr, (void *)(&__tdata_start), size);
-
+        uint8_t* tls_dst = (uint8_t*)tls_ptr;
+        for (size_t i = 0; i < size; i++) {
+            tls_dst[i] = tdata_src[i];  
+        }
         // Then initialize all other cores' .tdata sections from the DM
         // core's. The offset between the TLS section of successive cores
         // is defined in start.S
         size_t tls_offset = (1 << SNRT_LOG2_STACK_SIZE) + 8;
-        for (int i = 1; i < snrt_cluster_core_num(); i++) {
-            snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
-                              (void *)tls_ptr, size);
+        for (int i = 1; i < snrt_cluster_core_num(); i++) { 
+            uint8_t* dst = (uint8_t*)(tls_ptr + i * tls_offset);
+            for (size_t j = 0; j < size; j++) {
+                dst[j] = tls_dst[j];  
+            }
         }
-
         // Initialize all cores' .tbss sections
-        tls_ptr += size;
-        size = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
+        uint8_t* tbss_start = (uint8_t*)&__tbss_start;
+        uint8_t* tbss_end = (uint8_t*)&__tbss_end;
+        size_t tbss_size = tbss_end - tbss_start;
+        uint8_t* tls_tbss_base = tls_dst + size;
         for (int i = 0; i < snrt_cluster_core_num(); i++) {
-            snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
-                              (void *)(snrt_zero_memory_ptr()), size);
+            uint8_t* tbss_dst = tls_tbss_base + i * tls_offset;
+            for (size_t j = 0; j < tbss_size; j++) {
+                tbss_dst[j] = 0; 
+            }
         }
     }
+
+    // // To avoid contentions in main memory, and take advantage of the
+    // // bandwidth of the DMA, the DM core initializes the TLS section
+    // // for every core in a cluster.
+    // if (snrt_is_dm_core()) {
+    //     size = (size_t)(&__tdata_end) - (size_t)(&__tdata_start);
+
+    //     // First initialize the DM core's .tdata section from main memory
+    //     asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
+    //     snrt_dma_start_1d((void *)tls_ptr, (void *)(&__tdata_start), size);
+
+    //     // Then initialize all other cores' .tdata sections from the DM
+    //     // core's. The offset between the TLS section of successive cores
+    //     // is defined in start.S
+    //     size_t tls_offset = (1 << SNRT_LOG2_STACK_SIZE) + 8;
+    //     for (int i = 1; i < snrt_cluster_core_num(); i++) {
+    //         snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
+    //                           (void *)tls_ptr, size);
+    //     }
+
+    //     // Initialize all cores' .tbss sections
+    //     tls_ptr += size;
+    //     size = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
+    //     for (int i = 0; i < snrt_cluster_core_num(); i++) {
+    //         snrt_dma_start_1d((void *)(tls_ptr + i * tls_offset),
+    //                           (void *)(snrt_zero_memory_ptr()), size);
+    //     }
+    // }
 
     snrt_cluster_hw_barrier();
 }
@@ -62,11 +97,20 @@ static inline void snrt_init_bss() {
     // Only one core needs to perform the initialization
     // As the snitch core is 32bit, initialize the bss region above 4GB does not
     // make sense.
+
     if (snrt_cluster_idx() == 0 && snrt_is_dm_core()) {
-        size_t size = (size_t)(&__bss_end) - (size_t)(&__bss_start);
-        snrt_dma_start_1d((void *)(&__bss_start),
-                          (void *)(snrt_zero_memory_ptr()), size);
+        volatile uint8_t* bss_start = (volatile uint8_t*)&__bss_start;
+        volatile uint8_t* bss_end = (volatile uint8_t*)&__bss_end;
+        size_t size = bss_end - bss_start;
+        for (volatile uint8_t* p = bss_start; p < bss_end; p++) {
+            *p = 0U; 
+        }
     }
+    // if (snrt_cluster_idx() == 0 && snrt_is_dm_core()) {
+    //     size_t size = (size_t)(&__bss_end) - (size_t)(&__bss_start);
+    //     snrt_dma_start_1d((void *)(&__bss_start),
+    //                       (void *)(snrt_zero_memory_ptr()), size);
+    // }
 }
 #endif
 
@@ -76,21 +120,42 @@ static inline void snrt_init_cls() {
     extern volatile uint32_t __cbss_start, __cbss_end;
 
     _cls_ptr = (cls_t *)snrt_cls_base_addr();
-
-    // Only one core per cluster has to do this
     if (snrt_is_dm_core()) {
-        void *ptr = (void *)snrt_cls_base_addr();
+        volatile uint8_t* tcdm_base = (volatile uint8_t*)snrt_cls_base_addr();
         size_t size;
 
-        // Copy cdata section to base of the TCDM
-        size = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
-        snrt_dma_start_1d(ptr, (void *)(&__cdata_start), size);
+        volatile uint8_t* cdata_src = (volatile uint8_t*)&__cdata_start;
+        volatile uint8_t* cdata_end = (volatile uint8_t*)&__cdata_end;
+        size = cdata_end - cdata_src;
+    
+        for (size_t i = 0; i < size; i++) {
+            tcdm_base[i] = cdata_src[i];
+        }
+    
+        volatile uint8_t* cbss_start = (volatile uint8_t*)&__cbss_start;
+        volatile uint8_t* cbss_end = (volatile uint8_t*)&__cbss_end;
+        size_t cbss_size = cbss_end - cbss_start;
 
-        // Clear cbss section
-        ptr = (void *)((uint32_t)ptr + size);
-        size = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
-        snrt_dma_start_1d(ptr, (void *)(snrt_zero_memory_ptr()), size);
+        volatile uint8_t* cbss_dst = tcdm_base + size;
+        for (size_t i = 0; i < cbss_size; i++) {
+            cbss_dst[i] = 0U;
+        }
+
     }
+    // // Only one core per cluster has to do this
+    // if (snrt_is_dm_core()) {
+    //     void *ptr = (void *)snrt_cls_base_addr();
+    //     size_t size;
+
+    //     // Copy cdata section to base of the TCDM
+    //     size = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
+    //     snrt_dma_start_1d(ptr, (void *)(&__cdata_start), size);
+
+    //     // Clear cbss section
+    //     ptr = (void *)((uint32_t)ptr + size);
+    //     size = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
+    //     snrt_dma_start_1d(ptr, (void *)(snrt_zero_memory_ptr()), size);
+    // }
 }
 #endif
 

--- a/sw/tests/event_unit.c
+++ b/sw/tests/event_unit.c
@@ -28,7 +28,8 @@ int main() {
     eu_init();
     if (snrt_cluster_core_idx() == 0) {
         while (eu_get_workers_in_wfi() !=
-               (snrt_cluster_compute_core_num() - 1));
+               (snrt_cluster_compute_core_num() - 1)) {
+        }
     } else if (snrt_is_dm_core()) {
         // Park DM core
         return 0;

--- a/sw/tests/event_unit.c
+++ b/sw/tests/event_unit.c
@@ -27,8 +27,8 @@ int main() {
     // core 0 waits for the queue to be full of workers
     eu_init();
     if (snrt_cluster_core_idx() == 0) {
-        while (eu_get_workers_in_wfi() != (snrt_cluster_compute_core_num() - 1))
-            ;
+        while (eu_get_workers_in_wfi() !=
+               (snrt_cluster_compute_core_num() - 1));
     } else if (snrt_is_dm_core()) {
         // Park DM core
         return 0;
@@ -43,21 +43,21 @@ int main() {
     arg = 10;
     n_workers = snrt_cluster_compute_core_num();
     err |= run_and_verify_task(&arg, n_workers) << 0;
-    __asm__ volatile("fence.i" :::"memory");
+    __asm__ volatile("fence.i" ::: "memory");
     // Dispatch a task on 4 harts and wait for its completion
     printf("-- Test 2\n");
     sum = 0;
     arg = 20;
     n_workers = 4;
     err |= run_and_verify_task(&arg, n_workers) << 1;
-    __asm__ volatile("fence.i" :::"memory");
+    __asm__ volatile("fence.i" ::: "memory");
     // Dispatch a task on 1 hart and wait for its completion
     printf("-- Test 3\n");
     sum = 0;
     arg = 30;
     n_workers = 1;
     err |= run_and_verify_task(&arg, n_workers) << 2;
-    __asm__ volatile("fence.i" :::"memory");
+    __asm__ volatile("fence.i" ::: "memory");
     // exit
     eu_exit(snrt_cluster_core_idx());
     return err;

--- a/sw/tests/event_unit.c
+++ b/sw/tests/event_unit.c
@@ -43,21 +43,21 @@ int main() {
     arg = 10;
     n_workers = snrt_cluster_compute_core_num();
     err |= run_and_verify_task(&arg, n_workers) << 0;
-
+    __asm__ volatile("fence.i" :::"memory");
     // Dispatch a task on 4 harts and wait for its completion
     printf("-- Test 2\n");
     sum = 0;
     arg = 20;
     n_workers = 4;
     err |= run_and_verify_task(&arg, n_workers) << 1;
-
+    __asm__ volatile("fence.i" :::"memory");
     // Dispatch a task on 1 hart and wait for its completion
     printf("-- Test 3\n");
     sum = 0;
     arg = 30;
     n_workers = 1;
     err |= run_and_verify_task(&arg, n_workers) << 2;
-
+    __asm__ volatile("fence.i" :::"memory");
     // exit
     eu_exit(snrt_cluster_core_idx());
     return err;

--- a/target/snitch_cluster/cfg/snax_xdma_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_xdma_cluster.hjson
@@ -1,0 +1,226 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Cluster configuration for a simple testbench system.
+{
+    nr_s1_quadrant: 1,
+    s1_quadrant: {
+        nr_clusters: 1,
+    },
+
+    cluster: {
+        name: "snax_KUL_cluster",
+        bender_target: ["snax_KUL_cluster"],
+        boot_addr: 4096, // 0x1000
+        cluster_base_addr: 268435456, // 0x1000_0000
+        cluster_base_offset: 1048576,  // 1MB
+        cluster_base_hartid: 0,
+        addr_width: 48,
+        data_width: 64,
+        user_width: 3,
+        tcdm: {
+            size: 128,
+            banks: 32,
+        },
+        cluster_periph_size: 64, // kB
+        zero_mem_size: 64, // kB
+        dma_data_width: 512,
+        dma_axi_req_fifo_depth: 16,
+        dma_req_fifo_depth: 8,
+
+        // Observable pins parameter
+        observable_pin_width: 8,
+
+        // Additional parameters for Hemaia integration
+        narrow_trans: 4,
+        wide_trans: 32,
+        dma_user_width: 1,
+        // We don't need Snitch debugging in Hemaia
+        enable_debug: false,
+        // We don't need Snitch (core-internal) virtual memory support
+        vm_support: false,
+        // Memory configuration inputs
+        sram_cfg_expose: true,
+        sram_cfg_fields: {
+            ema: 3,
+            emaw: 2,
+            emas: 1
+        },
+        snax_custom_tcdm_assign: {
+            snax_enable_assign_tcdm_idx: true,
+            snax_narrow_assign_start_idx: [0,56],
+            snax_narrow_assign_end_idx: [7,71],
+            snax_wide_assign_start_idx: [8],
+            snax_wide_assign_end_idx: [55],
+        },
+        // AXI bandwidth switcher
+        use_ax_bw_converter: true,
+        converted_axi_bandwidth: 256,
+        // Timing parameters
+        timing: {
+            lat_comp_fp32: 3,
+            lat_comp_fp64: 3,
+            lat_comp_fp16: 2,
+            lat_comp_fp16_alt: 2,
+            lat_comp_fp8: 1,
+            lat_comp_fp8_alt: 1,
+            lat_noncomp: 1,
+            lat_conv: 1,
+            lat_sdotp: 2,
+            fpu_pipe_config: "BEFORE"
+            narrow_xbar_latency: "CUT_ALL_PORTS",
+            wide_xbar_latency: "CUT_ALL_PORTS",
+            // Isolate the core.
+            register_core_req: true,
+            register_core_rsp: true,
+            register_offload_req: true,
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
+        },
+        hives: [
+            // Hive 0
+            {
+                icache: {
+                    size: 8, // total instruction cache size in kByte
+                    sets: 2, // number of ways
+                    cacheline: 256 // word size in bits
+                },
+                cores: [
+                    { $ref: "#/snax_streamer_gemmX_core_template" },
+                    { $ref: "#/dma_core_template" },
+                ]
+            }
+        ]
+    },
+    dram: {
+        // 0x8000_0000
+        address: 2147483648,
+        // 0x8000_0000
+        length: 2147483648
+    },
+    peripherals: {
+        clint: {
+            // 0xffff_0000
+            address: 4294901760,
+            // 0x0000_1000
+            length: 4096
+        },
+    },
+    // Templates.
+    snax_streamer_gemmX_core_template: {
+        isa: "rv32ima",
+        xssr: false,
+        xfrep: false,
+        xdma: false,
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        snax_acc_cfg: {
+            snax_acc_name: "snax_streamer_gemmX",
+            bender_target: ["snax_gemmX"],
+            snax_narrow_tcdm_ports: 8,
+            snax_wide_tcdm_ports: 48,
+            snax_num_rw_csr: 19,
+            snax_num_ro_csr: 2,
+            snax_gemmx_mesh_row: 8,
+            snax_gemmx_tile_size: 8,
+            snax_gemmx_mesh_col: 8,
+            snax_gemmx_serial_c32_d32_width: 2048,
+            snax_gemmx_serial_d8_width: 512,
+            with_pipeline: true,
+            snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
+        },
+        snax_use_custom_ports: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+        // Enable division/square root unit
+        // Xdiv_sqrt: true,
+    },
+    // Templates.
+    dma_core_template: {
+        isa: "rv32ima",
+        snax_xdma_cfg: {
+            bender_target: ["snax_KUL_cluster_xdma"],
+            // Cross Cluster Calling Cfg
+            max_multicast: 4,
+            max_dimension: 6,
+            max_mem_size: 4096,
+            // DataMaestro Cfg
+            reader_buffer: 4, 
+            writer_buffer: 4, 
+            reader_agu_temporal_dimension: 6, 
+            writer_agu_temporal_dimension: 6, 
+            // Extension Cfg
+            HasVerilogMemset: {},
+            HasMaxPool: {},
+            HasTransposer: {row:[8], col:[8], elementWidth:[8]}, 
+        }
+        // Xdiv_sqrt: true,
+        # isa: "rv32ema",
+        xdma: true
+        xssr: false
+        xfrep: false
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+    },
+    // SNAX Streamer Templates
+    snax_streamer_gemmX_streamer_template :{
+
+        data_reader_params: {
+            spatial_bounds: [[8], [8]],
+            temporal_dim: [6, 3],
+            num_channel: [8, 8],
+            fifo_depth: [8, 8],
+            configurable_channel: [0, 0],
+            tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
+            datapath_extensions: [{HasTransposer: {row:[8], col:[8], elementWidth:[8]}}, {HasTransposer: {row:[8], col:[8], elementWidth:[8]}}]
+        },
+
+        data_writer_params:{
+            spatial_bounds: [[8]],
+            temporal_dim: [3],
+            num_channel: [8],
+            fifo_depth: [1],
+            configurable_channel: [0],
+            tcdm_logic_word_size: [[256, 128, 64]],
+        },
+
+        data_reader_writer_params:{
+            spatial_bounds: [[8, 4], [8, 4]],
+            temporal_dim: [3, 3],
+            num_channel: [32, 32],
+            fifo_depth: [1, 1],
+            configurable_channel: [1, 0],
+            tcdm_logic_word_size: [[256, 128, 64], [256, 128, 64]],
+            datapath_extensions: [{HasBroadcaster: {inputLength: 256, outputLength: 2048}}, {}]
+        },
+
+        # needs to be ketp for csr num calculation in snax_gen.py
+        has_transpose: true,
+
+        has_C_broadcast: true,
+
+        snax_library_name: "gemmx",
+    }
+}


### PR DESCRIPTION
This PR aims to add the XDMA to the snax cluster. The XDMA is an ongoing project by Fanchen and Yunhao. 

The basic idea is to use the Streamer as the frontend of the DMA to support the flexible and efficient data fetch. To achieve this, we did the following modifications to the original xdma (which only has local loop back)
1. Developed the xdma_axi_adapter to hook the xdma to the system axi
2. Added the interface signals between xdma and the xdma_axi_adapter in hw/templates/snax_xdma_wrapper.sv.tpl
3. Added the mmio_size field in the cfg file since the xdma needs those mmio addr to transfer cfg/data/grant/finish signals. Now we assign 16KB address space, each occupying 4KB address space from the end of the cluster addr space.

Another optimization we did was to remove the zero mem in the cluster. We added one master port and one slave port in the cluster wide xbar due to the xdma-axi integration. Hence we removed the zero mem to make the cluster wide xbar less crowded. To achieve this, we did the following:
1. Modified the snitch_cluster_wrapper.sv.tpl to remove the zero mem
2. Modified the start.c that previously relied on the zero mem to init some of the tcdm sections(CLS, TLS, etc). Now we only use the CPU to initialize those sections. In the future, we will gradually remove the original idma. So we also bumped those snrt_dma_1d() calls at the start.c.
