### PR TITLE
Update Snitch's starting program

### DIFF
--- a/sw/snRuntime/src/start.S
+++ b/sw/snRuntime/src/start.S
@@ -108,14 +108,12 @@ snrt.crt0.init_core_info:
     csrr a0, 0xbc1
     # a1 holds the cluster addr width
     li a1, CLUSTER_ADDRWIDTH
-    addi a1, a1, 8
-    # first we left shift a0 by 8 bits
-    slli a0, a0, 8
-    # then we shift right a0 by a1 (8 + cluster_addrwidth) bits
+    # a2 holds the cluster base address
+    li a2, CLUSTER_BASE_ADDR
+    # first we subtract the base address
+    sub a0, a0, a2
+    # then we shift right a0 by a1 (cluster_addrwidth) bits to get the correct cluster idx
     srl t0, a0, a1
-
-    # Calculate cluster-local core ID
-    # remu a0, a0, a1
 
     # The cluster-local core id is calculated as snrt_cluster_core_idx()
     # we read the lower 16bits of register 0xbc3

--- a/sw/snRuntime/src/team.h
+++ b/sw/snRuntime/src/team.h
@@ -61,11 +61,7 @@ inline uint32_t __attribute__((const)) snrt_global_compute_core_idx() {
 
 inline uint32_t __attribute__((const)) snrt_cluster_idx() {
     // return snrt_global_core_idx() / snrt_cluster_core_num();
-    // occamy assign 16MB cluster memory
-    // Hence we need the lower 22bit for cluster address
-    // We add 2 bits for future use
-    // Hence we mask the lower 24bits for cluster address
-    return (snrt_cluster_base_addrl() & 0x00FFFFFF) >> CLUSTER_ADDRWIDTH;
+    return (snrt_cluster_base_addrl() - CLUSTER_BASE_ADDR) >> CLUSTER_ADDRWIDTH;
 }
 
 inline uint32_t __attribute__((const)) snrt_cluster_core_idx() {

--- a/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
+++ b/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl
@@ -11,6 +11,7 @@
     import math
     cluster_addrwidth = int(math.log2(cfg['cluster']['cluster_base_offset']))
 %>
+#define CLUSTER_BASE_ADDR ${cfg['cluster']['cluster_base_addr']}
 #define CLUSTER_ADDRWIDTH ${cluster_addrwidth}
 #define CLUSTER_PERIPH_BASE_ADDR (CLUSTER_TCDM_BASE_ADDR + CLUSTER_TCDM_SIZE)
 #define CLUSTER_ZERO_MEM_START_ADDR (CLUSTER_PERIPH_BASE_ADDR + ${hex(cfg['cluster']['cluster_periph_size'] * 1024)})


### PR DESCRIPTION
This PR modifies the Snitch's assembly starting program to calculate the **sp** (x2) register's value in another way to compatible with very large TCDM & many SNAX clusters. 