### PR TITLE
Add ISOLET recognition

### DIFF
--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -64,6 +64,7 @@ SUBDIRS += snax-hypercorex/test-csr
 SUBDIRS += snax-hypercorex/char-recog
 SUBDIRS += snax-hypercorex/high-dim-bind
 SUBDIRS += snax-hypercorex/am-search
+SUBDIRS += snax-hypercorex/isolet-recog
 endif
 
 .PHONY: all clean $(SUBDIRS)

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/Makefile
@@ -1,0 +1,19 @@
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+APP     = isolet-recog
+
+# Grab the include directory from the snax-hypercorex
+INCDIRS += ../../../snax/hypercorex/include
+INCDIRS += data
+
+RISCV_LDFLAGS += ../../../snax/hypercorex/build/snax-hypercorex-lib.o
+
+include ./data/Makefile
+include ../Makefile
+include ../../common.mk
+
+$(DEP): $(DATA_H)

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleueven.be>
+
+# Usage of absolute paths is required to externally include this Makefile
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+DATA_DIR := $(realpath $(MK_DIR))
+
+# File paths
+DATAGEN_PY = $(DATA_DIR)/datagen.py
+DATA_H = $(DATA_DIR)/data.h
+
+.PHONY: clean clean-data
+
+clean-data:
+	rm -f $(DATA_H)
+
+clean: clean-data
+clean-sw: clean-data
+
+$(DATA_H): 
+	$(DATAGEN_PY) > $@

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/datagen.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+import sys
+import numpy as np
+import os
+import subprocess
+
+# -----------------------
+# Add data utility path
+# -----------------------
+sys.path.append(
+    os.path.join(os.path.dirname(__file__), "../../../../../../../util/sim/")
+)
+from data_utils import format_scalar_definition, format_vector_definition  # noqa: E402
+
+# -----------------------
+# Add hypercorex utility paths
+# -----------------------
+bender_command = subprocess.run(
+    ["bender", "path", "hypercorex"], capture_output=True, text=True
+)
+hypercorex_path = bender_command.stdout.strip()
+
+sys.path.append(hypercorex_path + "/hdc_exp/")
+sys.path.append(hypercorex_path + "/sw/")
+
+from hdc_util import (  # noqa: E402
+    load_am_model,
+    load_dataset,
+    pack_ld_to_hd,
+    reshape_hv_list,
+)
+
+from hypercorex_compiler import compile_hypercorex_asm  # noqa: E402
+
+# Paths for the hypercorex "asm"
+current_directory = os.path.dirname(os.path.abspath(__file__))
+asm_path = current_directory + "/isolet_recog.txt"
+
+# -----------------------
+# Some useful functions
+# -----------------------
+
+
+# Convert from list to binary value
+def hvlist2num(hv_list):
+    # Bring back into an integer itself!
+    # Sad workaround is to convert to str
+    # The convert to integer
+    hv_num = "".join(hv_list.astype(str))
+    hv_num = int(hv_num, 2)
+
+    return hv_num
+
+
+def reorder_list(input_list, reorder_chunk_size, num_iterations):
+    new_list = []
+    for i in range(num_iterations):
+        sub_list = input_list[i * reorder_chunk_size : (i + 1) * reorder_chunk_size]
+        # Reverse the sublist
+        sub_list_reversed = sub_list[::-1]
+        # Append the reversed sublist to the new list
+        new_list.extend(sub_list_reversed)
+    return new_list
+
+
+# -----------------------
+# Working fixed parameters
+# -----------------------
+
+
+snax_hypercorex_parameters = {
+    "seed_size": 32,
+    "hv_dim": 512,
+    "num_total_im": 1024,
+    "num_per_im_bank": 128,
+    "base_seeds": [
+        1103779247,
+        2391206478,
+        3074675908,
+        2850820469,
+        811160829,
+        4032445525,
+        2525737372,
+        2535149661,
+    ],
+    "gen_seed": True,
+    "ca90_mode": "ca90_hier",
+}
+
+# Number of classes in the ISOLET dataset
+NUM_CLASSES = 26
+
+# Specifics from cluster
+NARROW_DATA_WIDTH = 64
+WIDE_DATA_WIDTH = 512
+
+# Tailored parameters
+# This one is due to C code limitation
+# Can only take int 32-bits conversion for python
+CUT_WIDTH = 32
+
+
+# Main function to generate data
+def main():
+
+    # Extract instructions for training and testing
+    code_list, control_code_list = compile_hypercorex_asm(asm_path)
+
+    # Convert each instruction to integers for input
+    for i in range(len(code_list)):
+        code_list[i] = hvlist2num(np.array(code_list[i]))
+
+    # Loading data first
+    assoc_mem_fp = hypercorex_path + "/hemaia/trained_am/hypx_isolet_am.txt"
+    assoc_mem = load_am_model(assoc_mem_fp)
+
+    # Reshape the associative memory
+    assoc_mem_reshape = reshape_hv_list(assoc_mem, CUT_WIDTH)
+
+    # Save into AM list
+    am_list = []
+    for i in range(len(assoc_mem_reshape)):
+        am_list.append(hvlist2num(np.array(assoc_mem_reshape[i])))
+
+    # Reorder associative memory
+    am_list = reorder_list(am_list, 16, NUM_CLASSES)
+
+    # Loading test samples
+    test_samples_fp = hypercorex_path + "/hemaia/test_samples/hypx_isolet_test.txt"
+    test_samples = load_dataset(test_samples_fp)
+
+    # Pack samples into 32 bits
+    test_samples_compressed = []
+    for i in range(len(test_samples)):
+        compressed_sample = pack_ld_to_hd(test_samples[i], 8, CUT_WIDTH)
+        # Add extra 0 so the entire chunk fits in 64 bits later on
+        compressed_sample.append(0)
+        test_samples_compressed.append(compressed_sample)
+
+    test_samples_list = []
+    for i in range(len(test_samples_compressed)):
+        for j in range(len(test_samples_compressed[i])):
+            test_samples_list.append(test_samples_compressed[i][j])
+
+    # Golden list of data
+    golden_list_data = list(range(NUM_CLASSES))
+    golden_list_data[0] = 7
+
+    code_str = format_vector_definition("uint32_t", "code", code_list)
+    am_list_str = format_vector_definition("uint32_t", "am_list", am_list)
+    test_samples_str = format_vector_definition(
+        "uint32_t", "test_samples_list", test_samples_list
+    )
+    # Generate golden list
+    golden_list_data_str = format_vector_definition(
+        "uint32_t", "golden_list_data", golden_list_data
+    )
+    # Preparing string to load
+    f_str = "\n\n".join(
+        [
+            code_str,
+            am_list_str,
+            test_samples_str,
+            golden_list_data_str,
+        ]
+    )
+    f_str += "\n"
+
+    # Write to stdout
+    print(f_str)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/datagen.py
@@ -17,7 +17,7 @@ import subprocess
 sys.path.append(
     os.path.join(os.path.dirname(__file__), "../../../../../../../util/sim/")
 )
