### PR TITLE
Fix Race Condition in BSS Initialization for Multi-Cluster Execution

### DIFF
--- a/sw/snRuntime/src/start.c
+++ b/sw/snRuntime/src/start.c
@@ -78,6 +78,7 @@ static inline void snrt_init_bss() {
             *p = 0U;
         }
     }
+    snrt_global_barrier();
 }
 #endif
 
@@ -155,11 +156,6 @@ void snrt_main() {
 
 #ifdef SNRT_INIT_CLS
     snrt_init_cls();
-#endif
-
-#if defined(SNRT_INIT_BSS) || defined(SNRT_INIT_CLS)
-    // Single DMA wait call for both snrt_init_bss() and snrt_init_cls()
-    if (snrt_is_dm_core()) snrt_dma_wait_all();
 #endif
 
 #ifdef SNRT_CRT0_CALLBACK3

--- a/sw/snRuntime/src/sync.c
+++ b/sw/snRuntime/src/sync.c
@@ -6,9 +6,12 @@
 // Data
 //================================================================================
 
-volatile uint32_t _snrt_mutex;
-volatile snrt_barrier_t _snrt_barrier;
-volatile uint32_t _reduction_result;
+volatile uint32_t _snrt_mutex __attribute__((section(".data"))) = 0;
+volatile snrt_barrier_t _snrt_barrier __attribute__((section(".data"))) = {
+    .cnt       = 0,
+    .iteration = 0
+};
+volatile uint32_t _reduction_result __attribute__((section(".data"))) = 0;
 
 //================================================================================
 // Functions


### PR DESCRIPTION
### Problem Description
This PR resolves a critical race condition during BSS initialization that occurs when running code with multiple clusters. The issue manifests as a deadlock at the first global barrier in multi-cluster configurations:

```
int main() {
    if (snrt_cluster_idx() == 0) {
        if (snrt_is_dm_core()) {
            printf("[C0] Alive \r\n");
        }
    }
    snrt_global_barrier();  // System deadlocks here in multi-cluster runs
    return 0;
}

```

### Root Cause Analysis:
Generally the code would be look like this 

```
1. if(cluster_num==0) snrt_init_bss();
2. if(cluster_num==0) print();
3. snrt_global_barrier();
```

1. BSS Initialization Race:

- The _snrt_barrier structure (defined in sw/snRuntime/src/sync.h) resides in the .bss section
- Cluster 0 initializes the BSS section via snrt_init_bss() (called from snrt_main() in sw/snRuntime/src/start.c)
- Non-zero clusters can reach snrt_global_barrier() and modify _snrt_barrier.cnt before Cluster 0 initializes BSS
- Cluster 0's BSS initialization subsequently zeros out the partially updated barrier state

2. Chicken-and-Egg Problem：

- Barrier synchronization requires initialized memory state
- Memory initialization requires synchronization to prevent races
- This circular dependency caused deadlocks when:
  - Non-zero clusters increment _snrt_barrier.cnt
  - Cluster 0 later resets it to 0 during BSS init
  - All clusters then wait indefinitely for the barrier count to reach snrt_cluster_num()

### Solution Implemented
1. Critical Variable Relocation:
```
// Before: In .bss section (vulnerable to init race)
volatile uint32_t _snrt_mutex;
volatile snrt_barrier_t _snrt_barrier;
volatile uint32_t _reduction_result;

// After: Explicitly placed in .data section
volatile uint32_t _snrt_mutex __attribute__((section(".data"))) = 0;
volatile snrt_barrier_t _snrt_barrier __attribute__((section(".data"))) = {
    .cnt       = 0,
    .iteration = 0
};
volatile uint32_t _reduction_result __attribute__((section(".data"))) = 0;
```
2. Synchronization Point Added:
```
#ifdef SNRT_INIT_BSS
static inline void snrt_init_bss() {
    extern volatile uint32_t __bss_start, __bss_end;
    // Only one core needs to perform the initialization
    // As the snitch core is 32bit, initialize the bss region above 4GB does not
    // make sense.

    if (snrt_cluster_idx() == 0 && snrt_is_dm_core()) {
        volatile uint8_t* bss_start = (volatile uint8_t*)&__bss_start;
        volatile uint8_t* bss_end = (volatile uint8_t*)&__bss_end;
        size_t size = bss_end - bss_start;
        for (volatile uint8_t* p = bss_start; p < bss_end; p++) {
            *p = 0U;
        }
    }
    snrt_global_barrier(); // Newly added global sync
}
#endif
```
Another minor change is the DMA wait call is removed since BSS/CLS initialization no longer uses DMA.