### PR TITLE
Eliminate IDMA trace printing + Optimize cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
           sw/runtime.yaml \
           sw/snax-xdma-run.yaml -j
 
-  snax-VersaCore-cluster-vlt-generic:
+  snax-versaCore-cluster-vlt-generic:
     name: Simulate SW on VersaCore cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     steps:
@@ -338,15 +338,15 @@ jobs:
       - name: Generate RTL
         run: |
           make -C target/snitch_cluster rtl-gen \
-          CFG_OVERRIDE=cfg/snax_versacore.hjson
+          CFG_OVERRIDE=cfg/snax_versacore_cluster.hjson
       - name: Build Hardware
         run: |
-          make CFG_OVERRIDE=cfg/snax_versacore.hjson \
+          make CFG_OVERRIDE=cfg/snax_versacore_cluster.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
-          CFG_OVERRIDE=cfg/snax_versacore.hjson
+          CFG_OVERRIDE=cfg/snax_versacore_cluster.hjson
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,3 +354,34 @@ jobs:
           sw/runtime.yaml \
           sw/snax-versacore-matmul-run.yaml \
           sw/snax-xdma-run.yaml -j
+
+  snax-xdma-cluster-vlt-generic:
+    name: Simulate SW on XDMA cluster w/ Verilator (Generic LLVM)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          cache: true
+          cache-write: ${{ github.event_name == 'push' &&
+            github.ref_name == 'main' }}
+          activate-environment: true
+      - name: Generate RTL
+        run: |
+          make -C target/snitch_cluster rtl-gen \
+          CFG_OVERRIDE=cfg/snax_xdma_cluster.hjson
+      - name: Build Hardware
+        run: |
+          make CFG_OVERRIDE=cfg/snax_xdma_cluster.hjson \
+          -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
+      - name: Build Software
+        run: |
+          make -C target/snitch_cluster sw \
+          CFG_OVERRIDE=cfg/snax_xdma_cluster.hjson
+      - name: Run Tests
+        working-directory: target/snitch_cluster
+        run: |-
+          ./run.py --simulator verilator \
+          sw/snax-xdma-run.yaml -j

--- a/Bender.yml
+++ b/Bender.yml
@@ -385,6 +385,20 @@ sources:
       # Level 1
       - target/snitch_cluster/generated/snax_KUL_cluster_xdma/snax_KUL_cluster_xdma_wrapper.sv
 
+  - target: snax_versacore_cluster_xdma
+    files:
+      # Level 0
+      - target/snitch_cluster/generated/snax_versacore_cluster_xdma/snax_versacore_cluster_xdma.sv
+      # Level 1
+      - target/snitch_cluster/generated/snax_versacore_cluster_xdma/snax_versacore_cluster_xdma_wrapper.sv
+
+  - target: snax_xdma_cluster_xdma
+    files:
+      # Level 0
+      - target/snitch_cluster/generated/snax_xdma_cluster_xdma/snax_xdma_cluster_xdma.sv
+      # Level 1
+      - target/snitch_cluster/generated/snax_xdma_cluster_xdma/snax_xdma_cluster_xdma_wrapper.sv
+
   - target: test
     files:
       - hw/snitch_cluster/test/snitch_tcdm_interconnect_tb.sv
@@ -429,6 +443,13 @@ sources:
     files:
       - target/snitch_cluster/generated/snax_KUL_cluster_wrapper.sv
 
+  - target: snax_versacore_cluster
+    files:
+      - target/snitch_cluster/generated/snax_versacore_cluster_wrapper.sv
+
+  - target: snax_xdma_cluster
+    files:
+      - target/snitch_cluster/generated/snax_xdma_cluster_wrapper.sv
   #---------------------------
   # Test harness declaration
   #---------------------------

--- a/hw/chisel/src/main/scala/snax/streamer/StreamParamGen.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/StreamParamGen.scala
@@ -2,13 +2,12 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
-
 package snax.streamer
- 
+
 import snax.readerWriter._
 import snax.csr_manager._
 import snax.utils._
- 
+
 import chisel3._
 import chisel3.util._
 
