### PR TITLE
Fix io_ctrl_gemm_ctrl_bits_subtraction_constant_i width in syn

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm/BlockGemm.scala
@@ -12,6 +12,9 @@ class BlockGemmCtrlIO(val params: GemmParams) extends Bundle with HasGemmParams 
   val N_i                    = (UInt(sizeConfigWidth.W))
   val M_i                    = (UInt(sizeConfigWidth.W))
   val subtraction_constant_i = (UInt(subtractionCfgWidth.W))
+
+  assert(sizeConfigWidth == subtractionCfgWidth && sizeConfigWidth == 32, "CSR width is 32")
+
 }
 
 /** The BlockGemm's data port declaration. Decoupled interface connected to the streamer */
@@ -120,7 +123,7 @@ class BlockGemm(val params: GemmParams) extends Module with RequireAsyncReset wi
       )
     }
 
-    require(subtractionCfgWidth == 16, "TODO slicing is hardcoded yet the width is a parameter") // TODO
+    require(subtractionCfgWidth == 32, "TODO slicing is hardcoded yet the width is a parameter") // TODO
     subtraction_a := io.ctrl.bits.subtraction_constant_i(7, 0)
     subtraction_b := io.ctrl.bits.subtraction_constant_i(15, 8)
   }

--- a/hw/chisel_acc/src/main/scala/snax_acc/gemm/Parameter.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/gemm/Parameter.scala
@@ -44,7 +44,7 @@ object GemmConstant {
   lazy val dataWidthC     = dataWidthA * 4
   lazy val dataWidthAccum = dataWidthA * 4
 
-  lazy val subtractionCfgWidth = 16 // was 32, but why?
+  lazy val subtractionCfgWidth = 32
 
   lazy val meshRow  = 8
   lazy val tileSize = 8


### PR DESCRIPTION
io_ctrl_gemm_ctrl_bits_subtraction_constant_i  should be 32 otherwise it will give an error in synthesis as the CSR width is 32.

> Error: Width mismatch on port 'io_ctrl_gemm_ctrl_bits_subtraction_constant_i' of reference to 'BlockGemmRescaleSIMD' in 'snax_streamer_gemmX_shell_wrapper'. (LINK-3)