### PR TITLE
Fix bit-width mismatch

### DIFF
--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -112,7 +112,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // Observability register
   output logic [ObsWidth-1:0] obs_o,
   // Multi accelerator MUX
-  output logic [ObsWidth-1:0] multi_acc_mux_o,
+  output logic [31:0]   multi_acc_mux_o,
   // Cluster SNAX HW barrier
   input  logic          snax_barrier_i,
   // Cluster HW barrier

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -152,7 +152,7 @@ module snitch_cc #(
   // Observability register
   output logic [ObsWidth-1:0]        obs_o,
   // Multi accelerator MUX
-  output logic [ObsWidth-1:0]        multi_acc_mux_o,
+  output logic [31:0]                multi_acc_mux_o,
   // Cluster HW barrier
   input  logic                       snax_barrier_i,
   output logic                       barrier_o,


### PR DESCRIPTION
This PR is a simple fix for the bit-width mismatch added for the MUX-acc port.

@xiaoling-yi - this is the fix! I wonder why I used the `ObsWidth` which shouldn't have been lol.