-from data_utils import format_scalar_definition, format_vector_definition  # noqa: E402
+from data_utils import format_vector_definition  # noqa: E402
 
 # -----------------------
 # Add hypercorex utility paths
@@ -62,7 +62,8 @@ def hvlist2num(hv_list):
 def reorder_list(input_list, reorder_chunk_size, num_iterations):
     new_list = []
     for i in range(num_iterations):
-        sub_list = input_list[i * reorder_chunk_size : (i + 1) * reorder_chunk_size]
+        sub_list = \
+            input_list[i * reorder_chunk_size:(i + 1) * reorder_chunk_size]
         # Reverse the sublist
         sub_list_reversed = sub_list[::-1]
         # Append the reversed sublist to the new list
@@ -133,7 +134,8 @@ def main():
     am_list = reorder_list(am_list, 16, NUM_CLASSES)
 
     # Loading test samples
-    test_samples_fp = hypercorex_path + "/hemaia/test_samples/hypx_isolet_test.txt"
+    test_samples_fp = \
+        hypercorex_path + "/hemaia/test_samples/hypx_isolet_test.txt"
     test_samples = load_dataset(test_samples_fp)
 
     # Pack samples into 32 bits

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/isolet_recog.txt
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/data/isolet_recog.txt
@@ -1,0 +1,4 @@
+imab_bind_bunda
+mv_bunda_qhv
+am_search
+clr_bunda

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/src/isolet-recog.c
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/src/isolet-recog.c
@@ -1,0 +1,188 @@
+// Copyright 2024 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//-------------------------------
+// Author: Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Program: Hypercorex Test CSRs
+//
+// This program is to test the capabilities
+// of the HyperCoreX accelerator's CSRs so the test is
+// to check if registers are working as intended.
+//
+// This includes checking for RW, RO, and WO registers.
+//-------------------------------
+
+#include "snrt.h"
+
+#include "data.h"
+#include "snax-hypercorex-lib.h"
+#include "streamer_csr_addr_map.h"
+
+int main() {
+    // Set err value for checking
+    int err = 0;
+
+    //-------------------------------
+    // First load the data to be processed
+    //-------------------------------
+    uint32_t num_predictions = 24;
+    uint32_t num_features = 617;
+    uint32_t num_classes = 26;
+
+    uint32_t *am_start, *data_start_1, *data_start_2, *predict_start;
+
+    // AM address starts from 0
+    am_start = (uint64_t *)snrt_l1_next();
+
+    // Next data is 16 32b addresses away
+    data_start_1 = am_start + 16;
+    data_start_2 = am_start + 32;
+
+    // Output will be in the last 8 banks
+    predict_start = am_start + 48;
+
+    size_t src_stride = 16 * sizeof(uint32_t);
+    size_t dst_stride = 4 * src_stride;
+
+    // First load the data accordingly
+    if (snrt_is_dm_core()) {
+        uint32_t start_dma_load = snrt_mcycle();
+
+        // Load the AM unto the 1st 8 banks
+        snrt_dma_start_2d(
+            // Destination address, source address
+            am_start, am_list,
+            // Size per chunk
+            src_stride,
+            // Destination stride, source stride
+            dst_stride, src_stride,
+            // Number of times to do
+            num_classes);
+
+        // Load the data a list into the 2nd 8 banks
+        snrt_dma_start_2d(
+            // Destination address, source address
+            data_start_1, test_samples_list,
+            // Size per chunk
+            src_stride,
+            // Destination stride, source stride
+            dst_stride, src_stride,
+            // Number of times to do
+            234);
+
+        // Ensure that all DMA tasks finish
+        snrt_dma_wait_all();
+
+        uint32_t end_dma_load = snrt_mcycle();
+        printf("DMA load time: %d\n", end_dma_load - start_dma_load);
+    };
+
+    // Synchronize cores
+    snrt_cluster_hw_barrier();
+
+    //-------------------------------
+    // Set everything for the compute core
+    //-------------------------------
+    if (snrt_is_compute_core()) {
+        //-------------------------------
+        // Configuring the streamers
+        //-------------------------------
+        uint32_t core_config_start = snrt_mcycle();
+        // Configure streamer for high dim A
+        hypercorex_set_streamer_lowdim_a(
+            (uint32_t)data_start_1,  // Base pointer low
+            0,                       // Base pointer high
+            1,                       // Spatial stride
+            8,                       // Inner loop bound
+            234,                     // Outer loop bound
+            8,                       // Inner loop stride
+            256                      // Outer loop stride
+        );
+
+        // Configure streamer for AM
+        hypercorex_set_streamer_highdim_am(
+            (uint32_t)am_start,  // Base pointer low
+            0,                   // Base pointer high
+            8,                   // Spatial stride
+            num_classes,         // Inner loop bound
+            num_predictions,     // Outer loop bound
+            256,                 // Inner loop stride
+            0                    // Outer loop stride
+        );
+
+        hypercorex_set_streamer_lowdim_predict(
+            (uint32_t)predict_start,  // Base pointer low
+            0,                        // Base pointer high
+            1,                        // Spatial stride
+            num_predictions,          // Inner loop bound
+            1,                        // Outer loop bound
+            256,                      // Inner loop stride
+            0                         // Outer loop stride
+        );
+
+        // Start the streamers
+        hypercorex_start_streamer();
+
+        //-------------------------------
+        // Configuring the Hypercorex
+        //-------------------------------
+
+        // Write number of classes to be checked
+        csrw_ss(HYPERCOREX_AM_NUM_PREDICT_REG_ADDR, num_classes);
+
+        // Load instructions for hypercorex
+        hypercorex_load_inst(4, 0, code);
+
+        // Enable loop mode to 2D
+        csrw_ss(HYPERCOREX_INST_LOOP_CTRL_REG_ADDR, 0x00000002);
+
+        // Encoding loops and jumps
+        hypercorex_set_inst_loop_jump_addr(0, 0, 0);
+
+        hypercorex_set_inst_loop_end_addr(0, 3, 0);
+
+        hypercorex_set_inst_loop_count(num_features, num_predictions, 0);
+
+        // Set data slice control and automatic updates
+        hypercorex_set_data_slice_ctrl(3, 0, 0, 1);
+        hypercorex_set_data_slice_num_elem_a(num_features);
+
+        hypercorex_set_auto_counter_start_b(0);
+        hypercorex_set_auto_counter_num_b(num_features);
+
+        // Write control registers
+        csrw_ss(HYPERCOREX_CORE_SET_REG_ADDR, 0x00000008);
+
+        uint32_t core_config_end = snrt_mcycle();
+        printf("Core config time: %d\n", core_config_end - core_config_start);
+
+        uint32_t core_start = snrt_mcycle();
+
+        // Start hypercorex
+        csrw_ss(HYPERCOREX_CORE_SET_REG_ADDR, 0x00000009);
+
+        // Poll the busy-state of Hypercorex
+        // Check both the Hypercorex and Streamer
+        while (csrr_ss(STREAMER_BUSY_CSR)) {
+        };
+
+        uint32_t core_end = snrt_mcycle();
+        printf("Core run time: %d\n", core_end - core_start);
+
+        //-------------------------------
+        // Check results
+        //-------------------------------
+        for (uint32_t i = 0; i < num_predictions; i++) {
+            if (golden_list_data[i] != (uint32_t)*(predict_start + i * 64)) {
+                err++;
+            }
+        };
+    };
+
+    // Synchronize cores
+    snrt_cluster_hw_barrier();
+
+    return err;
+}

