### PR TITLE
Update the axi_riscv_atomics version from 0.6.0 -> 0.8.2

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ package:
 
 dependencies:
   axi:                { git: https://github.com/pulp-platform/axi,                version:  0.39.1  }
-  axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.6.0   }
+  axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.8.2   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells,       version:  1.28.0  }
   FPnew:              { git: https://github.com/pulp-platform/cvfpu.git,      rev:      pulp-v0.1.3 }
   register_interface: { git: https://github.com/pulp-platform/register_interface, version:  0.4.2   }


### PR DESCRIPTION
This PR updates the axi_riscv_atomics package from 0.6.0 to 0.8.2. 

Me and Yunhao are working on adding the FlooNoC to the HeMAiA system. However, the FlooNoC 0.6.1 needs the `axi_riscv_atomics `0.8.2 version (see https://github.com/pulp-platform/FlooNoC/blob/main/Bender.yml). Hence I manually update the package version to reconcile the version conflict between the snitch cluster and FlooNoC.

The snitch cluster only instantiates the `axi_riscv_atomics_wrap `at `target/common/test/tb_memory_axi.sv` line 58, which is not the core function unit. Besides, according to https://github.com/pulp-platform/axi_riscv_atomics/compare/v0.6.0...v0.8.2, that the difference between the `axi_riscv_atomics_wrap` from 0.8.2 and v0.6.0 is it has a new parameter `parameter int unsigned AXI_ADDR_LSB = $clog2(AXI_DATA_WIDTH/8)`. This parameter can be derived from the AXI_DATA_WIDTH. Hence we can see this update is safe.