### PR TITLE
Remove the zero mem test

### DIFF
--- a/target/snitch_cluster/sw/runtime.yaml
+++ b/target/snitch_cluster/sw/runtime.yaml
@@ -17,4 +17,3 @@ runs:
   - elf: tests/build/tls.elf
   - elf: tests/build/varargs_1.elf
   - elf: tests/build/varargs_2.elf
-  - elf: tests/build/zero_mem.elf


### PR DESCRIPTION
This PR relates to removing the zero mem test due to:
1. Our xdma can do the memset and there is no need to use the zero mem + idma to initialize the mem. We will add the xdma-version zero mem test in the future.
2. We will remove the zero mem in the future to ease the pressure on the cluster wide axi since our xdma will add one master and one slave port to it.