@@ -19,107 +18,110 @@ object StreamerParametersGen {
 // constrain: all the reader and writer needs to have same config of crossClockDomain
   def hasCrossClockDomain = false
 
-  def readerParams = Seq(
-    new ReaderWriterParam(
-      spatialBounds = List(
-        8
+  def readerParams =
+    Seq(
+      new ReaderWriterParam(
+        spatialBounds       = List(
+          8
+        ),
+        temporalDimension   = 6,
+        tcdmDataWidth       = 64,
+        tcdmSize            = 128,
+        tcdmLogicWordSize   = Seq(
+          256,
+          128,
+          64
+        ),
+        numChannel          = 8,
+        addressBufferDepth  = 8,
+        dataBufferDepth     = 8,
+        configurableChannel = false,
+        crossClockDomain    = hasCrossClockDomain
       ),
-      temporalDimension = 6,
-      tcdmDataWidth = 64,
-      tcdmSize = 128,
-      tcdmLogicWordSize = Seq(
-        256,
-        128,
-        64
-      ),
-      numChannel = 8,
-      addressBufferDepth = 8,
-      dataBufferDepth = 8,
-      configurableChannel = false,
-      crossClockDomain = hasCrossClockDomain
-   ), 
-    new ReaderWriterParam(
-      spatialBounds = List(
-        8
-      ),
-      temporalDimension = 3,
-      tcdmDataWidth = 64,
-      tcdmSize = 128,
-      tcdmLogicWordSize = Seq(
-        256,
-        128,
-        64
-      ),
-      numChannel = 8,
-      addressBufferDepth = 8,
-      dataBufferDepth = 8,
-      configurableChannel = false,
-      crossClockDomain = hasCrossClockDomain
+      new ReaderWriterParam(
+        spatialBounds       = List(
+          8
+        ),
+        temporalDimension   = 3,
+        tcdmDataWidth       = 64,
+        tcdmSize            = 128,
+        tcdmLogicWordSize   = Seq(
+          256,
+          128,
+          64
+        ),
+        numChannel          = 8,
+        addressBufferDepth  = 8,
+        dataBufferDepth     = 8,
+        configurableChannel = false,
+        crossClockDomain    = hasCrossClockDomain
+      )
     )
-  )
 
-  def writerParams = Seq(
-    new ReaderWriterParam(
-      spatialBounds = List(
-        8
-      ),
-      temporalDimension = 3,
-      tcdmDataWidth = 64,
-      tcdmSize = 128,
-      tcdmLogicWordSize = Seq(
-        256,
-        128,
-        64
-      ),
-      numChannel = 8,
-      addressBufferDepth = 1,
-      dataBufferDepth = 1,
-      configurableChannel = false,
-      crossClockDomain = hasCrossClockDomain
+  def writerParams =
+    Seq(
+      new ReaderWriterParam(
+        spatialBounds       = List(
+          8
+        ),
+        temporalDimension   = 3,
+        tcdmDataWidth       = 64,
+        tcdmSize            = 128,
+        tcdmLogicWordSize   = Seq(
+          256,
+          128,
+          64
+        ),
+        numChannel          = 8,
+        addressBufferDepth  = 1,
+        dataBufferDepth     = 1,
+        configurableChannel = false,
+        crossClockDomain    = hasCrossClockDomain
+      )
     )
-  )
 
-  def readerWriterParams = Seq(
-    new ReaderWriterParam(
-      spatialBounds = List(
-        8,
-        4
+  def readerWriterParams =
+    Seq(
+      new ReaderWriterParam(
+        spatialBounds       = List(
+          8,
+          4
+        ),
+        temporalDimension   = 3,
+        tcdmDataWidth       = 64,
+        tcdmSize            = 128,
+        tcdmLogicWordSize   = Seq(
+          256,
+          128,
+          64
+        ),
+        numChannel          = 32,
+        addressBufferDepth  = 1,
+        dataBufferDepth     = 1,
+        configurableChannel = true,
+        crossClockDomain    = hasCrossClockDomain
       ),
-      temporalDimension = 3,
-      tcdmDataWidth = 64,
-      tcdmSize = 128,
-      tcdmLogicWordSize = Seq(
-        256,
-        128,
-        64
-      ),
-      numChannel = 32,
-      addressBufferDepth = 1,
-      dataBufferDepth = 1,
-      configurableChannel = true,
-      crossClockDomain = hasCrossClockDomain
-   ), 
-    new ReaderWriterParam(
-      spatialBounds = List(
-        8,
-        4
-      ),
-      temporalDimension = 3,
-      tcdmDataWidth = 64,
-      tcdmSize = 128,
-      tcdmLogicWordSize = Seq(
-        256,
-        128,
-        64
-      ),
-      numChannel = 32,
-      addressBufferDepth = 1,
-      dataBufferDepth = 1,
-      configurableChannel = false,
-      crossClockDomain = hasCrossClockDomain
+      new ReaderWriterParam(
+        spatialBounds       = List(
+          8,
+          4
+        ),
+        temporalDimension   = 3,
+        tcdmDataWidth       = 64,
+        tcdmSize            = 128,
+        tcdmLogicWordSize   = Seq(
+          256,
+          128,
+          64
+        ),
+        numChannel          = 32,
+        addressBufferDepth  = 1,
+        dataBufferDepth     = 1,
+        configurableChannel = false,
+        crossClockDomain    = hasCrossClockDomain
+      )
     )
-  )
 
-  def tagName = "snax_streamer_gemmX_"
+  def tagName        = "snax_streamer_gemmX_"
   def headerFilepath = "../../target/snitch_cluster/sw/snax/gemmx/include"
 }

--- a/hw/chisel/src/main/scala/snax/streamer/StreamParamGen.scala
+++ b/hw/chisel/src/main/scala/snax/streamer/StreamParamGen.scala
@@ -1,0 +1,125 @@
+// Copyright 2024 KU Leuven.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+
+package snax.streamer
+ 
+import snax.readerWriter._
+import snax.csr_manager._
+import snax.utils._
+ 
+import chisel3._
+import chisel3.util._
+
+// Streamer parameters
+// tcdm_size in KB
+object StreamerParametersGen {
+
+// constrain: all the reader and writer needs to have same config of crossClockDomain
+  def hasCrossClockDomain = false
+
+  def readerParams = Seq(
+    new ReaderWriterParam(
+      spatialBounds = List(
+        8
+      ),
+      temporalDimension = 6,
+      tcdmDataWidth = 64,
+      tcdmSize = 128,
+      tcdmLogicWordSize = Seq(
+        256,
+        128,
+        64
+      ),
+      numChannel = 8,
+      addressBufferDepth = 8,
+      dataBufferDepth = 8,
+      configurableChannel = false,
+      crossClockDomain = hasCrossClockDomain
+   ), 
+    new ReaderWriterParam(
+      spatialBounds = List(
+        8
+      ),
+      temporalDimension = 3,
+      tcdmDataWidth = 64,
+      tcdmSize = 128,
+      tcdmLogicWordSize = Seq(
+        256,
+        128,
+        64
+      ),
+      numChannel = 8,
+      addressBufferDepth = 8,
+      dataBufferDepth = 8,
+      configurableChannel = false,
+      crossClockDomain = hasCrossClockDomain
+    )
+  )
+
+  def writerParams = Seq(
+    new ReaderWriterParam(
+      spatialBounds = List(
+        8
+      ),
+      temporalDimension = 3,
+      tcdmDataWidth = 64,
+      tcdmSize = 128,
+      tcdmLogicWordSize = Seq(
+        256,
+        128,
+        64
+      ),
+      numChannel = 8,
+      addressBufferDepth = 1,
+      dataBufferDepth = 1,
+      configurableChannel = false,
+      crossClockDomain = hasCrossClockDomain
+    )
+  )
+
+  def readerWriterParams = Seq(
+    new ReaderWriterParam(
+      spatialBounds = List(
+        8,
+        4
+      ),
+      temporalDimension = 3,
+      tcdmDataWidth = 64,
+      tcdmSize = 128,
+      tcdmLogicWordSize = Seq(
+        256,
+        128,
+        64
+      ),
+      numChannel = 32,
+      addressBufferDepth = 1,
+      dataBufferDepth = 1,
+      configurableChannel = true,
+      crossClockDomain = hasCrossClockDomain
+   ), 
+    new ReaderWriterParam(
+      spatialBounds = List(
+        8,
+        4
+      ),
+      temporalDimension = 3,
+      tcdmDataWidth = 64,
+      tcdmSize = 128,
+      tcdmLogicWordSize = Seq(
+        256,
+        128,
+        64
+      ),
+      numChannel = 32,
+      addressBufferDepth = 1,
+      dataBufferDepth = 1,
+      configurableChannel = false,
+      crossClockDomain = hasCrossClockDomain
+    )
+  )
+
+  def tagName = "snax_streamer_gemmX_"
+  def headerFilepath = "../../target/snitch_cluster/sw/snax/gemmx/include"
+}

--- a/hw/future/src/dma/axi_dma_backend.sv
+++ b/hw/future/src/dma/axi_dma_backend.sv
@@ -50,14 +50,14 @@ module axi_dma_backend #(
     /// Enable or disable tracing
     parameter bit          DmaTracing     = 0,
     /// Address type
-    parameter type            addr_t      = logic [AddrWidth-1:0]
+    parameter type         addr_t         = logic [AddrWidth-1:0]
 ) (
     /// Clock
     input  logic                        clk_i,
     /// Asynchronous reset, active low
     input  logic                        rst_ni,
     /// Cluster base address, just for correct logging
-    input  [7:0]                        chip_id_i,
+    input              [           7:0] chip_id_i,
     /// AXI4+ATOP master request
     output axi_req_t                    axi_dma_req_o,
     /// AXI4+ATOP master response
@@ -125,13 +125,13 @@ module axi_dma_backend #(
   /// Write request definition
   typedef struct packed {
     desc_ax_t aw;
-    desc_w_t w;
+    desc_w_t  w;
   } write_req_t;
 
   /// Read request definition
   typedef struct packed {
     desc_ax_t ar;
-    desc_r_t r;
+    desc_r_t  r;
   } read_req_t;
 
   //--------------------------------------
@@ -300,8 +300,8 @@ module axi_dma_backend #(
       // open file
       initial begin
         #1;
-        $sformat(fn, "logs/trace_chip_%01x%01x_dma_%05x.log", chip_id_i[7:4],
-                 chip_id_i[3:0], dma_id_i);
+        $sformat(fn, "logs/trace_chip_%01x%01x_dma_%05x.log", chip_id_i[7:4], chip_id_i[3:0],
+                 dma_id_i);
         f = $fopen(fn, "w");
         $display("[Tracer] Logging DMA %d to %s", dma_id_i, fn);
       end
@@ -336,81 +336,95 @@ module axi_dma_backend #(
           // Metadata
           //--------------------------------------
           dma_meta = '{
-          // time
-          "time"           : $time(),
-                    "DataWidth"      : DataWidth,
-                    "AddrWidth"      : AddrWidth,
-                    "IdWidth"        : IdWidth,
-                    "AxReqFifoDepth" : AxReqFifoDepth,
-                    "TransFifoDepth" : TransFifoDepth,
-                    "BufferDepth"    : BufferDepth
-                };
+              // time
+              "time"           :
+              $time(),
+              "DataWidth"      : DataWidth,
+              "AddrWidth"      : AddrWidth,
+              "IdWidth"        : IdWidth,
+              "AxReqFifoDepth" : AxReqFifoDepth,
+              "TransFifoDepth" : TransFifoDepth,
+              "BufferDepth"    : BufferDepth
+          };
 
           //--------------------------------------
           // Backend
           //--------------------------------------
           dma_backend = '{
-          // dma backend interface
-          "backend_burst_req_id"                : burst_req_i.id,
-          "backend_burst_req_src"               : burst_req_i.src,
-          "backend_burst_req_dst"               : burst_req_i.dst,
-          "backend_burst_req_num_bytes"         : burst_req_i.num_bytes,
-          // "backend_burst_req_cache_src"         : burst_req_i.cache_src,
-          // "backend_burst_req_cache_dst"         : burst_req_i.cache_dst,
-          // "backend_burst_req_burst_src"         : burst_req_i.burst_src,
-          // "backend_burst_req_burst_dst"         : burst_req_i.burst_dst,
-          "backend_burst_req_burst_decouple_rw" : burst_req_i.decouple_rw,
-          "backend_burst_req_burst_deburst"     : burst_req_i.deburst,
-          "backend_burst_req_valid"             : valid_i,
-          "backend_burst_req_ready"             : ready_o,
-          "backend_idle"                        : backend_idle_o,
-          "transfer_completed"                  : trans_complete_o
+              // dma backend interface
+              "backend_burst_req_id"                :
+              burst_req_i.id,
+              "backend_burst_req_src"               : burst_req_i.src,
+              "backend_burst_req_dst"               : burst_req_i.dst,
+              "backend_burst_req_num_bytes"         : burst_req_i.num_bytes,
+              // "backend_burst_req_cache_src"         : burst_req_i.cache_src,
+              // "backend_burst_req_cache_dst"         : burst_req_i.cache_dst,
+              // "backend_burst_req_burst_src"         : burst_req_i.burst_src,
+              // "backend_burst_req_burst_dst"         : burst_req_i.burst_dst,
+              "backend_burst_req_burst_decouple_rw" :
+              burst_req_i.decouple_rw,
+              "backend_burst_req_burst_deburst"     : burst_req_i.deburst,
+              "backend_burst_req_valid"             : valid_i,
+              "backend_burst_req_ready"             : ready_o,
+              "backend_idle"                        : backend_idle_o,
+              "transfer_completed"                  : trans_complete_o
           };
 
           //--------------------------------------
           // Burst Reshaper
           //--------------------------------------
           dma_burst_res = '{
-          // burst request
-          "burst_reshaper_burst_req_id"          : i_axi_dma_burst_reshaper.burst_req_i.id,
-          "burst_reshaper_burst_req_src"         : i_axi_dma_burst_reshaper.burst_req_i.src,
-          "burst_reshaper_burst_req_dst"         : i_axi_dma_burst_reshaper.burst_req_i.dst,
-          "burst_reshaper_burst_req_num_bytes"   : i_axi_dma_burst_reshaper.burst_req_i.num_bytes,
-          // "burst_reshaper_burst_req_cache_src" : i_axi_dma_burst_reshaper.burst_req_i.cache_src,
-          // "burst_reshaper_burst_req_cache_dst" : i_axi_dma_burst_reshaper.burst_req_i.cache_dst,
-          // "burst_reshaper_burst_req_burst_src" : i_axi_dma_burst_reshaper.burst_req_i.burst_src,
-          // "burst_reshaper_burst_req_burst_dst" : i_axi_dma_burst_reshaper.burst_req_i.burst_dst,
-          "burst_reshaper_burst_req_decouple_rw" : i_axi_dma_burst_reshaper.burst_req_i.decouple_rw,
-          "burst_reshaper_burst_req_deburst"     : i_axi_dma_burst_reshaper.burst_req_i.deburst,
-          "burst_reshaper_burst_req_valid"       : i_axi_dma_burst_reshaper.valid_i,
-          "burst_reshaper_burst_req_ready"       : i_axi_dma_burst_reshaper.ready_o,
-          // write request
-          "burst_reshaper_write_req_aw_id"       : i_axi_dma_burst_reshaper.write_req_o.aw.id,
-          "burst_reshaper_write_req_aw_last"     : i_axi_dma_burst_reshaper.write_req_o.aw.last,
-          "burst_reshaper_write_req_aw_addr"     : i_axi_dma_burst_reshaper.write_req_o.aw.addr,
-          "burst_reshaper_write_req_aw_len"      : i_axi_dma_burst_reshaper.write_req_o.aw.len,
-          "burst_reshaper_write_req_aw_size"     : i_axi_dma_burst_reshaper.write_req_o.aw.size,
-          "burst_reshaper_write_req_aw_burst"    : i_axi_dma_burst_reshaper.write_req_o.aw.burst,
-          "burst_reshaper_write_req_aw_cache"    : i_axi_dma_burst_reshaper.write_req_o.aw.cache,
-          "burst_reshaper_write_req_w_offset"    : i_axi_dma_burst_reshaper.write_req_o.w.offset,
-          "burst_reshaper_write_req_w_tailer"    : i_axi_dma_burst_reshaper.write_req_o.w.tailer,
-          "burst_reshaper_write_req_w_num_beats" : i_axi_dma_burst_reshaper.write_req_o.w.num_beats,
-          // "burst_reshaper_write_req_w_is_single" : i_axi_dma_burst_reshaper.write_req_o.w.is_single,
-          "burst_reshaper_write_req_valid"       : i_axi_dma_burst_reshaper.w_valid_o,
-          "burst_reshaper_write_req_ready"       : i_axi_dma_burst_reshaper.w_ready_i,
-          // read request
-          "burst_reshaper_read_req_ar_id"        : i_axi_dma_burst_reshaper.read_req_o.ar.id,
-          "burst_reshaper_read_req_ar_last"      : i_axi_dma_burst_reshaper.read_req_o.ar.last,
-          "burst_reshaper_read_req_ar_addr"      : i_axi_dma_burst_reshaper.read_req_o.ar.addr,
-          "burst_reshaper_read_req_ar_len"       : i_axi_dma_burst_reshaper.read_req_o.ar.len,
-          "burst_reshaper_read_req_ar_size"      : i_axi_dma_burst_reshaper.read_req_o.ar.size,
-          "burst_reshaper_read_req_ar_burst"     : i_axi_dma_burst_reshaper.read_req_o.ar.burst,
-          "burst_reshaper_read_req_ar_cache"     : i_axi_dma_burst_reshaper.read_req_o.ar.cache,
-          "burst_reshaper_read_req_r_offset"     : i_axi_dma_burst_reshaper.read_req_o.r.offset,
-          "burst_reshaper_read_req_r_tailer"     : i_axi_dma_burst_reshaper.read_req_o.r.tailer,
-          "burst_reshaper_read_req_r_shift"      : i_axi_dma_burst_reshaper.read_req_o.r.shift,
-          "burst_reshaper_read_req_valid"        : i_axi_dma_burst_reshaper.r_valid_o,
-          "burst_reshaper_read_req_ready"        : i_axi_dma_burst_reshaper.r_ready_i// ,
+              // burst request
+              "burst_reshaper_burst_req_id"          :
+              i_axi_dma_burst_reshaper.burst_req_i.id,
+              "burst_reshaper_burst_req_src"         : i_axi_dma_burst_reshaper.burst_req_i.src,
+              "burst_reshaper_burst_req_dst"         : i_axi_dma_burst_reshaper.burst_req_i.dst,
+              "burst_reshaper_burst_req_num_bytes"   :
+                  i_axi_dma_burst_reshaper.burst_req_i.num_bytes,
+              // "burst_reshaper_burst_req_cache_src" : i_axi_dma_burst_reshaper.burst_req_i.cache_src,
+              // "burst_reshaper_burst_req_cache_dst" : i_axi_dma_burst_reshaper.burst_req_i.cache_dst,
+              // "burst_reshaper_burst_req_burst_src" : i_axi_dma_burst_reshaper.burst_req_i.burst_src,
+              // "burst_reshaper_burst_req_burst_dst" : i_axi_dma_burst_reshaper.burst_req_i.burst_dst,
+              "burst_reshaper_burst_req_decouple_rw" :
+              i_axi_dma_burst_reshaper.burst_req_i.decouple_rw,
+              "burst_reshaper_burst_req_deburst"     : i_axi_dma_burst_reshaper.burst_req_i.deburst,
+              "burst_reshaper_burst_req_valid"       : i_axi_dma_burst_reshaper.valid_i,
+              "burst_reshaper_burst_req_ready"       : i_axi_dma_burst_reshaper.ready_o,
+              // write request
+              "burst_reshaper_write_req_aw_id"       :
+              i_axi_dma_burst_reshaper.write_req_o.aw.id,
+              "burst_reshaper_write_req_aw_last"     : i_axi_dma_burst_reshaper.write_req_o.aw.last,
+              "burst_reshaper_write_req_aw_addr"     : i_axi_dma_burst_reshaper.write_req_o.aw.addr,
+              "burst_reshaper_write_req_aw_len"      : i_axi_dma_burst_reshaper.write_req_o.aw.len,
+              "burst_reshaper_write_req_aw_size"     : i_axi_dma_burst_reshaper.write_req_o.aw.size,
+              "burst_reshaper_write_req_aw_burst"    :
+                  i_axi_dma_burst_reshaper.write_req_o.aw.burst,
+              "burst_reshaper_write_req_aw_cache"    :
+                  i_axi_dma_burst_reshaper.write_req_o.aw.cache,
+              "burst_reshaper_write_req_w_offset"    :
+                  i_axi_dma_burst_reshaper.write_req_o.w.offset,
+              "burst_reshaper_write_req_w_tailer"    :
+                  i_axi_dma_burst_reshaper.write_req_o.w.tailer,
+              "burst_reshaper_write_req_w_num_beats" :
+              i_axi_dma_burst_reshaper.write_req_o.w.num_beats,
+              // "burst_reshaper_write_req_w_is_single" : i_axi_dma_burst_reshaper.write_req_o.w.is_single,
+              "burst_reshaper_write_req_valid"       :
+              i_axi_dma_burst_reshaper.w_valid_o,
+              "burst_reshaper_write_req_ready"       : i_axi_dma_burst_reshaper.w_ready_i,
+              // read request
+              "burst_reshaper_read_req_ar_id"        :
+              i_axi_dma_burst_reshaper.read_req_o.ar.id,
+              "burst_reshaper_read_req_ar_last"      : i_axi_dma_burst_reshaper.read_req_o.ar.last,
+              "burst_reshaper_read_req_ar_addr"      : i_axi_dma_burst_reshaper.read_req_o.ar.addr,
+              "burst_reshaper_read_req_ar_len"       : i_axi_dma_burst_reshaper.read_req_o.ar.len,
+              "burst_reshaper_read_req_ar_size"      : i_axi_dma_burst_reshaper.read_req_o.ar.size,
+              "burst_reshaper_read_req_ar_burst"     : i_axi_dma_burst_reshaper.read_req_o.ar.burst,
+              "burst_reshaper_read_req_ar_cache"     : i_axi_dma_burst_reshaper.read_req_o.ar.cache,
+              "burst_reshaper_read_req_r_offset"     : i_axi_dma_burst_reshaper.read_req_o.r.offset,
+              "burst_reshaper_read_req_r_tailer"     : i_axi_dma_burst_reshaper.read_req_o.r.tailer,
+              "burst_reshaper_read_req_r_shift"      : i_axi_dma_burst_reshaper.read_req_o.r.shift,
+              "burst_reshaper_read_req_valid"        : i_axi_dma_burst_reshaper.r_valid_o,
+              "burst_reshaper_read_req_ready"        : i_axi_dma_burst_reshaper.r_ready_i  // ,
           // current burst
           // "burst_reshaper_burst_src_id"        : i_axi_dma_burst_reshaper.burst_q.src.id,
           // "burst_reshaper_burst_src_addr"      : i_axi_dma_burst_reshaper.burst_q.src.addr,
@@ -448,109 +462,126 @@ module axi_dma_backend #(
           // Data Mover
           //--------------------------------------
           dma_data_mover = '{
-          // AR emitter
-          // "data_mover_ar_emitter_full"          : i_axi_dma_data_mover.ar_emitter_full,
-          // "data_mover_ar_emitter_empty"         : i_axi_dma_data_mover.ar_emitter_empty,
-          // "data_mover_ar_emitter_push"          : i_axi_dma_data_mover.ar_emitter_push,
-          // "data_mover_ar_emitter_pop"           : i_axi_dma_data_mover.ar_emitter_pop,
-          // AW emitter
-          // "data_mover_aw_emitter_full"          : i_axi_dma_data_mover.aw_emitter_full,
-          // "data_mover_aw_emitter_empty"         : i_axi_dma_data_mover.aw_emitter_empty,
-          // "data_mover_aw_emitter_push"          : i_axi_dma_data_mover.aw_emitter_push,
-          // "data_mover_aw_emitter_pop"           : i_axi_dma_data_mover.aw_emitter_pop,
-          // "data_mover_is_last_aw"               : i_axi_dma_data_mover.is_last_aw,
-          // R emitter
-          // "data_mover_r_emitter_full"           : i_axi_dma_data_mover.r_emitter_full,
-          // "data_mover_r_emitter_empty"          : i_axi_dma_data_mover.r_emitter_empty,
-          // "data_mover_r_emitter_push"           : i_axi_dma_data_mover.r_emitter_push,
-          // "data_mover_r_emitter_pop"            : i_axi_dma_data_mover.r_emitter_pop,
-          // W emitter
-          // "data_mover_w_emitter_full"           : i_axi_dma_data_mover.w_emitter_full,
-          // "data_mover_w_emitter_empty"          : i_axi_dma_data_mover.w_emitter_empty,
-          // "data_mover_w_emitter_push"           : i_axi_dma_data_mover.w_emitter_push,
-          // "data_mover_w_emitter_pop"            : i_axi_dma_data_mover.w_emitter_pop,
-          // AW AXI signals
-          // "axi_dma_bus_aw_id"                   : i_axi_dma_data_mover.axi_dma_req_o.aw.id,
-          // "axi_dma_bus_aw_addr"                 : i_axi_dma_data_mover.axi_dma_req_o.aw.addr,
-          "axi_dma_bus_aw_len"                  : i_axi_dma_data_mover.axi_dma_req_o.aw.len,
-          "axi_dma_bus_aw_size"                 : i_axi_dma_data_mover.axi_dma_req_o.aw.size,
-          // "axi_dma_bus_aw_burst"                : i_axi_dma_data_mover.axi_dma_req_o.aw.burst,
-          // "axi_dma_bus_aw_cache"                : i_axi_dma_data_mover.axi_dma_req_o.aw.cache,
-          "axi_dma_bus_aw_valid"                : i_axi_dma_data_mover.axi_dma_req_o.aw_valid,
-          "axi_dma_bus_aw_ready"                : i_axi_dma_data_mover.axi_dma_res_i.aw_ready,
-          // B AXI signals
-          "axi_dma_bus_b_ready"                 : i_axi_dma_data_mover.axi_dma_req_o.b_ready,
-          "axi_dma_bus_b_valid"                 : i_axi_dma_data_mover.axi_dma_res_i.b_valid,
-          // AR AXI signals
-          // "axi_dma_bus_ar_id"                   : i_axi_dma_data_mover.axi_dma_req_o.ar.id,
-          // "axi_dma_bus_ar_addr"                 : i_axi_dma_data_mover.axi_dma_req_o.ar.addr,
-          "axi_dma_bus_ar_len"                  : i_axi_dma_data_mover.axi_dma_req_o.ar.len,
-          "axi_dma_bus_ar_size"                 : i_axi_dma_data_mover.axi_dma_req_o.ar.size,
-          // "axi_dma_bus_ar_burst"                : i_axi_dma_data_mover.axi_dma_req_o.ar.burst,
-          // "axi_dma_bus_ar_cache"                : i_axi_dma_data_mover.axi_dma_req_o.ar.cache,
-          "axi_dma_bus_ar_valid"                : i_axi_dma_data_mover.axi_dma_req_o.ar_valid,
-          "axi_dma_bus_ar_ready"                : i_axi_dma_data_mover.axi_dma_res_i.ar_ready
-                };
+              // AR emitter
+              // "data_mover_ar_emitter_full"          : i_axi_dma_data_mover.ar_emitter_full,
+              // "data_mover_ar_emitter_empty"         : i_axi_dma_data_mover.ar_emitter_empty,
+              // "data_mover_ar_emitter_push"          : i_axi_dma_data_mover.ar_emitter_push,
+              // "data_mover_ar_emitter_pop"           : i_axi_dma_data_mover.ar_emitter_pop,
+              // AW emitter
+              // "data_mover_aw_emitter_full"          : i_axi_dma_data_mover.aw_emitter_full,
+              // "data_mover_aw_emitter_empty"         : i_axi_dma_data_mover.aw_emitter_empty,
+              // "data_mover_aw_emitter_push"          : i_axi_dma_data_mover.aw_emitter_push,
+              // "data_mover_aw_emitter_pop"           : i_axi_dma_data_mover.aw_emitter_pop,
+              // "data_mover_is_last_aw"               : i_axi_dma_data_mover.is_last_aw,
+              // R emitter
+              // "data_mover_r_emitter_full"           : i_axi_dma_data_mover.r_emitter_full,
+              // "data_mover_r_emitter_empty"          : i_axi_dma_data_mover.r_emitter_empty,
+              // "data_mover_r_emitter_push"           : i_axi_dma_data_mover.r_emitter_push,
+              // "data_mover_r_emitter_pop"            : i_axi_dma_data_mover.r_emitter_pop,
+              // W emitter
+              // "data_mover_w_emitter_full"           : i_axi_dma_data_mover.w_emitter_full,
+              // "data_mover_w_emitter_empty"          : i_axi_dma_data_mover.w_emitter_empty,
+              // "data_mover_w_emitter_push"           : i_axi_dma_data_mover.w_emitter_push,
+              // "data_mover_w_emitter_pop"            : i_axi_dma_data_mover.w_emitter_pop,
+              // AW AXI signals
+              // "axi_dma_bus_aw_id"                   : i_axi_dma_data_mover.axi_dma_req_o.aw.id,
+              // "axi_dma_bus_aw_addr"                 : i_axi_dma_data_mover.axi_dma_req_o.aw.addr,
+              "axi_dma_bus_aw_len"                  :
+              i_axi_dma_data_mover.axi_dma_req_o.aw.len,
+              "axi_dma_bus_aw_size"                 : i_axi_dma_data_mover.axi_dma_req_o.aw.size,
+              // "axi_dma_bus_aw_burst"                : i_axi_dma_data_mover.axi_dma_req_o.aw.burst,
+              // "axi_dma_bus_aw_cache"                : i_axi_dma_data_mover.axi_dma_req_o.aw.cache,
+              "axi_dma_bus_aw_valid"                :
+              i_axi_dma_data_mover.axi_dma_req_o.aw_valid,
+              "axi_dma_bus_aw_ready"                : i_axi_dma_data_mover.axi_dma_res_i.aw_ready,
+              // B AXI signals
+              "axi_dma_bus_b_ready"                 :
+              i_axi_dma_data_mover.axi_dma_req_o.b_ready,
+              "axi_dma_bus_b_valid"                 : i_axi_dma_data_mover.axi_dma_res_i.b_valid,
+              // AR AXI signals
+              // "axi_dma_bus_ar_id"                   : i_axi_dma_data_mover.axi_dma_req_o.ar.id,
+              // "axi_dma_bus_ar_addr"                 : i_axi_dma_data_mover.axi_dma_req_o.ar.addr,
+              "axi_dma_bus_ar_len"                  :
+              i_axi_dma_data_mover.axi_dma_req_o.ar.len,
+              "axi_dma_bus_ar_size"                 : i_axi_dma_data_mover.axi_dma_req_o.ar.size,
+              // "axi_dma_bus_ar_burst"                : i_axi_dma_data_mover.axi_dma_req_o.ar.burst,
+              // "axi_dma_bus_ar_cache"                : i_axi_dma_data_mover.axi_dma_req_o.ar.cache,
+              "axi_dma_bus_ar_valid"                :
+              i_axi_dma_data_mover.axi_dma_req_o.ar_valid,
+              "axi_dma_bus_ar_ready"                : i_axi_dma_data_mover.axi_dma_res_i.ar_ready
+          };
 
           //--------------------------------------
           // Data Path
           //--------------------------------------
           dma_data_path = '{
