### PR TITLE
Add sw-based MUX-ing for multi-accelerator control within a single RISCV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,39 @@ jobs:
           sw/runtime.yaml \
           sw/snax-alu-run.yaml -j
 
+  snax-multi-alu-cluster-vlt-generic:
+    name: Simulate SW on SNAX Multi ALU Cluster w/ Verilator (Generic LLVM)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          cache: true
+          cache-write: ${{ github.event_name == 'push' &&
+            github.ref_name == 'main' }}
+          activate-environment: true
+      - name: Generate RTL
+        run: |
+          make -C target/snitch_cluster rtl-gen \
+          CFG_OVERRIDE=cfg/snax_multi_alu_cluster.hjson
+      - name: Build Software
+        run: |
+          make -C target/snitch_cluster sw \
+          CFG_OVERRIDE=cfg/snax_multi_alu_cluster.hjson
+      - name: Build Hardware
+        run: |
+          make CFG_OVERRIDE=cfg/snax_multi_alu_cluster.hjson \
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
+      - name: Run Tests
+        working-directory: target/snitch_cluster
+        run: |-
+          ./run.py --simulator verilator \
+          sw/runtime.yaml \
+          sw/snax-alu-run.yaml \
+          sw/snax-multi-alu-run.yaml -j
+
   snax-hypercorex-cluster-vlt-generic:
     name: SNAX Hypercorex w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -111,6 +111,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   output snitch_pkg::core_events_t  core_events_o,
   // Observability register
   output logic [ObsWidth-1:0] obs_o,
+  // Multi accelerator MUX
+  output logic [ObsWidth-1:0] multi_acc_mux_o,
   // Cluster SNAX HW barrier
   input  logic          snax_barrier_i,
   // Cluster HW barrier
@@ -253,6 +255,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   logic snax_csr_stall_d, snax_csr_stall_q;
   logic snax_csr_barr_en_d, snax_csr_barr_en_q;
   logic [31:0] csr_obs_d, csr_obs_q;
+  logic [31:0] csr_multi_acc_mux_d, csr_multi_acc_mux_q;
 
   localparam logic M = 0;
   localparam logic S = 1;
