### PR TITLE
.gitattributes: no diff for pixi.lock files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # SCM syntax highlighting
 pixi.lock linguist-language=YAML linguist-generated=true
+# Exclude lock from git diff
+pixi.lock -diff


### PR DESCRIPTION
This makes sure the diffs are a bit more cleaner when updating pixi environment things (for example like in #518)