-          // r channel
-          "data_path_r_dp_valid"         : i_axi_dma_data_mover.i_axi_dma_data_path.r_dp_valid_i,
-          "data_path_r_dp_ready"         : i_axi_dma_data_mover.i_axi_dma_data_path.r_dp_ready_o,
-          "data_path_r_tailer_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.r_tailer_i,
-          "data_path_r_offset_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.r_offset_i,
-          "data_path_r_shift_i"          : i_axi_dma_data_mover.i_axi_dma_data_path.r_shift_i,
-          "axi_dma_bus_r_valid"          : i_axi_dma_data_mover.i_axi_dma_data_path.r_valid_i,
-          // "axi_dma_bus_r_data"           : i_axi_dma_data_mover.i_axi_dma_data_path.r_data_i,
-          // "axi_dma_bus_r_last"           : i_axi_dma_data_mover.i_axi_dma_data_path.r_last_i,
-          // "axi_dma_bus_r_resp"           : i_axi_dma_data_mover.i_axi_dma_data_path.r_resp_i,
-          "axi_dma_bus_r_ready"          :
+              // r channel
+              "data_path_r_dp_valid"         :
+              i_axi_dma_data_mover.i_axi_dma_data_path.r_dp_valid_i,
+              "data_path_r_dp_ready"         :
+                  i_axi_dma_data_mover.i_axi_dma_data_path.r_dp_ready_o,
+              "data_path_r_tailer_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.r_tailer_i,
+              "data_path_r_offset_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.r_offset_i,
+              "data_path_r_shift_i"          : i_axi_dma_data_mover.i_axi_dma_data_path.r_shift_i,
+              "axi_dma_bus_r_valid"          : i_axi_dma_data_mover.i_axi_dma_data_path.r_valid_i,
+              // "axi_dma_bus_r_data"           : i_axi_dma_data_mover.i_axi_dma_data_path.r_data_i,
+              // "axi_dma_bus_r_last"           : i_axi_dma_data_mover.i_axi_dma_data_path.r_last_i,
+              // "axi_dma_bus_r_resp"           : i_axi_dma_data_mover.i_axi_dma_data_path.r_resp_i,
+              "axi_dma_bus_r_ready"          :
               i_axi_dma_data_mover.i_axi_dma_data_path.r_ready_o,
