### PR TITLE
Add AM search program

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
       # Need this for the hypercorex packages
       - name: Install prerequisites
         run: |
-          pip install tqdm matplotlib
+          pip install tqdm matplotlib requests
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -63,6 +63,7 @@ ifeq ($(CFG_OVERRIDE), cfg/snax_hypercorex_cluster.hjson)
 SUBDIRS += snax-hypercorex/test-csr
 SUBDIRS += snax-hypercorex/char-recog
 SUBDIRS += snax-hypercorex/high-dim-bind
+SUBDIRS += snax-hypercorex/am-search
 endif
 
 .PHONY: all clean $(SUBDIRS)

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/Makefile
@@ -1,0 +1,19 @@
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+APP     = am-search
+
+# Grab the include directory from the snax-hypercorex
+INCDIRS += ../../../snax/hypercorex/include
+INCDIRS += data
+
+RISCV_LDFLAGS += ../../../snax/hypercorex/build/snax-hypercorex-lib.o
+
+include ./data/Makefile
+include ../Makefile
+include ../../common.mk
+
+$(DEP): $(DATA_H)

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/data/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/data/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleueven.be>
+
+# Usage of absolute paths is required to externally include this Makefile
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+DATA_DIR := $(realpath $(MK_DIR))
+
+# File paths
+DATAGEN_PY = $(DATA_DIR)/datagen.py
+DATA_H = $(DATA_DIR)/data.h
+
+.PHONY: clean clean-data
+
+clean-data:
+	rm -f $(DATA_H)
+
+clean: clean-data
+clean-sw: clean-data
+
+$(DATA_H): 
+	$(DATAGEN_PY) > $@

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/data/am_search.txt
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/data/am_search.txt
@@ -1,0 +1,5 @@
+ima_reg 0
+mv_reg_qhv 0
+am_search
+mv_reg 0 0
+mv_reg 0 0

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/data/datagen.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+import sys
+import numpy as np
+import os
+import subprocess
+
+# -----------------------
+# Add data utility path
+# -----------------------
+sys.path.append(
+    os.path.join(os.path.dirname(__file__), "../../../../../../../util/sim/")
+)
+from data_utils import format_scalar_definition, format_vector_definition  # noqa: E402
+
+# -----------------------
+# Add hypercorex utility paths
+# -----------------------
+bender_command = subprocess.run(
+    ["bender", "path", "hypercorex"], capture_output=True, text=True
+)
+hypercorex_path = bender_command.stdout.strip()
+
+char_recog_dataset_path = (
+    hypercorex_path + "/hdc_exp/data_set/char_recog/characters.txt"
+)
+
+sys.path.append(hypercorex_path + "/hdc_exp/")
+sys.path.append(hypercorex_path + "/sw/")
+
+from hdc_util import (  # noqa: E402
+    reshape_hv_list,
+)
+
+from system_regression import (  # noqa: E402
+    data_ortho_im_only,
+)
+
+from hypercorex_compiler import compile_hypercorex_asm  # noqa: E402
+
+# Paths for the hypercorex "asm"
+current_directory = os.path.dirname(os.path.abspath(__file__))
+am_search_asm_path = current_directory + "/am_search.txt"
+
+# -----------------------
+# Some useful functions
+# -----------------------
+
+
+# Convert from list to binary value
+def hvlist2num(hv_list):
+    # Bring back into an integer itself!
+    # Sad workaround is to convert to str
+    # The convert to integer
+    hv_num = "".join(hv_list.astype(str))
+    hv_num = int(hv_num, 2)
+
+    return hv_num
+
+
+# -----------------------
+# Working fixed parameters
+# -----------------------
+
+
+snax_hypercorex_parameters = {
+    "seed_size": 32,
+    "hv_dim": 512,
+    "num_total_im": 1024,
+    "num_per_im_bank": 128,
+    "base_seeds": [
+        1103779247,
+        2391206478,
+        3074675908,
+        2850820469,
+        811160829,
+        4032445525,
+        2525737372,
+        2535149661,
+    ],
+    "gen_seed": True,
+    "ca90_mode": "ca90_hier",
+}
+
+# Loading data first
+ortho_im, _ = data_ortho_im_only(
+    seed_size=snax_hypercorex_parameters["seed_size"],
+    hv_dim=snax_hypercorex_parameters["hv_dim"],
+    num_total_im=snax_hypercorex_parameters["num_total_im"],
+    num_per_im_bank=snax_hypercorex_parameters["num_per_im_bank"],
+    base_seeds=snax_hypercorex_parameters["base_seeds"],
+    gen_seed=snax_hypercorex_parameters["gen_seed"],
+    ca90_mode=snax_hypercorex_parameters["ca90_mode"],
+)
+
+# Specifics from cluster
+NARROW_DATA_WIDTH = 64
+WIDE_DATA_WIDTH = 512
+
+# Tailored parameters
+# This one is due to C code limitation
+# Can only take int 32-bits conversion for python
+CUT_WIDTH = 32
+
+# Number of elements per wide
+NUM_CUT_IN_WIDE_ELEM = WIDE_DATA_WIDTH // CUT_WIDTH
+
+# Number of targetted wide data
+TARGET_NUM_DATA = 100
+
+# Total number of data to check
+TOTAL_NUM_DATA = TARGET_NUM_DATA * NUM_CUT_IN_WIDE_ELEM
+
+# Data B is half of ortho im
+HALF_START = len(ortho_im) // 2
+OFFSET_START = HALF_START * NUM_CUT_IN_WIDE_ELEM
+
+ortho_im_reshape = reshape_hv_list(ortho_im, CUT_WIDTH)
+
+
+# Main function to generate data
+def main():
+
+    # Extract instructions for training and testing
+    am_search_code_list, am_search_control_code_list = compile_hypercorex_asm(
+        am_search_asm_path
+    )
+
+    # Convert each instruction to integers for input
+    for i in range(len(am_search_code_list)):
+        am_search_code_list[i] = hvlist2num(np.array(am_search_code_list[i]))
+
+    # Convert ortho im to reshape
+    # Data a is the first TOTAL_NUM_DATA
+    ortho_im_list = []
+    for i in range(TOTAL_NUM_DATA):
+        ortho_im_list.append(hvlist2num(np.array(ortho_im_reshape[i])))
+
+    # Data b is the second TOTAL_NUM_DATA
+    data_b_list = []
+    for i in range(TOTAL_NUM_DATA):
+        data_b_list.append(hvlist2num(np.array(ortho_im_reshape[i + OFFSET_START])))
+
+    # Generating strings to print
+    target_num_data_str = format_scalar_definition(
+        "uint32_t", "target_num_data", TARGET_NUM_DATA
+    )
+    num_cut_in_wide_elem_str = format_scalar_definition(
+        "uint32_t", "num_cut_in_wide_elem", NUM_CUT_IN_WIDE_ELEM
+    )
+    am_search_code_str = format_vector_definition(
+        "uint32_t", "am_search_code", am_search_code_list
+    )
+    # Generate string for ortho_im_reshape
+    ortho_im_list_str = format_vector_definition(
+        "uint32_t", "ortho_im_list", ortho_im_list
+    )
+    # Preparing string to load
+    f_str = "\n\n".join(
+        [
+            target_num_data_str,
+            num_cut_in_wide_elem_str,
+            am_search_code_str,
+            ortho_im_list_str,
+        ]
+    )
+    f_str += "\n"
+
+    # Write to stdout
+    print(f_str)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/src/am-search.c
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/src/am-search.c
@@ -1,0 +1,175 @@
+// Copyright 2024 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//-------------------------------
+// Author: Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Program: Hypercorex Test AM Search
+//
+// This program is to test the Hypercorex's
+// AM search on a continuous data stream.
+//-------------------------------
+
+#include "snrt.h"
+
+#include "data.h"
+#include "snax-hypercorex-lib.h"
+#include "streamer_csr_addr_map.h"
+
+int main() {
+    // Set err value for checking
+    int err = 0;
+
+    //-------------------------------
+    // First load the data to be processed
+    //-------------------------------
+    uint32_t *local_data_0, *local_data_1, *predict_start;
+
+    // Start from base address 0
+    // This is where we will dump the first data
+    local_data_0 = (uint32_t *)snrt_l1_next();
+
+    // Next data is 16 addresses away
+    // Or, the next 8 banks
+    local_data_1 = local_data_0 + num_cut_in_wide_elem;
+
+    // Output will be in the next 8 banks
+    predict_start = local_data_1 + num_cut_in_wide_elem;
+
+    size_t chunk_size = num_cut_in_wide_elem * sizeof(uint32_t);
+    size_t dst_stride = 4 * chunk_size;
+
+    // First load the data accordingly
+    if (snrt_is_dm_core()) {
+        uint32_t start_dma_load = snrt_mcycle();
+        // Load the ortho im list into the first 8 banks
+        // This will be for the AM
+        snrt_dma_start_2d(
+            // Destination address, source address
+            local_data_0, ortho_im_list,
+            // Size per chunk
+            chunk_size,
+            // Destination stride, source stride
+            dst_stride, chunk_size,
+            // Number of times to do
+            target_num_data);
+
+        // This will be for the inputs
+        snrt_dma_start_2d(
+            // Destination address, source address
+            local_data_1, ortho_im_list,
+            // Size per chunk
+            chunk_size,
+            // Destination stride, source stride
+            dst_stride, chunk_size,
+            // Number of times to do
+            target_num_data);
+
+        // Ensure that all DMA tasks finish
+        snrt_dma_wait_all();
+        uint32_t end_dma_load = snrt_mcycle();
+        printf("DMA load time: %d\n", end_dma_load - start_dma_load);
+    };
+
+    // Synchronize cores
+    snrt_cluster_hw_barrier();
+
+    //-------------------------------
+    // Set everything for the compute core
+    //-------------------------------
+    if (snrt_is_compute_core()) {
+        //-------------------------------
+        // Configuring the streamers
+        //-------------------------------
+        uint32_t core_config_start = snrt_mcycle();
+        // Configure streamer for the input
+        hypercorex_set_streamer_highdim_a(
+            (uint32_t)local_data_1,  // Base pointer low
+            0,                       // Base pointer high
+            8,                       // Spatial stride
+            target_num_data,         // Inner loop bound
+            1,                       // Outer loop bound
+            256,                     // Inner loop stride
+            0                        // Outer loop stride
+        );
+
+        // Configure streamer for the AM
+        hypercorex_set_streamer_highdim_am(
+            (uint32_t)local_data_0,  // Base pointer low
+            0,                       // Base pointer high
+            8,                       // Spatial stride
+            target_num_data,         // Inner loop bound
+            target_num_data,         // Outer loop bound
+            256,                     // Inner loop stride
+            0                        // Outer loop stride
+        );
+
+        // Configure streamer for low dim predictions
+        hypercorex_set_streamer_lowdim_predict(
+            (uint32_t)predict_start,  // Base pointer low
+            0,                        // Base pointer high
+            1,                        // Spatial stride
+            target_num_data,          // Inner loop bound
+            1,                        // Outer loop bound
+            256,                      // Inner loop stride
+            0                         // Outer loop stride
+        );
+
+        // Start the streamers
+        hypercorex_start_streamer();
+
+        //-------------------------------
+        // Configuring the Hypercorex
+        //-------------------------------
+
+        // Load instructions for hypercorex
+        hypercorex_load_inst(5, 0, am_search_code);
+
+        // Set number of classes to be predicted
+        // During AM search mode
+        csrw_ss(HYPERCOREX_AM_NUM_PREDICT_REG_ADDR, target_num_data);
+
+        // Enable loop mode to 2D
+        csrw_ss(HYPERCOREX_INST_LOOP_CTRL_REG_ADDR, 0x00000002);
+
+        // Set loop jump addresses
+        hypercorex_set_inst_loop_jump_addr(3, 0, 0);
+
+        // Set loop end addresses
+        hypercorex_set_inst_loop_end_addr(3, 4, 0);
+
+        // Set loop counts
+        hypercorex_set_inst_loop_count(target_num_data, target_num_data, 0);
+
+        // Write control registers
+        csrw_ss(HYPERCOREX_CORE_SET_REG_ADDR, 0x00000010);
+
+        uint32_t core_config_end = snrt_mcycle();
+        printf("Core config time: %d\n", core_config_end - core_config_start);
+
+        uint32_t core_start = snrt_mcycle();
+        // Start hypercorex
+        csrw_ss(HYPERCOREX_CORE_SET_REG_ADDR, 0x00000011);
+
+        // Poll the busy-state of Hypercorex
+        // Check both the Hypercorex and Streamer
+        while (csrr_ss(STREAMER_BUSY_CSR)) {
+        };
+
+        uint32_t core_end = snrt_mcycle();
+        printf("Core run time: %d\n", core_end - core_start);
+
+        // Check if prediction results are correct
+        for (uint32_t i = 0; i < 10; i++) {
+            if (i != (uint32_t) * (predict_start + i * 64)) {   
+                err++;
+            }
+        };
+    };
+
+    // Synchronize cores
+    snrt_cluster_hw_barrier();
+
+    return err;
+}

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/src/am-search.c
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/am-search/src/am-search.c
@@ -162,7 +162,7 @@ int main() {
 
         // Check if prediction results are correct
         for (uint32_t i = 0; i < 10; i++) {
-            if (i != (uint32_t) * (predict_start + i * 64)) {   
+            if (i != (uint32_t) * (predict_start + i * 64)) {
                 err++;
             }
         };

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/char-recog/data/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/char-recog/data/Makefile
@@ -18,6 +18,7 @@ clean-data:
 	rm -f $(DATA_H)
 
 clean: clean-data
+clean-sw: clean-data
 
 $(DATA_H): 
 	$(DATAGEN_PY) > $@

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/high-dim-bind/data/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/high-dim-bind/data/Makefile
@@ -18,6 +18,7 @@ clean-data:
 	rm -f $(DATA_H)
 
 clean: clean-data
+clean-sw: clean-data
 
 $(DATA_H): 
 	$(DATAGEN_PY) > $@

--- a/target/snitch_cluster/sw/snax-hypercorex-run.yaml
+++ b/target/snitch_cluster/sw/snax-hypercorex-run.yaml
@@ -7,4 +7,6 @@
 
 runs:
   - elf: apps/snax-hypercorex/test-csr/build/test-csr.elf
+  - elf: apps/snax-hypercorex/high-dim-bind/build/high-dim-bind.elf
+  - elf: apps/snax-hypercorex/am-search/build/am-search.elf
   - elf: apps/snax-hypercorex/char-recog/build/char-recog.elf


### PR DESCRIPTION
This PR adds the AM search program, a subset of what is needed for the Hemaia bring-up of the CNN+FSL.

Flow of the program:
- Load the orthogonal IM of the IM core as inputs in the TCDM and the AM.
- Do an am search for each orthogonal IM with the AM
- Expected output is the same indices to which the IM is arranged (i.e., 0-99)
- Did this for 100 samples

Major TODO:
- [x] Create the program
- [x] Create the datagen.py

Minor TOOD:
- [x] Fix the clean-data commands