### PR TITLE
delete build.properties

### DIFF
--- a/hw/chisel/project/build.properties
+++ b/hw/chisel/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.6

--- a/hw/chisel_acc/project/build.properties
+++ b/hw/chisel_acc/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.6


### PR DESCRIPTION
The sbt version is already specified explicitly here:
https://github.com/KULeuven-MICAS/snax_cluster/blob/583a97c9c1b4f7c7eab8157a067c62a2bf26caef/pixi.toml#L30

Can these be deleted?
The fact that these versions aren't the same was the reason the CI in praxis was failing...