-          // w channel
-          "data_path_w_dp_valid"         : i_axi_dma_data_mover.i_axi_dma_data_path.w_dp_valid_i,
-          "data_path_w_dp_ready"         : i_axi_dma_data_mover.i_axi_dma_data_path.w_dp_ready_o,
-          "data_path_w_tailer_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.w_tailer_i,
-          "data_path_w_offset_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.w_offset_i,
-          "data_path_w_num_beats"        : i_axi_dma_data_mover.i_axi_dma_data_path.w_num_beats_i,
-          "data_path_w_is_single"        : i_axi_dma_data_mover.i_axi_dma_data_path.w_is_single_i,
-          "axi_dma_bus_w_valid"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_valid_o,
-          // "axi_dma_bus_w_data"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_data_o,
-          "axi_dma_bus_w_strb"           : i_axi_dma_data_mover.i_axi_dma_data_path.w_strb_o,
-          // "axi_dma_bus_w_last"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_last_o,
-          "axi_dma_bus_w_ready"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_ready_i,
-          // mask pre-calculation
-          "data_path_r_first_mask"       : i_axi_dma_data_mover.i_axi_dma_data_path.r_first_mask,
-          "data_path_r_last_mask"        : i_axi_dma_data_mover.i_axi_dma_data_path.r_last_mask,
-          "data_path_w_first_mask"       : i_axi_dma_data_mover.i_axi_dma_data_path.w_first_mask,
-          "data_path_w_last_mask"        : i_axi_dma_data_mover.i_axi_dma_data_path.w_last_mask,
-          // barrel shifter
-          // "data_path_buffer_in"         : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_in,
-          "data_path_read_aligned_in_mask"  :
-                  i_axi_dma_data_mover.i_axi_dma_data_path.read_aligned_in_mask,
-          "data_path_write_aligned_in_mask" :
-                  i_axi_dma_data_mover.i_axi_dma_data_path.in_mask,
-          // in mask generation
-          // "data_path_is_first_r"        : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_r,
-          // "data_path_is_first_r_d"      : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_r_d,
-          // "data_path_is_first_r_d"      : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_r_d,
-          // read control
-          // "data_path_buffer_full"       : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_full,
-          // "data_path_buffer_push"       : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_push,
-          // "data_path_full"              : i_axi_dma_data_mover.i_axi_dma_data_path.full,
-          "data_path_push"               : i_axi_dma_data_mover.i_axi_dma_data_path.push,
-          // out mask generation
-          "data_path_out_mask"           : i_axi_dma_data_mover.i_axi_dma_data_path.out_mask,
-          // "data_path_is_first_w"        : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_w,
-          // "data_path_is_last_w"         : i_axi_dma_data_mover.i_axi_dma_data_path.is_last_w,
-          // write control
-          // "data_path_buffer_out"        : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_out,
-          // "data_path_buffer_empty"      : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_empty,
-          // "data_path_buffer_pop"        : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_pop,
-          // "data_path_w_num_beats"       : i_axi_dma_data_mover.i_axi_dma_data_path.w_num_beats_q,
-          // "data_path_w_cnt_valid"       : i_axi_dma_data_mover.i_axi_dma_data_path.w_cnt_valid_q,
-          "data_path_pop"                : i_axi_dma_data_mover.i_axi_dma_data_path.pop  // ,
+              // w channel
+              "data_path_w_dp_valid"         :
+              i_axi_dma_data_mover.i_axi_dma_data_path.w_dp_valid_i,
+              "data_path_w_dp_ready"         :
+                  i_axi_dma_data_mover.i_axi_dma_data_path.w_dp_ready_o,
+              "data_path_w_tailer_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.w_tailer_i,
+              "data_path_w_offset_i"         : i_axi_dma_data_mover.i_axi_dma_data_path.w_offset_i,
+              "data_path_w_num_beats"        :
+                  i_axi_dma_data_mover.i_axi_dma_data_path.w_num_beats_i,
+              "data_path_w_is_single"        :
+                  i_axi_dma_data_mover.i_axi_dma_data_path.w_is_single_i,
+              "axi_dma_bus_w_valid"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_valid_o,
+              // "axi_dma_bus_w_data"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_data_o,
+              "axi_dma_bus_w_strb"           :
+              i_axi_dma_data_mover.i_axi_dma_data_path.w_strb_o,
+              // "axi_dma_bus_w_last"          : i_axi_dma_data_mover.i_axi_dma_data_path.w_last_o,
+              "axi_dma_bus_w_ready"          :
+              i_axi_dma_data_mover.i_axi_dma_data_path.w_ready_i,
+              // mask pre-calculation
+              "data_path_r_first_mask"       :
+              i_axi_dma_data_mover.i_axi_dma_data_path.r_first_mask,
+              "data_path_r_last_mask"        : i_axi_dma_data_mover.i_axi_dma_data_path.r_last_mask,
+              "data_path_w_first_mask"       :
+                  i_axi_dma_data_mover.i_axi_dma_data_path.w_first_mask,
+              "data_path_w_last_mask"        : i_axi_dma_data_mover.i_axi_dma_data_path.w_last_mask,
+              // barrel shifter
+              // "data_path_buffer_in"         : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_in,
+              "data_path_read_aligned_in_mask"  :
+              i_axi_dma_data_mover.i_axi_dma_data_path.read_aligned_in_mask,
+              "data_path_write_aligned_in_mask" : i_axi_dma_data_mover.i_axi_dma_data_path.in_mask,
+              // in mask generation
+              // "data_path_is_first_r"        : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_r,
+              // "data_path_is_first_r_d"      : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_r_d,
+              // "data_path_is_first_r_d"      : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_r_d,
+              // read control
+              // "data_path_buffer_full"       : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_full,
+              // "data_path_buffer_push"       : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_push,
+              // "data_path_full"              : i_axi_dma_data_mover.i_axi_dma_data_path.full,
+              "data_path_push"               :
+              i_axi_dma_data_mover.i_axi_dma_data_path.push,
+              // out mask generation
+              "data_path_out_mask"           :
+              i_axi_dma_data_mover.i_axi_dma_data_path.out_mask,
+              // "data_path_is_first_w"        : i_axi_dma_data_mover.i_axi_dma_data_path.is_first_w,
+              // "data_path_is_last_w"         : i_axi_dma_data_mover.i_axi_dma_data_path.is_last_w,
+              // write control
+              // "data_path_buffer_out"        : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_out,
+              // "data_path_buffer_empty"      : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_empty,
+              // "data_path_buffer_pop"        : i_axi_dma_data_mover.i_axi_dma_data_path.buffer_pop,
+              // "data_path_w_num_beats"       : i_axi_dma_data_mover.i_axi_dma_data_path.w_num_beats_q,
+              // "data_path_w_cnt_valid"       : i_axi_dma_data_mover.i_axi_dma_data_path.w_cnt_valid_q,
+              "data_path_pop"                :
+              i_axi_dma_data_mover.i_axi_dma_data_path.pop  // ,
           // "data_path_write_happening"   : i_axi_dma_data_mover.i_axi_dma_data_path.write_happening,
           // "data_path_ready_to_write"    : i_axi_dma_data_mover.i_axi_dma_data_path.ready_to_write,
           // "data_path_first_possible"    : i_axi_dma_data_mover.i_axi_dma_data_path.first_possible,
