### PR TITLE
Narrow-Wide XDMA

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -34,7 +34,7 @@ dependencies:
   hypercorex:         { git: "https://github.com/KULeuven-MICAS/hypercorex.git", rev: main }
   dimc:               { git: "https://github.com/KULeuven-MICAS/snax-dimc.git", rev: main }
   cgra:               { git: "https://github.com/KULeuven-MICAS/snax_cgra.git", rev: main }
-  xdma_axi_adapter:   { git: https://github.com/KULeuven-MICAS/xdma_axi_adapter.git, rev: main }
+  xdma_axi_adapter:   { git: https://github.com/KULeuven-MICAS/xdma_axi_adapter.git, rev: fkong/narrow-wide-xdma }
 
 vendor_package:
   - name: musl

--- a/Bender.yml
+++ b/Bender.yml
@@ -34,7 +34,7 @@ dependencies:
   hypercorex:         { git: "https://github.com/KULeuven-MICAS/hypercorex.git", rev: main }
   dimc:               { git: "https://github.com/KULeuven-MICAS/snax-dimc.git", rev: main }
   cgra:               { git: "https://github.com/KULeuven-MICAS/snax_cgra.git", rev: main }
-  xdma_axi_adapter:   { git: https://github.com/KULeuven-MICAS/xdma_axi_adapter.git, rev: fkong/narrow-wide-xdma }
+  xdma_axi_adapter:   { git: https://github.com/KULeuven-MICAS/xdma_axi_adapter.git, rev: main }
 
 vendor_package:
   - name: musl

--- a/hw/snitch/src/snitch_pkg.sv
+++ b/hw/snitch/src/snitch_pkg.sv
@@ -127,27 +127,29 @@ package snitch_pkg;
   typedef enum integer {
     TCDM               = 0,
     ClusterPeripherals = 1,
-    SoC                = 2
+    SoC                = 2,
+    NarrowXDMAOut      = 3
   } cluster_slave_e;
 
   typedef enum integer {
-    CoreReq = 0,
-    AXISoC  = 1,
-    PTW     = 2
+    CoreReq      = 0,
+    AXISoC       = 1,
+    PTW          = 2,
+    NarrowXDMAIn = 3
   } cluster_master_e;
 
   // Slaves on Cluster DMA AXI Bus
   typedef enum int unsigned {
-    TCDMDMA    = 0,
-    SoCDMAOut  = 1,
-    XDMAOut    = 2
+    TCDMDMA      = 0,
+    SoCDMAOut    = 1,
+    WideXDMAOut  = 2
   } cluster_slave_dma_e;
 
   typedef enum int unsigned {
-    SDMAMst  = 0,
-    SoCDMAIn = 1,
-    ICache   = 2,
-    XDMAIn   = 3
+    SDMAMst      = 0,
+    SoCDMAIn     = 1,
+    ICache       = 2,
+    WideXDMAIn   = 3
   } cluster_master_dma_e;
 
   /// Possible interconnect implementations.

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -534,7 +534,7 @@ module snitch_cluster
   // data mmio
   addr_t xdma_mmio_data_start_address, xdma_mmio_data_end_address;
   assign xdma_mmio_data_start_address = xdma_mmio_start_address;
-  assign xdma_mmio_data_end_address = xdma_mmio_data_start_address - (ClusterMMIOSize/4) * 1024;
+  assign xdma_mmio_data_end_address = xdma_mmio_data_start_address + (ClusterMMIOSize/4) * 1024;
   // control mmio
   addr_t xdma_mmio_ctrl_start_address, xdma_mmio_ctrl_end_address;
   assign xdma_mmio_ctrl_start_address = xdma_mmio_data_end_address;

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -290,12 +290,18 @@ module snitch_cluster
     /// AXI Core cluster out-port.
     output narrow_out_req_t                                 narrow_out_req_o,
     input  narrow_out_resp_t                                narrow_out_resp_i,
-    /// XDMA Out ports
+    /// XDMA Wide Out ports
     output wide_out_req_t                                   xdma_wide_out_req_o,
     input  wide_out_resp_t                                  xdma_wide_out_resp_i,
-    /// XDMA In ports
+    /// XDMA Wide In ports
     input  wide_in_req_t                                    xdma_wide_in_req_i,
     output wide_in_resp_t                                   xdma_wide_in_resp_o,
+    /// XDMA Narrow Out ports
+    output narrow_out_req_t                                 xdma_narrow_out_req_o,
+    input  narrow_out_resp_t                                xdma_narrow_out_resp_i,
+    /// XDMA Narrow In ports
+    input  narrow_in_req_t                                  xdma_narrow_in_req_i,
+    output narrow_in_resp_t                                 xdma_narrow_in_resp_o,
     /// AXI DMA cluster out-port. Usually wider than the cluster ports so that the
     /// DMA engine can efficiently transfer bulk of data.
     output wide_out_req_t                                   wide_out_req_o,
@@ -334,18 +340,19 @@ module snitch_cluster
   localparam int unsigned NumTCDMIn = NrTCDMPortsCores + 1;
   localparam logic [PhysicalAddrWidth-1:0] TCDMMask = ~(TCDMSize - 1);
 
-  // Core Requests, SoC Request, PTW.
-  localparam int unsigned NrNarrowMasters = 3;
+  // Core Requests, SoC Request, PTW, XDMA
+  localparam int unsigned NrNarrowMasters = 4;
   localparam int unsigned NarrowIdWidthOut = $clog2(NrNarrowMasters) + NarrowIdWidthIn;
 
-  localparam int unsigned NrSlaves = 3;
+  localparam int unsigned NrSlaves = 4;
   localparam int unsigned NrRules = NrSlaves - 1;
 
-  // DMA, SoC Request, `n` instruction caches.
+  // DMA, SoC Request, XDMA, `n` instruction caches.
   localparam int unsigned NrWideMasters = 3 + NrHives;
   localparam int unsigned WideIdWidthOut = $clog2(NrWideMasters) + WideIdWidthIn;
   // DMA X-BAR configuration
   localparam int unsigned NrWideSlaves = 3;
+  localparam int unsigned NrWideRules = NrWideSlaves - 1;
 
   // AXI Configuration
   localparam axi_pkg::xbar_cfg_t ClusterXbarCfg = '{
@@ -378,7 +385,7 @@ module snitch_cluster
       UniqueIds: 1'b0,
       AxiAddrWidth: PhysicalAddrWidth,
       AxiDataWidth: WideDataWidth,
-      NoAddrRules: 2
+      NoAddrRules: NrWideRules
   };
 
   function automatic int unsigned get_hive_size(int unsigned current_hive);
@@ -510,11 +517,28 @@ module snitch_cluster
   assign cluster_periph_end_address   = tcdm_end_address + ClusterPeriphSize * 1024;
 
   // The MMIO is at the end of each cluster
+  // In total, We need 4 MMIOs, each MMIO is 4KB
+  // 1) Data 2)CFG 3)Grant 4)Finish
+  // We put the data(1) MMIO at the wide xbar
+  // We put the control(2,3,4) MMIO at the narrow xbar
+  // Low Addr      (cluster_base_addr_i+ClusterAddrSpace)-16KB <-xdma_mmio_start_address
+  // Data          (cluster_base_addr_i+ClusterAddrSpace)-16KB  - (cluster_base_addr_i+ClusterAddrSpace)-12kB
+  // CFG           (cluster_base_addr_i+ClusterAddrSpace)-12KB  - (cluster_base_addr_i+ClusterAddrSpace)-8kB
+  // Grant         (cluster_base_addr_i+ClusterAddrSpace)-8KB   - (cluster_base_addr_i+ClusterAddrSpace)-4kB
+  // Finish        (cluster_base_addr_i+ClusterAddrSpace)-4KB   - (cluster_base_addr_i+ClusterAddrSpace)-8kB
+  // High address  (cluster_base_addr_i+ClusterAddrSpace)      <-xdma_mmio_end_address
   addr_t xdma_mmio_start_address, xdma_mmio_end_address;
   assign xdma_mmio_start_address = cluster_base_addr_i + ClusterAddrSpace * 1024  -
                                    ClusterMMIOSize * 1024;
   assign xdma_mmio_end_address = cluster_base_addr_i + ClusterAddrSpace * 1024;
-
+  // data mmio
+  addr_t xdma_mmio_data_start_address, xdma_mmio_data_end_address;
+  assign xdma_mmio_data_start_address = xdma_mmio_start_address;
+  assign xdma_mmio_data_end_address = xdma_mmio_data_start_address - (ClusterMMIOSize/4) * 1024;
+  // control mmio
+  addr_t xdma_mmio_ctrl_start_address, xdma_mmio_ctrl_end_address;
+  assign xdma_mmio_ctrl_start_address = xdma_mmio_data_end_address;
+  assign xdma_mmio_ctrl_end_address = xdma_mmio_end_address;
   // ----------------
   // Wire Definitions
   // ----------------
@@ -619,10 +643,10 @@ module snitch_cluster
   // -------------
   // XDMA Ports
   // -------------
-  assign xdma_wide_out_req_o = wide_axi_slv_req[XDMAOut];
-  assign wide_axi_slv_rsp[XDMAOut] = xdma_wide_out_resp_i;
-  assign wide_axi_mst_req[XDMAIn] = xdma_wide_in_req_i;
-  assign xdma_wide_in_resp_o = wide_axi_mst_rsp[XDMAIn];
+  assign xdma_wide_out_req_o = wide_axi_slv_req[WideXDMAOut];
+  assign wide_axi_slv_rsp[WideXDMAOut] = xdma_wide_out_resp_i;
+  assign wide_axi_mst_req[WideXDMAIn] = xdma_wide_in_req_i;
+  assign xdma_wide_in_resp_o = wide_axi_mst_rsp[WideXDMAIn];
   // -------------
   // DMA XBAR Rule
   // -------------
@@ -632,7 +656,7 @@ module snitch_cluster
   assign dma_xbar_default_port = '{default: SoCDMAOut};
   assign dma_xbar_rule = '{
           '{idx: TCDMDMA, start_addr: tcdm_start_address, end_addr: tcdm_end_address},
-          '{idx: XDMAOut, start_addr: xdma_mmio_start_address, end_addr: xdma_mmio_end_address}
+          '{idx: WideXDMAOut, start_addr: xdma_mmio_data_start_address, end_addr: xdma_mmio_data_end_address}
       };
   localparam bit [DmaXbarCfg.NoSlvPorts-1:0] DMAEnableDefaultMstPort = '1;
   axi_xbar #(
@@ -1543,18 +1567,23 @@ module snitch_cluster
       .axi_rsp_i(narrow_axi_mst_rsp[CoreReq])
   );
 
-  logic [ClusterXbarCfg.NoSlvPorts-1:0][$clog2(
-ClusterXbarCfg.NoMstPorts
-)-1:0] cluster_xbar_default_port;
+
+  // -----------------
+  // XDMA Narrow Ports
+  // -----------------
+  assign xdma_narrow_out_req_o = narrow_axi_slv_req[NarrowXDMAOut];
+  assign narrow_axi_slv_rsp[NarrowXDMAOut] = xdma_narrow_out_resp_i;
+  assign narrow_axi_mst_req[NarrowXDMAIn] = xdma_narrow_in_req_i;
+  assign xdma_narrow_in_resp_o = narrow_axi_mst_rsp[NarrowXDMAIn];
+
+
+  logic [ClusterXbarCfg.NoSlvPorts-1:0][$clog2(ClusterXbarCfg.NoMstPorts)-1:0] cluster_xbar_default_port;
   xbar_rule_t [NrRules-1:0] cluster_xbar_rules;
 
   assign cluster_xbar_rules = '{
-          '{idx: TCDM, start_addr: tcdm_start_address, end_addr: tcdm_end_address},
-          '{
-              idx: ClusterPeripherals,
-              start_addr: cluster_periph_start_address,
-              end_addr: cluster_periph_end_address
-          }
+          '{idx: TCDM,               start_addr: tcdm_start_address,           end_addr: tcdm_end_address},
+          '{idx: ClusterPeripherals, start_addr: cluster_periph_start_address, end_addr: cluster_periph_end_address},
+          '{idx: NarrowXDMAOut,      start_addr: xdma_mmio_ctrl_start_address, end_addr: xdma_mmio_ctrl_end_address}              
       };
 
   localparam bit [ClusterXbarCfg.NoSlvPorts-1:0] ClusterEnableDefaultMstPort = '1;

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -529,10 +529,21 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
   //-----------------------------
   // XDMA Wire
   //-----------------------------
