### PR TITLE
Rm broadcast cfg in versacore sw

### DIFF
--- a/target/snitch_cluster/sw/apps/snax-versacore-matmul/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-versacore-matmul/data/params.hjson
@@ -12,10 +12,7 @@
   K: 4,
   N: 2,
   M: 3,
-  bypassSIMD: 1,
-  // broadcast_C won't work in the serial C input
-  broadcast_C: 0,
   channel_en_C: 1,
-  // 0 for output, 1 for weight
+  // 0 for output, 1 for weight, 2 for input
   stationary: 0,
 }

--- a/target/snitch_cluster/sw/apps/snax-versacore-matmul/src/snax-versacore-matmul.c
+++ b/target/snitch_cluster/sw/apps/snax-versacore-matmul/src/snax-versacore-matmul.c
@@ -70,7 +70,7 @@ int main() {
             set_addr_remap_index_B, transposed_B, channel_en_B,
 
             delta_local_c, Cslstride, Ctlbound, Ctlstride,
-            set_addr_remap_index_C, channel_en_C, broadcast_C,
+            set_addr_remap_index_C, channel_en_C,
 
             delta_local_d, D32slstride, D32tlbound, D32tlstride,
             set_addr_remap_index_D32, channel_en_D);

--- a/target/snitch_cluster/sw/snax/versacore/include/snax-versacore-lib.h
+++ b/target/snitch_cluster/sw/snax/versacore/include/snax-versacore-lib.h
@@ -44,7 +44,6 @@ void set_versacore_streamer_csr(
 
     int32_t delta_local_c, int32_t* Cslstride, int32_t* Ctlbound,
     int32_t* Ctlstride, int32_t set_addr_remap_index_C, int32_t* channel_en_C,
-    int32_t broadcast_C,
 
     int32_t delta_local_d32, int32_t* D32slstride, int32_t* D32tlbound,
     int32_t* D32tlstride, int32_t set_addr_remap_index_D32,

--- a/target/snitch_cluster/sw/snax/versacore/src/snax-versacore-lib.c
+++ b/target/snitch_cluster/sw/snax/versacore/src/snax-versacore-lib.c
@@ -25,7 +25,6 @@ void set_versacore_streamer_csr(
 
     int32_t delta_local_c, int32_t* Cslstride, int32_t* Ctlbound,
     int32_t* Ctlstride, int32_t set_addr_remap_index_C, int32_t* channel_en_C,
-    int32_t broadcast_C,
 
     int32_t delta_local_d32, int32_t* D32slstride, int32_t* D32tlbound,
     int32_t* D32tlstride, int32_t set_addr_remap_index_D32,
@@ -180,10 +179,6 @@ void set_versacore_streamer_csr(
     csrw_ss(READER_EXTENSION_1_CSR_BASE, transpose_B == 1 ? 0 : 1);
 #endif
 
-#ifdef READER_WRITER_EXTENSION_0_CSR_BASE
-    csrw_ss(READER_WRITER_EXTENSION_0_CSR_BASE, broadcast_C == 1 ? 0 : 1);
-#endif
-
 #else
     // ----------------------------------A-----------------------------------
     // ----------------------------------A-----------------------------------
@@ -330,10 +325,6 @@ void set_versacore_streamer_csr(
 
 #ifdef READER_EXTENSION_1_CSR_BASE
     csrw_ss(READER_EXTENSION_1_CSR_BASE, transpose_B == 1 ? 0 : 1);
-#endif
-
-#ifdef READER_WRITER_EXTENSION_0_CSR_BASE
-    csrw_ss(READER_WRITER_EXTENSION_0_CSR_BASE, broadcast_C == 1 ? 0 : 1);
 #endif
 
 #endif


### PR DESCRIPTION
This PR removes the broadcast configuration in the Versacore test software, as there is no runtime-configurable broadcast extension.