@@ -559,7 +590,7 @@ module axi_dma_backend #(
 
           // write dicts to string
           foreach (dma_meta[key])
-            dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_meta[key]);
+          dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_meta[key]);
           // only write bulk of data if dma is actually active :)
           if (!backend_idle_o | valid_i & ready_o |
                     i_axi_dma_burst_reshaper.valid_i & i_axi_dma_burst_reshaper.ready_o |
@@ -567,13 +598,13 @@ module axi_dma_backend #(
                     i_axi_dma_burst_reshaper.burst_q.dst.valid |
                     trans_complete_o) begin
             foreach (dma_backend[key])
-              dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_backend[key]);
+            dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_backend[key]);
             foreach (dma_burst_res[key])
-              dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_burst_res[key]);
+            dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_burst_res[key]);
             foreach (dma_data_mover[key])
-              dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_data_mover[key]);
+            dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_data_mover[key]);
             foreach (dma_data_path[key])
-              dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_data_path[key]);
+            dma_string = $sformatf("%s'%s': 0x%0x, ", dma_string, key, dma_data_path[key]);
 
             //--------------------------------------
             // Realign Buffer Data Store
@@ -585,10 +616,10 @@ module axi_dma_backend #(
             //         );
             //     end
             // end
+            dma_string = $sformatf("%s}", dma_string);
+            $fwrite(f, dma_string);
+            $fwrite(f, "\n");
           end