-  ${cfg['pkg_name']}::wide_out_req_t xdma_wide_out_req;
-  ${cfg['pkg_name']}::wide_out_resp_t xdma_wide_out_resp;
-  ${cfg['pkg_name']}::wide_in_req_t xdma_wide_in_req;
-  ${cfg['pkg_name']}::wide_in_resp_t xdma_wide_in_resp;
+
+  // We need both wide and narrow links
+  // The wide links are for the data
+  // The narrow links are for the configurations
+  
+  // Wide links
+  ${cfg['pkg_name']}::wide_out_req_t    xdma_wide_out_req;
+  ${cfg['pkg_name']}::wide_out_resp_t   xdma_wide_out_resp;
+  ${cfg['pkg_name']}::wide_in_req_t     xdma_wide_in_req;
+  ${cfg['pkg_name']}::wide_in_resp_t    xdma_wide_in_resp;
+  // Narrow links
+  ${cfg['pkg_name']}::narrow_out_req_t  xdma_narrow_out_req;
+  ${cfg['pkg_name']}::narrow_out_resp_t xdma_narrow_out_resp;
+  ${cfg['pkg_name']}::narrow_in_req_t   xdma_narrow_in_req;
+  ${cfg['pkg_name']}::narrow_in_resp_t  xdma_narrow_in_resp;
 %endif
 
 