--- a/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/src/isolet-recog.c
+++ b/target/snitch_cluster/sw/apps/snax-hypercorex/isolet-recog/src/isolet-recog.c
@@ -175,7 +175,7 @@ int main() {
         // Check results
         //-------------------------------
         for (uint32_t i = 0; i < num_predictions; i++) {
-            if (golden_list_data[i] != (uint32_t)*(predict_start + i * 64)) {
+            if (golden_list_data[i] != (uint32_t) * (predict_start + i * 64)) {
                 err++;
             }
         };

--- a/target/snitch_cluster/sw/snax-hypercorex-run.yaml
+++ b/target/snitch_cluster/sw/snax-hypercorex-run.yaml
@@ -9,5 +9,5 @@ runs:
   - elf: apps/snax-hypercorex/test-csr/build/test-csr.elf
   - elf: apps/snax-hypercorex/high-dim-bind/build/high-dim-bind.elf
   - elf: apps/snax-hypercorex/am-search/build/am-search.elf
-  - elf: apps/snax-hypercorex/am-search/build/isolet-recog.elf
+  - elf: apps/snax-hypercorex/isolet-recog/build/isolet-recog.elf
   - elf: apps/snax-hypercorex/char-recog/build/char-recog.elf

--- a/target/snitch_cluster/sw/snax-hypercorex-run.yaml
+++ b/target/snitch_cluster/sw/snax-hypercorex-run.yaml
@@ -9,4 +9,5 @@ runs:
   - elf: apps/snax-hypercorex/test-csr/build/test-csr.elf
   - elf: apps/snax-hypercorex/high-dim-bind/build/high-dim-bind.elf
   - elf: apps/snax-hypercorex/am-search/build/am-search.elf
+  - elf: apps/snax-hypercorex/am-search/build/isolet-recog.elf
   - elf: apps/snax-hypercorex/char-recog/build/char-recog.elf


### PR DESCRIPTION
This PR adds the ISOLET recognition test.

Major TODO:
- [x] Make data generator for this
- [x] Add ISOLET program

Notes:
- There is a necessary reorder function in the datagen.py. This is because the bits are flipped when we load the AM.