@@ -328,6 +331,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
 
   // Observable register
   `FFAR(csr_obs_q, csr_obs_d, '0, clk_i, rst_i)
+
+  // Multi accelerator mux
+  `FFAR(csr_multi_acc_mux_q, csr_multi_acc_mux_d, '0, clk_i, rst_i)
+
 
   typedef struct packed {
     fpnew_pkg::fmt_mode_t  fmode;
@@ -2382,6 +2389,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     snax_csr_stall_d = snax_csr_stall_q;
     snax_csr_barr_en_d = snax_csr_barr_en_q;
     csr_obs_d = csr_obs_q;
+    csr_multi_acc_mux_d = csr_multi_acc_mux_q;
 
     // Snitch barrier
     if (barrier_i) csr_stall_d = 1'b0;
@@ -2626,6 +2634,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           CsrObsRegister: begin
             csr_rvalue = csr_obs_q;
             csr_obs_d = alu_result;
+          end
+          CsrMultiAccMux: begin
+            csr_rvalue = csr_multi_acc_mux_q;
+            csr_multi_acc_mux_d = alu_result;
           end
           // HW cluster barrier
           CSR_BARRIER: begin
@@ -3043,6 +3055,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // Observability pin
   // ----------
   assign obs_o = csr_obs_q[ObsWidth-1:0];
+  assign multi_acc_mux_o = csr_multi_acc_mux_q;
 
   // ----------
   // Assertions

--- a/hw/snitch/src/snitch_pkg.sv
+++ b/hw/snitch/src/snitch_pkg.sv
@@ -183,6 +183,8 @@ package snitch_pkg;
   localparam logic [11:0] CsrClusterCoreId = 12'hBC3;
   // CsrObsRegister: RW, a simple observability register
   localparam logic [11:0] CsrObsRegister = 12'h7c5;
+  // CsrMultiAccMux: RW, a register for MUX-ing multi acc per core
+  localparam logic [11:0] CsrMultiAccMux = 12'h7c6;
 
   // --------------------
   // Trace Infrastructure

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -139,18 +139,20 @@ module snitch_cc #(
   output axi_dma_pkg::dma_perf_t     axi_dma_perf_o,
   output dma_events_t                axi_dma_events_o,
   // Snax ports
-  output acc_req_t                  snax_req_o,
-  output logic                      snax_qvalid_o,
-  input  logic                      snax_qready_i,
-  input  acc_resp_t                 snax_resp_i,
-  input  logic                      snax_pvalid_i,
-  output logic                      snax_pready_o,
+  output acc_req_t                   snax_req_o,
+  output logic                       snax_qvalid_o,
+  input  logic                       snax_qready_i,
+  input  acc_resp_t                  snax_resp_i,
+  input  logic                       snax_pvalid_i,
+  output logic                       snax_pready_o,
   // Core event strobes
   output snitch_pkg::core_events_t   core_events_o,
   // TCDM base address, which also is the Base Address of the Snitch Cluster that the core belongs to
   input  addr_t                      tcdm_addr_base_i,
   // Observability register
   output logic [ObsWidth-1:0]        obs_o,
+  // Multi accelerator MUX
+  output logic [ObsWidth-1:0]        multi_acc_mux_o,
   // Cluster HW barrier
   input  logic                       snax_barrier_i,
   output logic                       barrier_o,
@@ -288,6 +290,7 @@ module snitch_cc #(
     .fpu_status_i ( fpu_status ),
     .core_events_o ( snitch_events),
     .obs_o ( obs_o ),
+    .multi_acc_mux_o ( multi_acc_mux_o ),
     .snax_barrier_i (snax_barrier_i ),
     .barrier_o ( barrier_o ),
     .barrier_i ( barrier_i )

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -228,6 +228,8 @@ module snitch_cluster
     /// Observability register for the cluster. This register is assumed to be
     /// sticky and only useful for observing signals from the outside.
     output logic             [          ObsWidth-1:0]       obs_o,
+    /// Multi accelerator MUXing control signal
+    output logic             [           NrCores-1:0][31:0] multi_acc_mux_o,
     /// Per-core debug request signal. Asserting this signals puts the
     /// corresponding core into debug mode. This signal is assumed to be _async_.
     input  logic             [           NrCores-1:0]       debug_req_i,
@@ -1347,9 +1349,9 @@ module snitch_cluster
         .TCDMAddrWidth(TCDMAddrWidth),
         .DebugSupport(DebugSupport)
     ) i_snitch_cc (
-        .clk_i,
+        .clk_i(clk_i),
+        .rst_ni(rst_ni),
         .clk_d2_i(clk_d2),
-        .rst_ni,
         .rst_int_ss_ni(1'b1),
         .rst_fp_ss_ni(1'b1),
         .hart_id_i(hart_base_id_i + i),
@@ -1376,6 +1378,7 @@ module snitch_cluster
         .core_events_o(core_events[i]),
         .tcdm_addr_base_i(tcdm_start_address),
         .obs_o(obs_signal[i]),
+        .multi_acc_mux_o(multi_acc_mux_o[i]),
         .snax_barrier_i(snax_barrier_i[i]),
         .barrier_o(barrier_in[i]),
         .barrier_i(barrier_out)

--- a/sw/snRuntime/src/csr.h
+++ b/sw/snRuntime/src/csr.h
@@ -33,9 +33,7 @@ static void write_csr_multi_acc_mux(uint32_t value) {
     return;
 }
 
-static uint32_t read_csr_multi_acc_mux(void) {
-    return read_csr(1990);
-}
+static uint32_t read_csr_multi_acc_mux(void) { return read_csr(1990); }
 
 static uint32_t csrr_ss(uint32_t csr_address) {
     uint32_t value;

--- a/sw/snRuntime/src/csr.h
+++ b/sw/snRuntime/src/csr.h
@@ -19,12 +19,23 @@
 // Uncomment the above line to enable 64 CSRs addressability, with the down side
 // of larger binary size.
 
+// These are for RW observable registers
 static void write_csr_obs(uint32_t value) {
     write_csr(1989, value);
     return;
 }
 
 static uint32_t read_csr_obs(void) { return read_csr(1989); }
+
+// These are for controlling the multi-accelerator MUX
+static void write_csr_multi_acc_mux(uint32_t value) {
+    write_csr(1990, value);
+    return;
+}
+
+static uint32_t read_csr_multi_acc_mux(void) {
+    return read_csr(1990);
+}
 
 static uint32_t csrr_ss(uint32_t csr_address) {
     uint32_t value;

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -34,6 +34,10 @@ ifeq (${CFG_OVERRIDE}, cfg/snax_alu_cluster.hjson)
 SUBDIRS += snax/snax-alu
 endif
 
+ifeq (${CFG_OVERRIDE}, cfg/snax_multi_alu_cluster.hjson)
+SUBDIRS += snax/snax-alu
+endif
+
 ifeq (${CFG_OVERRIDE}, cfg/snax_hypercorex_cluster.hjson)
 SUBDIRS += snax/hypercorex
 endif

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -27,6 +27,9 @@ SUBDIRS += snax-mac-simple/tiled
 ifeq ($(CFG_OVERRIDE), cfg/snax_alu_cluster.hjson)
 SUBDIRS += snax-alu
 endif
+ifeq ($(CFG_OVERRIDE), cfg/snax_multi_alu_cluster.hjson)
+SUBDIRS += snax-multi-alu
+endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_dse_cluster_3D.hjson)
 SUBDIRS += snax-data-reshuffler
 SUBDIRS += snax-gemmx-matmul

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -28,6 +28,7 @@ ifeq ($(CFG_OVERRIDE), cfg/snax_alu_cluster.hjson)
 SUBDIRS += snax-alu
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_multi_alu_cluster.hjson)
+SUBDIRS += snax-alu
 SUBDIRS += snax-multi-alu
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_dse_cluster_3D.hjson)

--- a/target/snitch_cluster/sw/apps/snax-multi-alu/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-multi-alu/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+APP     = snax-multi-alu
+
+INCDIRS = data
+
+INCDIRS += ../../snax/snax-alu/include
+
+# Include this binary in the final build
+RISCV_LDFLAGS += ../../snax/snax-alu/build/snax-alu-lib.o
+
+SRCS    = src/snax-multi-alu.c
+
+include ../common.mk
+include ./data/Makefile
+
+$(DEP): $(DATA_H)

--- a/target/snitch_cluster/sw/apps/snax-multi-alu/data/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-multi-alu/data/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleueven.be>
+
+# Usage of absolute paths is required to externally include this Makefile
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+DATA_DIR := $(realpath $(MK_DIR))
+
+# Set these as default values
+LENGTH ?= 100
+MODE ?= 0
+
+# File paths
+DATAGEN_PY = $(DATA_DIR)/datagen.py
+DATA_H = $(DATA_DIR)/data.h
+
+.PHONY: clean clean-data
+
+clean-data:
+	rm -f $(DATA_H)
+
+clean: clean-data
+
+$(DATA_H): 
+	$(DATAGEN_PY) $< --mode=$(MODE) --length=$(LENGTH) > $@
+
+

--- a/target/snitch_cluster/sw/apps/snax-multi-alu/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-multi-alu/data/datagen.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+import sys
+import argparse
+import numpy as np
+import os
+
+# Add data utility path
+sys.path.append(os.path.join(os.path.dirname(__file__),
+                "../../../../../../util/sim/"))
+from data_utils import format_scalar_definition, \
+                       format_vector_definition  # noqa: E402
+
+# Hard parameters so modify
+# at your own risk
+
+# Value range
+MIN = 0
+MAX = 100
+
+# Design-time spatial parallelism
+SPATIAL_PAR = 4
+
+
+def golden_model(a, b, mode):
+    if (mode == 1):
+        return a - b
+    elif (mode == 2):
+        return a * b
+    elif (mode == 3):
+        return a ^ b
+    else:
+        return a + b
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--mode',
+        type=int,
+        help='Mode: 0 - add; 1 - sub; 2 - mul; 3 - XOR;')
+    parser.add_argument(
+        '--length',
+        type=int,
+        help='Number of elements. Do: python datagen.py --length <insert num>')
+
+    args = parser.parse_args()
+    mode = args.mode
+    length = args.length
+
+    # Randomly generate inputs
+    a = np.random.randint(MIN, MAX, length)
+    b = np.random.randint(MIN, MAX, length)
+
+    out = golden_model(a, b, mode)
+
+    # Number of iterations for accelerator
+    # depend on the spatial parallelism
+    loop_iter = length//SPATIAL_PAR
+
+    # Format header file
+    mode_str = format_scalar_definition('uint64_t', 'MODE', mode)
+    dl_str = format_scalar_definition('uint64_t', 'DATA_LEN', length)
+    li_str = format_scalar_definition('uint64_t', 'LOOP_ITER', loop_iter)
+    a_str = format_vector_definition('uint64_t', 'A', a)
+    b_str = format_vector_definition('uint64_t', 'B', b)
+
+    out_str = format_vector_definition('uint64_t', 'OUT', out)
+    f_str = '\n\n'.join([mode_str, dl_str, li_str, a_str, b_str, out_str])
+
+    f_str += '\n'
+
+    print(f_str)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/target/snitch_cluster/sw/apps/snax-multi-alu/src/snax-multi-alu.c
+++ b/target/snitch_cluster/sw/apps/snax-multi-alu/src/snax-multi-alu.c
@@ -1,0 +1,100 @@
+// Copyright 2024 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "snrt.h"
+
+#include "data.h"
+#include "snax-alu-lib.h"
+#include "streamer_csr_addr_map.h"
+
+int main() {
+    // Set err value for checking
+    int err = 0;
+
+    // Allocates space in TCDM
+    uint64_t *local_a, *local_b, *local_o;
+
+    local_a = (uint64_t *)snrt_l1_next();
+    local_b = local_a + DATA_LEN;
+    local_o = local_b + DATA_LEN;
+
+    // Start of pre-loading data from L2 memory
+    // towards the L1 TCDM memory
+    // Use the Snitch core with a DMA
+    // to move the data from L2 to L1
+    if (snrt_is_dm_core()) {
+        // This measures the start of cycle count
+        // for preloading the data to the L1 memory
+        uint32_t start_dma_load = snrt_mcycle();
+
+        // The DATA_LEN is found in data.h
+        size_t vector_size = DATA_LEN * sizeof(uint64_t);
+        snrt_dma_start_1d(local_a, A, vector_size);
+        snrt_dma_start_1d(local_b, B, vector_size);
+
+        // Measure the end of the transfer process
+        uint32_t end_dma_load = snrt_mcycle();
+    }
+
+    // Synchronize cores by setting up a
+    // fence barrier for the DMA and accelerator core
+    snrt_cluster_hw_barrier();
+
+    // This assigns the tasks inside the condition
+    // to the core controlling the accelerator
+    if (snrt_is_compute_core()) {
+        // Iterate 3 times for different accelerators
+        for (uint32_t i = 0; i < 3; i++) {
+            printf("Accelerator %d \n", i);
+
+            uint32_t start_csr_setup = snrt_mcycle();
+
+            // Configure MUX for the accelerator
+            write_csr_multi_acc_mux(i);
+
+            // Configure streamer settings
+            configure_streamer_a((uint64_t)local_a, 0, 8, LOOP_ITER, 32);
+
+            configure_streamer_b((uint64_t)local_b, 0, 8, LOOP_ITER, 32);
+
+            configure_streamer_o((uint64_t)local_o, 0, 8, LOOP_ITER, 32);
+
+            // Configure ALU settings
+            configure_alu(MODE, LOOP_ITER);
+
+            // Start streamer then start ALU
+            start_streamer();
+            start_alu();
+
+            // Mark the end of the CSR setup cycles
+            uint32_t end_csr_setup = snrt_mcycle();
+
+            // Do this to poll the accelerator
+            while (read_busy_alu()) {
+            };
+
+            // Do this to poll the streamer state
+            while (read_busy_streamer()) {
+            };
+
+            // Compare results and check if the
+            // accelerator returns correct answers
+            // For every incorrect answer, increment err
+            for (uint32_t i = 0; i < DATA_LEN; i++) {
+                if (OUT[i] != *(local_o + i)) {
+                    err++;
+                }
+            }
+
+            // Read performance counter
+            uint32_t perf_count = csrr_ss(ALU_RO_PERF_COUNT);
+
+            printf("Accelerator Done! \n");
+            printf("Accelerator Cycles: %d \n", perf_count);
+            printf("Number of errors: %d \n", err);
+        };
+    };
+
+    return err;
+}

--- a/target/snitch_cluster/sw/snax-multi-alu-run.yaml
+++ b/target/snitch_cluster/sw/snax-multi-alu-run.yaml
@@ -1,0 +1,9 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file contains all tests that require hardware to be built with
+# a snax core with a simple mac accelerator attached to it
+
+runs:
+  - elf: apps/snax-multi-alu/build/snax-multi-alu.elf


### PR DESCRIPTION
This PR is an upgrade to PR #491, where control signals are MUX'd to the appropriate accelerator.

**Advantages to this approach**:
⭐ No need to stack the CSR addresses in SW, so fewer management problems on the SW side
⭐ MUX-ing hardware is made simple as the MUX control is SW managed. So integration is much easier and simplifies design.
⭐ It only uses a single register for configuring.

**How does it work?**
🔧 You only need to write to CSR register number 1990. Or specifically `write_csr(1990, value);` and the value you write is the core address. The order of address is according to the list specified in the configuration file.

**What needs to be tested after this?**
❓ Try with multiple accelerators of different CSR numbers
❓ Try with multiple cores and multiple accelerator architecture

**What needs to be added after this?**
🪄 Accelerator hardware barrier. Note that this was already present before, but it needs to be upgraded.
