### PR TITLE
run acc unit tests in CI

### DIFF
--- a/.github/workflows/scala-unit-test.yml
+++ b/.github/workflows/scala-unit-test.yml
@@ -31,3 +31,7 @@ jobs:
         working-directory: hw/chisel
         run: |
           sbt test
+      - name: Run the acc unit tests
+        working-directory: hw/chisel_acc
+        run: |
+          sbt test


### PR DESCRIPTION
unless I'm missing something, the chisel unit tests were only fun for `hw/chisel` and not `hw/chisel_acc`