### PR TITLE
Fix Questasim build

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -152,10 +152,11 @@ work/${FESVR_VERSION}_unzip:
 	touch $@
 
 work/lib/libfesvr.a: work/${FESVR_VERSION}_unzip
-	cd $(dir $<)/ && ./configure --prefix `pwd`
-	make -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
+	cd $(dir $<)/ && ./configure --prefix `pwd` --with-boost=$(CONDA_PREFIX) --with-boost-libdir=$(CONDA_PREFIX)/lib
+	$(MAKE) -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
 	mkdir -p $(dir $@)
 	cp $(dir $<)libfesvr.a $@
+	strip --strip-debug $@
 
 # Build fesvr seperately for verilator since this might use different compilers
 # and libraries than modelsim/vcs and


### PR DESCRIPTION
# Official PR documentation
This PR basically fixes the questa sim build. Ever since we moved to a pixi version, there has been a mismatch between Questa's  GCC compiler and the one we're using. This is a limitation of Questasim...

The fix is to simply tell the `libfesvr` build where the boost libraries are, and to strip the debug info from the `libvesfr.a` because it is compiled by newer GCC version, but Questasim uses its old compiler to compiler/run it...

To do questasim builds, do:

1. In container: make CFG_OVERRIDE=cfg/<whatever config> rtl-gen
2. In container: make CFG_OVERRIDE=cfg/<whatever config> vsim_preparation
3. In container: make CFG_OVERRIDE=cfg/<whatever config> sw -j
4. Outside: make CFG_OVERRIDE=cfg/<whatever config> bin/snitch_cluster.vsim
5. Outside: bin/snitch_cluster.vsim <path to elf file>

# Some documentation for notes

This is just a test PR to see if there's a way to fix questasim... hours and hours of debugging 😢 

Documentation of what has been tried:

❌ Use pixi only without the container (actually works on some parts even on verilator building) but starts to fail when we reach the vsim simulations. Error has something to do with:

```bash
** Fatal: (vsim-3828) Could not link 'vsim_auto_compile.so': cmd = '/esat/micas-data/software/Mentor/questasim_2022.4/gcc-7.4.0-linux_x86_64/bin/g++ -shared -fPIC -o "/tmp/rantonio@micas-lapserv1.esat.kuleuven.be_dpi_3975180/linux_x86_64_gcc-7.4.0/vsim_auto_compile.so" /users/micas/rantonio/no_backup/kul_main/snax_cluster/target/snitch_cluster/work-vsim/_dpi/auto_compile@/linux_x86_64_gcc-7.4.0/*.o   -Wl,-rpath,/users/micas/rantonio/no_backup/kul_main/snax_cluster/target/snitch_cluster/work/lib -L/users/micas/rantonio/no_backup/kul_main/snax_cluster/target/snitch_cluster/work/lib -lfesvr -lutil -Wl,-Bsymbolic '
# (vsim-50) A call to system(/esat/micas-data/software/Mentor/questasim_2022.4/gcc-7.4.0-linux_x86_64/bin/g++ -shared -fPIC -o "/tmp/rantonio@micas-lapserv1.esat.kuleuven.be_dpi_3975180/linux_x86_64_gcc-7.4.0/vsim_auto_compile.so" /users/micas/rantonio/no_backup/kul_main/snax_cluster/target/snitch_cluster/work-vsim/_dpi/auto_compile@/linux_x86_64_gcc-7.4.0/*.o   -Wl,-rpath,/users/micas/rantonio/no_backup/kul_main/snax_cluster/target/snitch_cluster/work/lib -L/users/micas/rantonio/no_backup/kul_main/snax_cluster/target/snitch_cluster/work/lib -lfesvr -lutil -Wl,-Bsymbolic  >'/tmp/questatmp.QefHDY' 2>&1) returned error code '1'
```

❌ Also tried to force the Questasim compiler to use pixi compiler (or whatever is the newer GCCversion); however, it cannot be overridden... It seems like a built-in thing for Questasim.

❌ Tried using GCC version 13.3.0, but it has the same problem ... therefore it is not a GCC version problem. I thought it was because the error above seems to point to using a separate gcc...

❌ Tried using VCS instead, but you need to prepare the libfesvr too. However, the VCS starts to fail because of an unwanted setting. *This might be a working solution for later*

❌ When I tried to clean the pixi environment, it started to crash barnard/micas-lapserv 😭 why ....

❄️ Things that you need to make sure:

🍨 The libboost is a must and needs to be specified in the make file.
```Makefile
work/lib/libfesvr.a: work/${FESVR_VERSION}_unzip
	cd $(dir $<)/ && ./configure --prefix `pwd` --with-boost=$(CONDA_PREFIX) --with-boost-libdir=$(CONDA_PREFIX)/lib
	$(MAKE) -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
	mkdir -p $(dir $@)
	cp $(dir $<)libfesvr.a $@
```