-          dma_string = $sformatf("%s}", dma_string);
-          $fwrite(f, dma_string);
-          $fwrite(f, "\n");
         end
       end
       // close the file

--- a/target/snitch_cluster/cfg/snax_versacore_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_versacore_cluster.hjson
@@ -12,10 +12,10 @@
     }
     cluster:
     {
-        name: snax_KUL_cluster
+        name: snax_versacore_cluster
         bender_target:
         [
-            snax_KUL_cluster
+            snax_versacore_cluster
         ]
         boot_addr: 4096
         cluster_base_addr: 268435456
@@ -235,9 +235,9 @@
         {
             bender_target:
             [
-                snax_KUL_cluster_xdma
+                snax_versacore_cluster_xdma
             ]
-            max_multicast: 4
+            max_multicast: 16
             max_dimension: 5
             max_mem_size: 4096
             reader_buffer: 12

--- a/target/snitch_cluster/cfg/snax_xdma_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_xdma_cluster.hjson
@@ -1,0 +1,152 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Cluster configuration for a simple testbench system.
+{
+    nr_s1_quadrant: 1,
+    s1_quadrant: {
+        nr_clusters: 1,
+    },
+
+    cluster: {
+        name: "snax_xdma_cluster",
+        bender_target: ["snax_xdma_cluster"],
+        boot_addr: 4096, // 0x1000
+        cluster_base_addr: 268435456, // 0x1000_0000
+        cluster_base_offset: 4194304,  // 4MB
+        cluster_base_hartid: 0,
+        addr_width: 48,
+        data_width: 64,
+        user_width: 3,
+        tcdm: {
+            size: 1024,
+            banks: 32,
+        },
+        cluster_periph_size: 64, // kB
+        zero_mem_size: 64, // kB
+        dma_data_width: 512,
+        dma_axi_req_fifo_depth: 16,
+        dma_req_fifo_depth: 8,
+
+        // Observable pins parameter
+        observable_pin_width: 8,
+
+        // Additional parameters for Hemaia integration
+        narrow_trans: 4,
+        wide_trans: 32,
+        dma_user_width: 1,
+        // We don't need Snitch debugging in Hemaia
+        enable_debug: false,
+        // We don't need Snitch (core-internal) virtual memory support
+        vm_support: false,
+        // Memory configuration inputs
+        sram_cfg_expose: true,
+        sram_cfg_fields: {
+            ema: 3,
+            emaw: 2,
+            emas: 1
+        },
+        snax_custom_tcdm_assign: {
+            snax_enable_assign_tcdm_idx: true,
+            snax_narrow_assign_start_idx: [0,56],
+            snax_narrow_assign_end_idx: [7,71],
+            snax_wide_assign_start_idx: [8],
+            snax_wide_assign_end_idx: [55],
+        },
+        // AXI bandwidth switcher
+        use_ax_bw_converter: true,
+        converted_axi_bandwidth: 256,
+        // Timing parameters
+        timing: {
+            lat_comp_fp32: 3,
+            lat_comp_fp64: 3,
+            lat_comp_fp16: 2,
+            lat_comp_fp16_alt: 2,
+            lat_comp_fp8: 1,
+            lat_comp_fp8_alt: 1,
+            lat_noncomp: 1,
+            lat_conv: 1,
+            lat_sdotp: 2,
+            fpu_pipe_config: "BEFORE"
+            narrow_xbar_latency: "CUT_ALL_PORTS",
+            wide_xbar_latency: "CUT_ALL_PORTS",
+            // Isolate the core.
+            register_core_req: true,
+            register_core_rsp: true,
+            register_offload_req: true,
+            register_offload_rsp: true,
+            register_ext_narrow: true,
+            register_ext_wide: true,
+        },
+        hives: [
+            // Hive 0
+            {
+                icache: {
+                    size: 8, // total instruction cache size in kByte
+                    sets: 2, // number of ways
+                    cacheline: 256 // word size in bits
+                },
+                cores: [
+                    { $ref: "#/xdma_core_template" },
+                ]
+            }
+        ]
+    },
+    dram: {
+        // 0x8000_0000
+        address: 2147483648,
+        // 0x8000_0000
+        length: 2147483648
+    },
+    peripherals: {
+        clint: {
+            // 0xffff_0000
+            address: 4294901760,
+            // 0x0000_1000
+            length: 4096
+        },
+    },
+    // Templates.
+    xdma_core_template: {
+        isa: "rv32ima",
+        snax_xdma_cfg: {
+            bender_target: ["snax_xdma_cluster_xdma"],
+            // Cross Cluster Calling Cfg
+            max_multicast: 25,
+            max_dimension: 5,
+            max_mem_size: 4096,
+            // DataMaestro Cfg
+            reader_buffer: 12, 
+            writer_buffer: 12, 
+            reader_agu_temporal_dimension: 5,
+            writer_agu_temporal_dimension: 5,
+            // Extension Cfg
+            writer_extensions: {
+                HasVerilogMemset: {},
+                HasTransposer: {row:[8, 8], col:[8, 8], elementWidth:[8, 16]},
+            },
+            reader_extensions: {
+                HasMaxPool: {},
+            }
+        },
+        // Xdiv_sqrt: true,
+        # isa: "rv32ema",
+        xdma: true
+        xssr: false
+        xfrep: false
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+    },
+}

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -26,10 +26,13 @@ endif
 ifeq (${CFG_OVERRIDE}, cfg/snax_KUL_dse_cluster_1D.hjson)
 SUBDIRS += snax/gemmx snax/data-reshuffler
 endif
+ifeq ($(CFG_OVERRIDE), cfg/snax_xdma_cluster.hjson)
+SUBDIRS += snax/xdma
+endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
 SUBDIRS += snax/xdma
 endif
-ifeq ($(CFG_OVERRIDE), cfg/snax_versacore.hjson)
+ifeq ($(CFG_OVERRIDE), cfg/snax_versacore_cluster.hjson)
 SUBDIRS += snax/versacore snax/xdma
 endif
 ifeq (${CFG_OVERRIDE}, cfg/snax_alu_cluster.hjson)

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -45,13 +45,19 @@ SUBDIRS += snax-data-reshuffler
 SUBDIRS += snax-gemmx-matmul
 SUBDIRS += snax-gemmx-conv
 endif
+ifeq ($(CFG_OVERRIDE), cfg/snax_xdma_cluster.hjson)
+SUBDIRS += snax-xdma-memset
+SUBDIRS += snax-xdma-maxpool
+SUBDIRS += snax-xdma-transpose
+SUBDIRS += snax-xdma-reshape-comparison
+endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
 SUBDIRS += snax-xdma-memset
 SUBDIRS += snax-xdma-maxpool
 SUBDIRS += snax-xdma-transpose
 SUBDIRS += snax-xdma-reshape-comparison
 endif
-ifeq ($(CFG_OVERRIDE), cfg/snax_versacore.hjson)
+ifeq ($(CFG_OVERRIDE), cfg/snax_versacore_cluster.hjson)
 SUBDIRS += snax-versacore-matmul
 SUBDIRS += snax-xdma-memset
 SUBDIRS += snax-xdma-maxpool


### PR DESCRIPTION
This PR
1. Eliminate the redundant DMA trace printing
2. Rename and optimize versacore cluster's cfg
3. Create the indepependent xdma cluster for faster simulation 