@@ -734,15 +745,23 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     // XDMA
     //-----------------------------
 % if snax_xdma_flag:
-    .xdma_wide_out_req_o  (xdma_wide_out_req ),
-    .xdma_wide_out_resp_i (xdma_wide_out_resp),
-    .xdma_wide_in_req_i   (xdma_wide_in_req  ),
-    .xdma_wide_in_resp_o  (xdma_wide_in_resp ),
+    .xdma_wide_out_req_o     (xdma_wide_out_req   ),
+    .xdma_wide_out_resp_i    (xdma_wide_out_resp  ),
+    .xdma_wide_in_req_i      (xdma_wide_in_req    ),
+    .xdma_wide_in_resp_o     (xdma_wide_in_resp   ),
+    .xdma_narrow_out_req_o   (xdma_narrow_out_req ),
+    .xdma_narrow_out_resp_i  (xdma_narrow_out_resp),
+    .xdma_narrow_in_req_i    (xdma_narrow_in_req  ),
+    .xdma_narrow_in_resp_o   (xdma_narrow_in_resp ),
 % else:
-    .xdma_wide_out_req_o  (                  ),
-    .xdma_wide_out_resp_i ('0                ),
-    .xdma_wide_in_req_i   ('0                ),
-    .xdma_wide_in_resp_o  (                  ),    
+    .xdma_wide_out_req_o     (                    ),
+    .xdma_wide_out_resp_i    ('0                  ),
+    .xdma_wide_in_req_i      ('0                  ),
+    .xdma_wide_in_resp_o     (                    ),
+    .xdma_narrow_out_req_o   (                    ),
+    .xdma_narrow_out_resp_i  ('0                  ),
+    .xdma_narrow_in_req_i    ('0                  ),
+    .xdma_narrow_in_resp_o   (                    ), 
 %endif
     //-----------------------------
     // Wide AXI ports
@@ -953,13 +972,19 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     % for jdx, jdx_key in enumerate(snax_core_acc[idx_key]['snax_acc_dict']):
   // Instantiation of xdma wrapper
   ${cfg['name']}_xdma_wrapper # (
-    .tcdm_req_t       ( ${cfg['pkg_name']}::tcdm_req_t     ),
-    .tcdm_rsp_t       ( ${cfg['pkg_name']}::tcdm_rsp_t     ),
-    .wide_slv_id_t    ( ${cfg['pkg_name']}::wide_out_id_t  ),
-    .wide_out_req_t   ( ${cfg['pkg_name']}::wide_in_req_t ),
-    .wide_out_resp_t  ( ${cfg['pkg_name']}::wide_in_resp_t),
-    .wide_in_req_t    ( ${cfg['pkg_name']}::wide_out_req_t  ),
-    .wide_in_resp_t   ( ${cfg['pkg_name']}::wide_out_resp_t ),
+    .tcdm_req_t         ( ${cfg['pkg_name']}::tcdm_req_t        ),
+    .tcdm_rsp_t         ( ${cfg['pkg_name']}::tcdm_rsp_t        ),
+    .wide_slv_id_t      ( ${cfg['pkg_name']}::wide_out_id_t     ),
+    .wide_out_req_t     ( ${cfg['pkg_name']}::wide_in_req_t     ),
+    .wide_out_resp_t    ( ${cfg['pkg_name']}::wide_in_resp_t    ),
+    .wide_in_req_t      ( ${cfg['pkg_name']}::wide_out_req_t    ),
+    .wide_in_resp_t     ( ${cfg['pkg_name']}::wide_out_resp_t   ),
+    .narrow_slv_id_t    ( ${cfg['pkg_name']}::narrow_out_id_t   ),
+    .narrow_out_req_t   ( ${cfg['pkg_name']}::narrow_in_req_t   ),
+    .narrow_out_resp_t  ( ${cfg['pkg_name']}::narrow_in_resp_t  ),
+    .narrow_in_req_t    ( ${cfg['pkg_name']}::narrow_out_req_t  ),
+    .narrow_in_resp_t   ( ${cfg['pkg_name']}::narrow_out_resp_t ),
+
     .ClusterBaseAddr  ( ${cfg['pkg_name']}::ClusterBaseAddr),
     .ClusterAddressSpace(${to_sv_hex(cfg['cluster_base_offset'], cfg['addr_width'])}),
     .MMIOSize(${cfg['mmio_size']})
@@ -993,10 +1018,16 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     //-----------------------------
     // XDMA Intercluster Ports
     //-----------------------------
-    .xdma_wide_out_req_o (xdma_wide_in_req  ),
-    .xdma_wide_out_resp_i(xdma_wide_in_resp ),
-    .xdma_wide_in_req_i  (xdma_wide_out_req ),
-    .xdma_wide_in_resp_o (xdma_wide_out_resp),
+    // Wide ports for the data
+    .xdma_wide_out_req_o   (xdma_wide_in_req    ),
+    .xdma_wide_out_resp_i  (xdma_wide_in_resp   ),
+    .xdma_wide_in_req_i    (xdma_wide_out_req   ),
+    .xdma_wide_in_resp_o   (xdma_wide_out_resp  ),
+    // Narrow ports for the control
+    .xdma_narrow_out_req_o (xdma_narrow_in_req  ),
+    .xdma_narrow_out_resp_i(xdma_narrow_in_resp ),
+    .xdma_narrow_in_req_i  (xdma_narrow_out_req ),
+    .xdma_narrow_in_resp_o (xdma_narrow_out_resp),
     //-----------------------------
     // TCDM ports
     //-----------------------------

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -125,29 +125,30 @@ import xdma_pkg::*;
   ///---------------------------------------------------------------
   // XDMA Intercluster Signals
   ///---------------------------------------------------------------
-  xdma_pkg::data_t                   xdma_to_remote_cfg_bits;
-  xdma_pkg::data_t                   xdma_from_remote_cfg_bits;
+  xdma_pkg::wide_data_t                   xdma_to_remote_cfg_bits;
+  xdma_pkg::wide_data_t                   xdma_from_remote_cfg_bits;
   ///---------------------
   /// TO REMOTE
   ///---------------------
   // to remote cfg
-  xdma_pkg::xdma_inter_cluster_cfg_t xdma_to_remote_cfg;
-  logic                              xdma_to_remote_cfg_valid;
-  logic                              xdma_to_remote_cfg_ready;
+  xdma_pkg::xdma_inter_cluster_cfg_t   xdma_to_remote_cfg;
+  logic                                xdma_to_remote_cfg_valid;
+  logic                                xdma_to_remote_cfg_ready;
   // to remote data
-  xdma_pkg::xdma_to_remote_data_t    xdma_to_remote_data;
-  logic                              xdma_to_remote_data_valid;
-  logic                              xdma_to_remote_data_ready;
+  xdma_pkg::xdma_to_remote_data_t      xdma_to_remote_data;
+  logic                                xdma_to_remote_data_valid;
+  logic                                xdma_to_remote_data_ready;
   // to remote accompany cfg
-  xdma_pkg::xdma_accompany_cfg_t     xdma_to_remote_data_accompany_cfg;
-  xdma_pkg::id_t                     xdma_to_remote_data_accompany_cfg_dma_id;
-  logic                              xdma_to_remote_data_accompany_cfg_dma_type;
-  xdma_pkg::addr_t                   xdma_to_remote_data_accompany_cfg_src_addr;
-  xdma_pkg::addr_t                   xdma_to_remote_data_accompany_cfg_dst_addr;
-  xdma_pkg::len_t                    xdma_to_remote_data_accompany_cfg_dma_length;
-  logic                              xdma_to_remote_data_accompany_cfg_ready_to_transfer;
-  logic                              xdma_to_remote_data_accompany_cfg_is_first_cw;
-  logic                              xdma_to_remote_data_accompany_cfg_is_last_cw;
+  xdma_pkg::xdma_accompany_cfg_t       xdma_to_remote_data_accompany_cfg;
+  xdma_pkg::id_t                       xdma_to_remote_data_accompany_cfg_dma_id;
+  logic                                xdma_to_remote_data_accompany_cfg_dma_type;
+  xdma_pkg::addr_t                     xdma_to_remote_data_accompany_cfg_src_addr;
+  xdma_pkg::addr_t                     xdma_to_remote_data_accompany_cfg_dst_addr;
+  xdma_pkg::len_t                      xdma_to_remote_data_accompany_cfg_dma_length;
+  logic                                xdma_to_remote_data_accompany_cfg_ready_to_transfer;
+  logic                                xdma_to_remote_data_accompany_cfg_is_first_cw;
+  logic                                xdma_to_remote_data_accompany_cfg_is_last_cw;cw;
+  logic                                xdma_to_remote_data_accompany_cfg_is_last_cw;
   ///---------------------
   /// FROM REMOTE
   ///---------------------
@@ -177,7 +178,7 @@ import xdma_pkg::*;
   // Assign Signals
   ///---------------------------------------------------------------
   assign xdma_to_remote_cfg = xdma_pkg::xdma_inter_cluster_cfg_t'(xdma_to_remote_cfg_bits);
-  assign xdma_from_remote_cfg_bits = xdma_pkg::data_t'(xdma_from_remote_cfg);
+  assign xdma_from_remote_cfg_bits = xdma_pkg::wide_data_t'(xdma_from_remote_cfg);
   assign xdma_to_remote_data_accompany_cfg = xdma_pkg::xdma_accompany_cfg_t'{
     dma_id:            xdma_to_remote_data_accompany_cfg_dma_id,
     dma_type:          xdma_to_remote_data_accompany_cfg_dma_type,
@@ -333,10 +334,16 @@ import xdma_pkg::*;
         .axi_narrow_in_req_t                  (narrow_in_req_t                   ),
         .axi_narrow_in_resp_t                 (narrow_in_resp_t                  ),
         // Reqrsp Types
-        .reqrsp_req_t                         (xdma_pkg::reqrsp_req_t            ),
-        .reqrsp_rsp_t                         (xdma_pkg::reqrsp_rsp_t            ),
-        .data_t                               (xdma_pkg::data_t                  ),
-        .strb_t                               (xdma_pkg::strb_t                  ),
+        // Wide
+        .reqrsp_wide_req_t                    (xdma_pkg::reqrsp_wide_req_t       ),
+        .reqrsp_wide_rsp_t                    (xdma_pkg::reqrsp_wide_rsp_t       ),
+        // Narrow
+        .reqrsp_narrow_req_t                  (xdma_pkg::reqrsp_narrow_req_t     ),
+        .reqrsp_narrow_rsp_t                  (xdma_pkg::reqrsp_narrow_rsp_t     ),
+        .wide_data_t                          (xdma_pkg::wide_data_t             ),
+        .wide_strb_t                          (xdma_pkg::wide_strb_t             ),
+        .narrow_data_t                        (xdma_pkg::narrow_data_t           ),
+        .narrow_strb_t                        (xdma_pkg::narrow_strb_t           ),
         .addr_t                               (xdma_pkg::addr_t                  ),
         .len_t                                (xdma_pkg::len_t                   ),
         .xdma_to_remote_cfg_t                 (xdma_pkg::xdma_inter_cluster_cfg_t),

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -19,14 +19,21 @@ import xdma_pkg::*;
   // Address width
   parameter int unsigned PhysicalAddrWidth = ${cfg["addr_width"]},
   // TCDM typedefs
-  parameter type         tcdm_req_t        = logic,
-  parameter type         tcdm_rsp_t        = logic,
+  parameter type         tcdm_req_t          = logic,
+  parameter type         tcdm_rsp_t          = logic,
   // AXI type
-  parameter type         wide_slv_id_t     = logic,
-  parameter type         wide_out_req_t    = logic,
-  parameter type         wide_out_resp_t   = logic,
-  parameter type         wide_in_req_t     = logic,
-  parameter type         wide_in_resp_t    = logic,
+  // Wide
+  parameter type         wide_slv_id_t       = logic,
+  parameter type         wide_out_req_t      = logic,
+  parameter type         wide_out_resp_t     = logic,
+  parameter type         wide_in_req_t       = logic,
+  parameter type         wide_in_resp_t      = logic,
+  // Narrow
+  parameter type         narrow_slv_id_t     = logic,
+  parameter type         narrow_out_req_t    = logic,
+  parameter type         narrow_out_resp_t   = logic,
+  parameter type         narrow_in_req_t     = logic,
+  parameter type         narrow_in_resp_t    = logic,
   // Parameters related to TCDM
   parameter int unsigned TCDMDataWidth     = ${cfg["data_width"]},
   parameter int unsigned TCDMNumPorts      = ${num_tcdm_ports},
@@ -68,10 +75,16 @@ import xdma_pkg::*;
   //-----------------------------
   // XDMA Intercluster Ports
   //-----------------------------
+  // Wide for data
   output wide_out_req_t      xdma_wide_out_req_o,
   input  wide_out_resp_t     xdma_wide_out_resp_i,
   input  wide_in_req_t       xdma_wide_in_req_i,
-  output wide_in_resp_t      xdma_wide_in_resp_o
+  output wide_in_resp_t      xdma_wide_in_resp_o,
+  // Narrow for control
+  output narrow_out_req_t    xdma_narrow_out_req_o,
+  input  narrow_out_resp_t   xdma_narrow_out_resp_i,
+  input  narrow_in_req_t     xdma_narrow_in_req_i,
+  output narrow_in_resp_t    xdma_narrow_in_resp_o
 );
   
   //-----------------------------
@@ -307,11 +320,19 @@ import xdma_pkg::*;
 
 
     xdma_axi_adapter_top #(
-        .axi_id_t                             (wide_slv_id_t                     ),
-        .axi_out_req_t                        (wide_out_req_t                    ),
-        .axi_out_resp_t                       (wide_out_resp_t                   ),
-        .axi_in_req_t                         (wide_in_req_t                     ),
-        .axi_in_resp_t                        (wide_in_resp_t                    ),
+        // Wide AXI Types
+        .axi_wide_id_t                        (wide_slv_id_t                     ),
+        .axi_wide_out_req_t                   (wide_out_req_t                    ),
+        .axi_wide_out_resp_t                  (wide_out_resp_t                   ),
+        .axi_wide_in_req_t                    (wide_in_req_t                     ),
+        .axi_wide_in_resp_t                   (wide_in_resp_t                    ),
+        // Narrow AXI Types
+        .axi_narrow_id_t                      (narrow_slv_id_t                   ),
+        .axi_narrow_out_req_t                 (narrow_out_req_t                  ),
+        .axi_narrow_out_resp_t                (narrow_out_resp_t                 ),
+        .axi_narrow_in_req_t                  (narrow_in_req_t                   ),
+        .axi_narrow_in_resp_t                 (narrow_in_resp_t                  ),
+        // Reqrsp Types
         .reqrsp_req_t                         (xdma_pkg::reqrsp_req_t            ),
         .reqrsp_rsp_t                         (xdma_pkg::reqrsp_rsp_t            ),
         .data_t                               (xdma_pkg::data_t                  ),
@@ -360,10 +381,16 @@ import xdma_pkg::*;
         // finish
         .xdma_finish_o                   (xdma_finish                        ),
         // AXI interface
+        // Wide
         .axi_xdma_wide_out_req_o         (xdma_wide_out_req_o                ),
         .axi_xdma_wide_out_resp_i        (xdma_wide_out_resp_i               ),
         .axi_xdma_wide_in_req_i          (xdma_wide_in_req_i                 ),
-        .axi_xdma_wide_in_resp_o         (xdma_wide_in_resp_o                )
+        .axi_xdma_wide_in_resp_o         (xdma_wide_in_resp_o                ),
+        // Narrow
+        .axi_xdma_narrow_out_req_o       (xdma_narrow_out_req_o              ),
+        .axi_xdma_narrow_out_resp_i      (xdma_narrow_out_resp_i             ),
+        .axi_xdma_narrow_in_req_i        (xdma_narrow_in_req_i               ),
+        .axi_xdma_narrow_in_resp_o       (xdma_narrow_in_resp_o              )
     );
 
 

--- a/hw/templates/snax_xdma_wrapper.sv.tpl
+++ b/hw/templates/snax_xdma_wrapper.sv.tpl
@@ -147,7 +147,6 @@ import xdma_pkg::*;
   xdma_pkg::len_t                      xdma_to_remote_data_accompany_cfg_dma_length;
   logic                                xdma_to_remote_data_accompany_cfg_ready_to_transfer;
   logic                                xdma_to_remote_data_accompany_cfg_is_first_cw;
-  logic                                xdma_to_remote_data_accompany_cfg_is_last_cw;cw;
   logic                                xdma_to_remote_data_accompany_cfg_is_last_cw;
   ///---------------------
   /// FROM REMOTE


### PR DESCRIPTION
## Overview
This PR enhances XDMA performance by decoupling data and control transmissions to eliminate bandwidth contention.

## Problem
Previously, the XDMA used a single wide AXI interface for both:
- DATA payloads
- Control signals (CFG, GRANT, FINISH)
This caused bandwidth degradation during concurrent cluster Send/Receive operations. When CFG signals and DATA contended for the same interface, bandwidth dropped by ~50% as data transfers waited for control transactions to complete.

## Solution
Decouple transmission paths at the AXI interface level:
1. **Control signals** now route through dedicated narrow AXI
2. **Data payloads** retain the wide AXI interface

## Key modification
At the snax cluster level, this PR modifies the xdma wrapper and add one narrow port at the cluster narrow xbar.