### PR TITLE
Add Average Pooling

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -362,6 +362,6 @@ class ElementwiseAddToLong(
   ext_data_o.valid                 := output_stage.io.self_valid
   intermediate_ready               := output_stage.io.self_ready
 
-  ext_busy_o := !accumulate_stage.io.self_ready 
+  ext_busy_o := !accumulate_stage.io.self_ready
 
 }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -1,0 +1,252 @@
+package snax.DataPathExtension
+
+import chisel3._
+import chisel3.util._
+
+class HasElementwiseAddToLong(
+  in_elementWidth: Int = 8,
+  out_elementWidth: Int = 32,
+  dataWidth:    Int = 512
+) extends HasDataPathExtension {
+  implicit val extensionParam: DataPathExtensionParam =
+    new DataPathExtensionParam(
+      moduleName = s"ElementwiseAddToLongBit${in_elementWidth}To${out_elementWidth}",
+      userCsrNum = 1,
+      dataWidth  = dataWidth match {
+        case 0 => in_elementWidth
+        case _ => dataWidth
+      }
+    )
+
+  def instantiate(clusterName: String): ElementwiseAddToLong =
+    Module(
+      new ElementwiseAddToLong(in_elementWidth, out_elementWidth) {
+        override def desiredName = clusterName + namePostfix
+      }
+    )
+}
+
+object OutputCtrlEnumObj {
+  object OutputCtrlEnum extends ChiselEnum {
+    val WaitingInput, Busy = Value
+  }
+}
+
+
+
+
+class AccumulateStage(
+  in_elementWidth: Int,
+  out_elementWidth: Int
+)(implicit extensionParam: DataPathExtensionParam)
+    extends DataPathExtension {
+
+  val io = IO(new Bundle {
+    val data_i     = Flipped(Valid(UInt(extensionParam.dataWidth.W)))
+    val data_o     = Output(UInt((out_elementWidth / in_elementWidth * extensionParam.dataWidth).W)) //TODO: replace by 2D-vector
+    val previous_valid = previous_valid
+    val output_ready = Input(Bool())
+    val self_valid = Output(Bool())
+    val self_ready = Output(Bool())
+  })
+
+}
+
+
+
+
+
+
+
+class OutputCtrl(
+  in_elementWidth: Int = 8,
+  out_elementWidth: Int = 32
+)(implicit extensionParam: DataPathExtensionParam)
+    extends DataPathExtension {
+  val io = IO(new Bundle {
+    val accumulate_valid = Input(Bool())
+    val next_ready       = Input(Bool())
+    val self_valid   = Output(Bool())
+    val self_ready   = Output(Bool())
+    val output_counter_value = Output(UInt(log2Ceil(out_elementWidth / in_elementWidth).W))
+  })
+    import OutputCtrlEnumObj.OutputCtrlEnum._
+
+    val counter_active = Wire(Bool())
+    val reset_counter  = Wire(Bool())
+
+    // Counter to record the steps
+    val output_counter = Module(new snax.utils.BasicCounter(8) {
+        override val desiredName = "Output_Counter"
+    })
+    output_counter.io.ceil := (out_elementWidth / in_elementWidth - 1).U(8.W) //TODO: check if inclusive
+    output_counter.io.reset := reset_counter
+    output_counter.io.tick  := counter_active & next_ready //Only go up when handshaking is done
+
+    output_counter_value := output_counter.io.value
+
+    val state = RegInit(WaitingInput)
+
+    switch(state) {
+      is(WaitingInput) {
+        when(io.accumulate_valid) {
+          state := Busy
+        }
+      }
+      is(Busy) {
+        when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
+            when(io.accumulate_valid){
+                state := Busy
+            }.otherwise {
+          state := WaitingOutput
+            }
+        }.otherwise{
+          state := Busy
+        }
+      }
+    }
+
+    switch(state) {
+        is(WaitingInput) {
+      io.self_valid := false.B
+        reset_counter := true.B
+        counter_active := false.B
+        io.self_ready := true.B
+      }
+      is(Busy) {
+        when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
+          io.self_valid := true.B
+          reset_counter := false.B
+          counter_active := true.B
+          io.self_ready := true.B
+        }.otherwise {
+          io.self_valid := true.B
+          reset_counter := false.B
+          counter_active := true.B
+          io.self_ready := false.B
+        }
+      }
+
+  }
+
+class OutputStage(
+  in_elementWidth: Int,
+  out_elementWidth: Int
+)(implicit extensionParam: DataPathExtensionParam)
+    extends DataPathExtension { // TODO; Should not extend DataPathExtension
+  
+  val io = IO(new Bundle {
+    val data_i     = Flipped(Valid(UInt((out_elementWidth / in_elementWidth * extensionParam.dataWidth).W))) // TODO: replace by 2D-vector
+    val data_o     = Output(UInt(extensionParam.dataWidth.W))
+    val accumulate_valid = Input(Bool())
+    val next_ready = Input(Bool())
+    val self_ready = Output(Bool())
+  })
+
+    val output_ctrl = Module(
+        new OutputCtrl(in_elementWidth, out_elementWidth) {
+        override def desiredName = "OutputCtrl"
+        }
+    )
+    output_ctrl.io.accumulate_valid := io.accumulate_valid
+    output_ctrl.io.next_ready       := io.next_ready
+
+    io.self_ready := output_ctrl.io.self_ready
+
+    // For each input element, on output element is needed
+    val output_regs = RegInit(
+        VecInit(
+            Seq.fill(in_elementWidth / out_elementWidth, extensionParam.dataWidth / out_elementWidth)(0.U(out_elementWidth.W))
+        )
+    )
+
+    //TODO: make logic for updating the registers
+
+
+    ext_data_o.bits := Cat(output_regs(output_counter.io.value).reverse)
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class ElementwiseAddToLong(
+  in_elementWidth: Int,
+  out_elementWidth: Int
+)(implicit extensionParam: DataPathExtensionParam)
+    extends DataPathExtension {
+  require(
+    extensionParam.dataWidth % in_elementWidth == 0,
+    s"Data width ${extensionParam.dataWidth} must be a multiple of element width $in_elementWidth"
+  )
+  require(
+    extensionParam.dataWidth % out_elementWidth == 0,
+    s"Data width ${extensionParam.dataWidth} must be a multiple of output element width $out_elementWidth"
+  )
+
+  // Counter to record the steps
+  val counter = Module(new snax.utils.BasicCounter(8) {
+    override val desiredName = "ElementwiseAddToLongCounter"
+  })
+  counter.io.ceil := ext_csr_i(0)
+  counter.io.reset := ext_start_i
+  counter.io.tick  := ext_data_i.fire
+  ext_busy_o       := counter.io.value =/= 0.U
+
+  // The wire to connect the output result
+  val ext_data_o_bits = Wire(
+    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
+  )
+
+  // The register to hold the sum of each Element
+  val regs = RegInit(
+    VecInit(
+      Seq.fill(extensionParam.dataWidth / elementWidth)(0.U(elementWidth.W))
+    )
+  )
+
+  val input_data = ext_data_i.bits.asTypeOf(
+    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
+  )
+  for (i <- 0 until extensionParam.dataWidth / elementWidth) {
+    ext_data_o_bits(i) := regs(i) + input_data(i)
+  }
+
+  when(ext_data_i.fire) {
+    when(counter.io.value === (ext_csr_i(0) - 1.U(8.W))) {
+      // Reset the registers when the counter reaches the end
+      for (i <- 0 until extensionParam.dataWidth / elementWidth) {
+        regs(i) := 0.U
+      }
+    } otherwise {
+      // Add the input data to the corresponding register
+      for (i <- 0 until extensionParam.dataWidth / elementWidth) {
+        regs(i) := regs(i) + input_data(i)
+      }
+    }
+  }
+
+  ext_data_o.bits  := Cat(ext_data_o_bits.reverse)
+  ext_data_o.valid := (counter.io.value === (ext_csr_i(0) - 1.U)(7, 0)) & ext_data_i.fire
+  ext_data_i.ready := ext_data_o.ready
+}

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -26,6 +26,170 @@ class HasElementwiseAddToLong(
     )
 }
 
+object AccumulateCtrlEnumObj {
+  object AccumulateCtrlEnum extends ChiselEnum {
+    val Busy, WaitingOutput = Value
+  }
+}
+
+class AccumulateCtrl(
+  in_elementWidth: Int = 8,
+  out_elementWidth: Int = 32,
+  dataWidth: Int = 512
+)  extends Module{
+
+  val io = IO(new Bundle {
+    val previous_valid = Input(Bool())
+    val output_ready       = Input(Bool())
+    val pooling_size = Input(UInt(32.W))
+    val self_valid       = Output(Bool())
+    val self_ready       = Output(Bool())
+    val accumulate_reset = Output(Bool())
+    val accumulate_update = Output(Bool())
+  })
+
+  import AccumulateCtrlEnumObj.AccumulateCtrlEnum._
+
+  val reset_counter = WireInit(true.B)
+
+  val counter_active = Wire(Bool())
+    // Counter to record the steps
+    val accumulate_counter = Module(new snax.utils.BasicCounter(8) {
+        override val desiredName = "Accumulate_Counter"
+    })
+    accumulate_counter.io.ceil := io.pooling_size
+    accumulate_counter.io.reset := reset_counter
+    accumulate_counter.io.tick  := counter_active & io.previous_valid //Only go up when handshaking is done
+
+  val state = RegInit(Busy)
+
+  switch(state) {
+    is(Busy) {
+      when(accumulate_counter.io.value === (io.pooling_size - 1.U(8.W))) {
+        when(io.output_ready){
+          state := Busy
+        }.otherwise {
+          state := WaitingOutput
+        }
+      }.otherwise {
+        state := Busy
+      }
+    }
+    is(WaitingOutput) {
+      when(io.output_ready) {
+        state := Busy
+      }.otherwise {
+        state := WaitingOutput
+      }
+    }
+
+  }
+
+  io.self_valid := false.B
+  counter_active := false.B
+  reset_counter := true.B
+  io.self_ready := true.B
+  io.accumulate_reset := true.B
+  io.accumulate_update := false.B
+
+  switch(state) {
+    is(Busy) {
+      when(accumulate_counter.io.value === (io.pooling_size - 1.U(8.W))) {
+        when (io.output_ready) {
+          io.self_valid := true.B
+          counter_active := true.B
+          reset_counter := false.B
+          io.self_ready := true.B
+          io.accumulate_reset := true.B
+          io.accumulate_update := true.B
+        }.otherwise {
+          io.self_valid := true.B
+          counter_active := false.B
+          reset_counter := false.B
+          io.self_ready := false.B
+          io.accumulate_reset := false.B
+          io.accumulate_update := false.B
+        }
+      }.otherwise {
+        io.self_valid := false.B
+        counter_active := true.B
+        reset_counter := false.B
+        io.self_ready := true.B
+        io.accumulate_reset := false.B
+        io.accumulate_update := true.B
+      }
+    }
+    is(WaitingOutput) {
+      io.self_valid := true.B
+      counter_active := io.output_ready
+      reset_counter := false.B
+      io.self_ready := io.output_ready
+      io.accumulate_reset := io.output_ready
+      io.accumulate_update := false.B
+    }
+  }
+}
+
+
+class AccumulateStage(
+  in_elementWidth: Int,
+  out_elementWidth: Int,
+  dataWidth: Int = 512
+) extends Module {
+
+  val io = IO(new Bundle {
+    val data_i     = Flipped(UInt(dataWidth.W))
+    val data_o     = Output(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
+    val previous_valid = Input(Bool())
+    val output_ready = Input(Bool())
+    val pooling_size = Input(UInt(32.W))
+    val self_valid = Output(Bool())
+    val self_ready = Output(Bool())
+  })
+
+  val accumulate_ctrl = Module(
+    new AccumulateCtrl(in_elementWidth, out_elementWidth) 
+  )
+  accumulate_ctrl.io.previous_valid := io.previous_valid
+  accumulate_ctrl.io.output_ready := io.output_ready
+  accumulate_ctrl.io.pooling_size := io.pooling_size
+  io.self_valid := accumulate_ctrl.io.self_valid
+  io.self_ready := accumulate_ctrl.io.self_ready
+
+  val accumulate_regs = RegInit(
+    VecInit.fill(out_elementWidth / in_elementWidth, dataWidth / out_elementWidth)(0.S(out_elementWidth.W))
+  )
+
+  val output_data = Wire(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
+
+  val input_data = io.data_i.asTypeOf(
+    Vec(dataWidth / in_elementWidth, SInt(in_elementWidth.W))
+  )
+
+
+  for (i <- 0 until dataWidth / out_elementWidth) {
+    for (j <- 0 until out_elementWidth / in_elementWidth) {
+
+      output_data(j)(i) := accumulate_regs(j)(i) + input_data(j * dataWidth / out_elementWidth + i)
+
+      when(accumulate_ctrl.io.accumulate_reset){
+        accumulate_regs(j)(i) := 0.S
+      }.elsewhen(accumulate_ctrl.io.accumulate_update & io.previous_valid) {
+        accumulate_regs(j)(i) := output_data(j)(i)
+      }.otherwise {
+        accumulate_regs(j)(i) := accumulate_regs(j)(i)
+      }
+
+    }
+  }
+
+  io.data_o := output_data
+
+}
+
+
+
+
 object OutputCtrlEnumObj {
   object OutputCtrlEnum extends ChiselEnum {
     val WaitingInput, Busy = Value
@@ -34,35 +198,11 @@ object OutputCtrlEnumObj {
 
 
 
-
-class AccumulateStage(
-  in_elementWidth: Int,
-  out_elementWidth: Int
-)(implicit extensionParam: DataPathExtensionParam)
-    extends DataPathExtension {
-
-  val io = IO(new Bundle {
-    val data_i     = Flipped(Valid(UInt(extensionParam.dataWidth.W)))
-    val data_o     = Output(UInt((out_elementWidth / in_elementWidth * extensionParam.dataWidth).W)) //TODO: replace by 2D-vector
-    val previous_valid = previous_valid
-    val output_ready = Input(Bool())
-    val self_valid = Output(Bool())
-    val self_ready = Output(Bool())
-  })
-
-}
-
-
-
-
-
-
-
 class OutputCtrl(
   in_elementWidth: Int = 8,
-  out_elementWidth: Int = 32
-)(implicit extensionParam: DataPathExtensionParam)
-    extends DataPathExtension {
+  out_elementWidth: Int = 32,
+  dataWidth: Int = 512
+) extends Module {
   val io = IO(new Bundle {
     val accumulate_valid = Input(Bool())
     val next_ready       = Input(Bool())
@@ -72,18 +212,19 @@ class OutputCtrl(
   })
     import OutputCtrlEnumObj.OutputCtrlEnum._
 
-    val counter_active = Wire(Bool())
-    val reset_counter  = Wire(Bool())
+    val counter_active = WireInit(false.B)
+    val reset_counter  = WireInit(true.B)
 
     // Counter to record the steps
     val output_counter = Module(new snax.utils.BasicCounter(8) {
         override val desiredName = "Output_Counter"
     })
-    output_counter.io.ceil := (out_elementWidth / in_elementWidth - 1).U(8.W) //TODO: check if inclusive
+    output_counter.io.ceil := (out_elementWidth / in_elementWidth).U(8.W)
     output_counter.io.reset := reset_counter
-    output_counter.io.tick  := counter_active & next_ready //Only go up when handshaking is done
+    output_counter.io.tick  := counter_active & io.next_ready //Only go up when handshaking is done
 
-    output_counter_value := output_counter.io.value
+
+    io.output_counter_value := output_counter.io.value
 
     val state = RegInit(WaitingInput)
 
@@ -95,30 +236,37 @@ class OutputCtrl(
       }
       is(Busy) {
         when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
+          when(io.next_ready) {
             when(io.accumulate_valid){
                 state := Busy
             }.otherwise {
-          state := WaitingOutput
+          state := WaitingInput
             }
+          }.otherwise {
+            state := Busy
+          }
         }.otherwise{
           state := Busy
         }
       }
     }
 
+    io.self_valid := false.B
+    io.self_ready := true.B
+
     switch(state) {
-        is(WaitingInput) {
-      io.self_valid := false.B
-        reset_counter := true.B
-        counter_active := false.B
-        io.self_ready := true.B
-      }
+      is(WaitingInput) {
+        io.self_valid := false.B
+          reset_counter := true.B
+          counter_active := false.B
+          io.self_ready := true.B
+        }
       is(Busy) {
         when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
           io.self_valid := true.B
           reset_counter := false.B
           counter_active := true.B
-          io.self_ready := true.B
+          io.self_ready := io.next_ready
         }.otherwise {
           io.self_valid := true.B
           reset_counter := false.B
@@ -126,66 +274,52 @@ class OutputCtrl(
           io.self_ready := false.B
         }
       }
+    } 
 
   }
 
 class OutputStage(
   in_elementWidth: Int,
-  out_elementWidth: Int
-)(implicit extensionParam: DataPathExtensionParam)
-    extends DataPathExtension { // TODO; Should not extend DataPathExtension
+  out_elementWidth: Int,
+  dataWidth: Int = 512
+) extends Module { 
   
   val io = IO(new Bundle {
-    val data_i     = Flipped(Valid(UInt((out_elementWidth / in_elementWidth * extensionParam.dataWidth).W))) // TODO: replace by 2D-vector
-    val data_o     = Output(UInt(extensionParam.dataWidth.W))
+    val data_i     = Flipped(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
+    val data_o     = Output(UInt(dataWidth.W))
     val accumulate_valid = Input(Bool())
     val next_ready = Input(Bool())
     val self_ready = Output(Bool())
+    val self_valid = Output(Bool())
   })
 
     val output_ctrl = Module(
-        new OutputCtrl(in_elementWidth, out_elementWidth) {
-        override def desiredName = "OutputCtrl"
-        }
+        new OutputCtrl(in_elementWidth, out_elementWidth, dataWidth) 
     )
     output_ctrl.io.accumulate_valid := io.accumulate_valid
     output_ctrl.io.next_ready       := io.next_ready
+    io.self_valid := output_ctrl.io.self_valid
+    io.self_ready := output_ctrl.io.self_ready
+    val output_counter_value = Wire(UInt(log2Ceil(out_elementWidth / in_elementWidth).W))
+    output_counter_value := output_ctrl.io.output_counter_value
 
     io.self_ready := output_ctrl.io.self_ready
 
     // For each input element, on output element is needed
-    val output_regs = RegInit(
-        VecInit(
-            Seq.fill(in_elementWidth / out_elementWidth, extensionParam.dataWidth / out_elementWidth)(0.U(out_elementWidth.W))
-        )
-    )
+    val output_regs = RegInit(VecInit.fill(out_elementWidth / in_elementWidth, dataWidth / out_elementWidth)(0.S(out_elementWidth.W)))
 
-    //TODO: make logic for updating the registers
+    for (i <- 0 until dataWidth / out_elementWidth) {
+      for (j <- 0 until out_elementWidth / in_elementWidth) {
+        when(output_ctrl.io.self_ready && io.accumulate_valid){
+          output_regs(j)(i) := io.data_i(j)(i)
+        }.otherwise {
+          output_regs(j)(i) := output_regs(j)(i)
+        }
+      }
+    }
 
-
-    ext_data_o.bits := Cat(output_regs(output_counter.io.value).reverse)
+    io.data_o := Cat(output_regs(output_counter_value).reverse)
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -204,49 +338,35 @@ class ElementwiseAddToLong(
     s"Data width ${extensionParam.dataWidth} must be a multiple of output element width $out_elementWidth"
   )
 
-  // Counter to record the steps
-  val counter = Module(new snax.utils.BasicCounter(8) {
-    override val desiredName = "ElementwiseAddToLongCounter"
-  })
-  counter.io.ceil := ext_csr_i(0)
-  counter.io.reset := ext_start_i
-  counter.io.tick  := ext_data_i.fire
-  ext_busy_o       := counter.io.value =/= 0.U
+  val intermediate_data = VecInit.fill(out_elementWidth / in_elementWidth, extensionParam.dataWidth / out_elementWidth)(0.S(out_elementWidth.W))
+  val intermediate_valid = Wire(Bool())
+  val intermediate_ready = Wire(Bool())
 
-  // The wire to connect the output result
-  val ext_data_o_bits = Wire(
-    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
-  )
-
-  // The register to hold the sum of each Element
-  val regs = RegInit(
-    VecInit(
-      Seq.fill(extensionParam.dataWidth / elementWidth)(0.U(elementWidth.W))
-    )
-  )
-
-  val input_data = ext_data_i.bits.asTypeOf(
-    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
-  )
-  for (i <- 0 until extensionParam.dataWidth / elementWidth) {
-    ext_data_o_bits(i) := regs(i) + input_data(i)
-  }
-
-  when(ext_data_i.fire) {
-    when(counter.io.value === (ext_csr_i(0) - 1.U(8.W))) {
-      // Reset the registers when the counter reaches the end
-      for (i <- 0 until extensionParam.dataWidth / elementWidth) {
-        regs(i) := 0.U
-      }
-    } otherwise {
-      // Add the input data to the corresponding register
-      for (i <- 0 until extensionParam.dataWidth / elementWidth) {
-        regs(i) := regs(i) + input_data(i)
-      }
+  val accumulate_stage = Module(
+    new AccumulateStage(in_elementWidth, out_elementWidth, extensionParam.dataWidth) {
+      override def desiredName = "AccumulateStage"
     }
-  }
+  )
+  accumulate_stage.io.data_i := ext_data_i.bits
+  accumulate_stage.io.previous_valid := ext_data_i.valid
+  accumulate_stage.io.output_ready := intermediate_ready
+  accumulate_stage.io.pooling_size := ext_csr_i(0).asUInt
+  intermediate_data := accumulate_stage.io.data_o
+  ext_data_i.ready := accumulate_stage.io.self_ready
+  intermediate_valid := accumulate_stage.io.self_valid
 
-  ext_data_o.bits  := Cat(ext_data_o_bits.reverse)
-  ext_data_o.valid := (counter.io.value === (ext_csr_i(0) - 1.U)(7, 0)) & ext_data_i.fire
-  ext_data_i.ready := ext_data_o.ready
+
+
+  val output_stage = Module(
+    new OutputStage(in_elementWidth, out_elementWidth, extensionParam.dataWidth) 
+  )
+  output_stage.io.data_i := intermediate_data
+  output_stage.io.accumulate_valid := intermediate_valid
+  output_stage.io.next_ready := ext_data_o.ready
+  ext_data_o.bits := output_stage.io.data_o
+  ext_data_o.valid := output_stage.io.self_valid
+  intermediate_ready := output_stage.io.self_ready
+
+  ext_busy_o := accumulate_stage.io.self_ready || output_stage.io.self_valid
+
 }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -362,6 +362,6 @@ class ElementwiseAddToLong(
   ext_data_o.valid                 := output_stage.io.self_valid
   intermediate_ready               := output_stage.io.self_ready
 
-  ext_busy_o := !accumulate_stage.io.self_ready
+  ext_busy_o := !accumulate_stage.io.self_ready 
 
 }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -4,9 +4,9 @@ import chisel3._
 import chisel3.util._
 
 class HasElementwiseAddToLong(
-  in_elementWidth: Int = 8,
+  in_elementWidth:  Int = 8,
   out_elementWidth: Int = 32,
-  dataWidth:    Int = 512
+  dataWidth:        Int = 512
 ) extends HasDataPathExtension {
   implicit val extensionParam: DataPathExtensionParam =
     new DataPathExtensionParam(
@@ -33,18 +33,18 @@ object AccumulateCtrlEnumObj {
 }
 
 class AccumulateCtrl(
-  in_elementWidth: Int = 8,
+  in_elementWidth:  Int = 8,
   out_elementWidth: Int = 32,
-  dataWidth: Int = 512
-)  extends Module{
+  dataWidth:        Int = 512
+) extends Module {
 
   val io = IO(new Bundle {
-    val previous_valid = Input(Bool())
-    val output_ready       = Input(Bool())
-    val pooling_size = Input(UInt(32.W))
-    val self_valid       = Output(Bool())
-    val self_ready       = Output(Bool())
-    val accumulate_reset = Output(Bool())
+    val previous_valid    = Input(Bool())
+    val output_ready      = Input(Bool())
+    val pooling_size      = Input(UInt(32.W))
+    val self_valid        = Output(Bool())
+    val self_ready        = Output(Bool())
+    val accumulate_reset  = Output(Bool())
     val accumulate_update = Output(Bool())
   })
 
@@ -52,21 +52,21 @@ class AccumulateCtrl(
 
   val reset_counter = WireInit(true.B)
 
-  val counter_active = Wire(Bool())
-    // Counter to record the steps
-    val accumulate_counter = Module(new snax.utils.BasicCounter(8) {
-        override val desiredName = "Accumulate_Counter"
-    })
-    accumulate_counter.io.ceil := io.pooling_size
-    accumulate_counter.io.reset := reset_counter
-    accumulate_counter.io.tick  := counter_active & io.previous_valid //Only go up when handshaking is done
+  val counter_active     = Wire(Bool())
+  // Counter to record the steps
+  val accumulate_counter = Module(new snax.utils.BasicCounter(8) {
+    override val desiredName = "Accumulate_Counter"
+  })
+  accumulate_counter.io.ceil := io.pooling_size
+  accumulate_counter.io.reset := reset_counter
+  accumulate_counter.io.tick  := counter_active & io.previous_valid // Only go up when handshaking is done
 
   val state = RegInit(Busy)
 
   switch(state) {
     is(Busy) {
       when(accumulate_counter.io.value === (io.pooling_size - 1.U(8.W))) {
-        when(io.output_ready){
+        when(io.output_ready) {
           state := Busy
         }.otherwise {
           state := WaitingOutput
@@ -85,94 +85,95 @@ class AccumulateCtrl(
 
   }
 
-  io.self_valid := false.B
-  counter_active := false.B
-  reset_counter := true.B
-  io.self_ready := true.B
-  io.accumulate_reset := true.B
+  io.self_valid        := false.B
+  counter_active       := false.B
+  reset_counter        := true.B
+  io.self_ready        := true.B
+  io.accumulate_reset  := true.B
   io.accumulate_update := false.B
 
   switch(state) {
     is(Busy) {
       when(accumulate_counter.io.value === (io.pooling_size - 1.U(8.W))) {
-        when (io.output_ready) {
-          io.self_valid := true.B
-          counter_active := true.B
-          reset_counter := false.B
-          io.self_ready := true.B
-          io.accumulate_reset := true.B
+        when(io.output_ready) {
+          io.self_valid        := true.B
+          counter_active       := true.B
+          reset_counter        := false.B
+          io.self_ready        := true.B
+          io.accumulate_reset  := true.B
           io.accumulate_update := true.B
         }.otherwise {
-          io.self_valid := true.B
-          counter_active := false.B
-          reset_counter := false.B
-          io.self_ready := false.B
-          io.accumulate_reset := false.B
+          io.self_valid        := true.B
+          counter_active       := false.B
+          reset_counter        := false.B
+          io.self_ready        := false.B
+          io.accumulate_reset  := false.B
           io.accumulate_update := false.B
         }
       }.otherwise {
-        io.self_valid := false.B
-        counter_active := true.B
-        reset_counter := false.B
-        io.self_ready := true.B
-        io.accumulate_reset := false.B
+        io.self_valid        := false.B
+        counter_active       := true.B
+        reset_counter        := false.B
+        io.self_ready        := true.B
+        io.accumulate_reset  := false.B
         io.accumulate_update := true.B
       }
     }
     is(WaitingOutput) {
-      io.self_valid := true.B
-      counter_active := io.output_ready
-      reset_counter := false.B
-      io.self_ready := io.output_ready
-      io.accumulate_reset := io.output_ready
+      io.self_valid        := true.B
+      counter_active       := io.output_ready
+      reset_counter        := false.B
+      io.self_ready        := io.output_ready
+      io.accumulate_reset  := io.output_ready
       io.accumulate_update := false.B
     }
   }
 }
 
-
 class AccumulateStage(
-  in_elementWidth: Int,
+  in_elementWidth:  Int,
   out_elementWidth: Int,
-  dataWidth: Int = 512
+  dataWidth:        Int = 512
 ) extends Module {
 
   val io = IO(new Bundle {
-    val data_i     = Flipped(UInt(dataWidth.W))
-    val data_o     = Output(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
+    val data_i         = Flipped(UInt(dataWidth.W))
+    val data_o         =
+      Output(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
     val previous_valid = Input(Bool())
-    val output_ready = Input(Bool())
-    val pooling_size = Input(UInt(32.W))
-    val self_valid = Output(Bool())
-    val self_ready = Output(Bool())
+    val output_ready   = Input(Bool())
+    val pooling_size   = Input(UInt(32.W))
+    val self_valid     = Output(Bool())
+    val self_ready     = Output(Bool())
   })
 
   val accumulate_ctrl = Module(
-    new AccumulateCtrl(in_elementWidth, out_elementWidth) 
+    new AccumulateCtrl(in_elementWidth, out_elementWidth)
   )
   accumulate_ctrl.io.previous_valid := io.previous_valid
-  accumulate_ctrl.io.output_ready := io.output_ready
-  accumulate_ctrl.io.pooling_size := io.pooling_size
-  io.self_valid := accumulate_ctrl.io.self_valid
-  io.self_ready := accumulate_ctrl.io.self_ready
+  accumulate_ctrl.io.output_ready   := io.output_ready
+  accumulate_ctrl.io.pooling_size   := io.pooling_size
+  io.self_valid                     := accumulate_ctrl.io.self_valid
+  io.self_ready                     := accumulate_ctrl.io.self_ready
 
   val accumulate_regs = RegInit(
     VecInit.fill(out_elementWidth / in_elementWidth, dataWidth / out_elementWidth)(0.S(out_elementWidth.W))
   )
 
-  val output_data = Wire(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
+  val output_data = Wire(
+    Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W)))
+  )
 
   val input_data = io.data_i.asTypeOf(
     Vec(dataWidth / in_elementWidth, SInt(in_elementWidth.W))
   )
-
 
   for (i <- 0 until dataWidth / out_elementWidth) {
     for (j <- 0 until out_elementWidth / in_elementWidth) {
 
       output_data(j)(i) := accumulate_regs(j)(i) + input_data(j * dataWidth / out_elementWidth + i)
 
-      when(accumulate_ctrl.io.accumulate_reset){
+      when(accumulate_ctrl.io.accumulate_reset) {
         accumulate_regs(j)(i) := 0.S
       }.elsewhen(accumulate_ctrl.io.accumulate_update & io.previous_valid) {
         accumulate_regs(j)(i) := output_data(j)(i)
@@ -187,145 +188,139 @@ class AccumulateStage(
 
 }
 
-
-
-
 object OutputCtrlEnumObj {
   object OutputCtrlEnum extends ChiselEnum {
     val WaitingInput, Busy = Value
   }
 }
 
-
-
 class OutputCtrl(
-  in_elementWidth: Int = 8,
+  in_elementWidth:  Int = 8,
   out_elementWidth: Int = 32,
-  dataWidth: Int = 512
+  dataWidth:        Int = 512
 ) extends Module {
   val io = IO(new Bundle {
-    val accumulate_valid = Input(Bool())
-    val next_ready       = Input(Bool())
-    val self_valid   = Output(Bool())
-    val self_ready   = Output(Bool())
+    val accumulate_valid     = Input(Bool())
+    val next_ready           = Input(Bool())
+    val self_valid           = Output(Bool())
+    val self_ready           = Output(Bool())
     val output_counter_value = Output(UInt(log2Ceil(out_elementWidth / in_elementWidth).W))
   })
-    import OutputCtrlEnumObj.OutputCtrlEnum._
+  import OutputCtrlEnumObj.OutputCtrlEnum._
 
-    val counter_active = WireInit(false.B)
-    val reset_counter  = WireInit(true.B)
+  val counter_active = WireInit(false.B)
+  val reset_counter  = WireInit(true.B)
 
-    // Counter to record the steps
-    val output_counter = Module(new snax.utils.BasicCounter(8) {
-        override val desiredName = "Output_Counter"
-    })
-    output_counter.io.ceil := (out_elementWidth / in_elementWidth).U(8.W)
-    output_counter.io.reset := reset_counter
-    output_counter.io.tick  := counter_active & io.next_ready //Only go up when handshaking is done
+  // Counter to record the steps
+  val output_counter = Module(new snax.utils.BasicCounter(8) {
+    override val desiredName = "Output_Counter"
+  })
+  output_counter.io.ceil := (out_elementWidth / in_elementWidth).U(8.W)
+  output_counter.io.reset := reset_counter
+  output_counter.io.tick  := counter_active & io.next_ready // Only go up when handshaking is done
 
+  io.output_counter_value := output_counter.io.value
 
-    io.output_counter_value := output_counter.io.value
+  val state = RegInit(WaitingInput)
 
-    val state = RegInit(WaitingInput)
-
-    switch(state) {
-      is(WaitingInput) {
-        when(io.accumulate_valid) {
-          state := Busy
-        }
-      }
-      is(Busy) {
-        when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
-          when(io.next_ready) {
-            when(io.accumulate_valid){
-                state := Busy
-            }.otherwise {
-          state := WaitingInput
-            }
-          }.otherwise {
-            state := Busy
-          }
-        }.otherwise{
-          state := Busy
-        }
+  switch(state) {
+    is(WaitingInput) {
+      when(io.accumulate_valid) {
+        state := Busy
       }
     }
-
-    io.self_valid := false.B
-    io.self_ready := true.B
-
-    switch(state) {
-      is(WaitingInput) {
-        io.self_valid := false.B
-          reset_counter := true.B
-          counter_active := false.B
-          io.self_ready := true.B
-        }
-      is(Busy) {
-        when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
-          io.self_valid := true.B
-          reset_counter := false.B
-          counter_active := true.B
-          io.self_ready := io.next_ready
+    is(Busy) {
+      when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
+        when(io.next_ready) {
+          when(io.accumulate_valid) {
+            state := Busy
+          }.otherwise {
+            state := WaitingInput
+          }
         }.otherwise {
-          io.self_valid := true.B
-          reset_counter := false.B
-          counter_active := true.B
-          io.self_ready := false.B
+          state := Busy
         }
+      }.otherwise {
+        state := Busy
       }
-    } 
-
+    }
   }
 
-class OutputStage(
-  in_elementWidth: Int,
-  out_elementWidth: Int,
-  dataWidth: Int = 512
-) extends Module { 
-  
-  val io = IO(new Bundle {
-    val data_i     = Flipped(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
-    val data_o     = Output(UInt(dataWidth.W))
-    val accumulate_valid = Input(Bool())
-    val next_ready = Input(Bool())
-    val self_ready = Output(Bool())
-    val self_valid = Output(Bool())
-  })
+  io.self_valid := false.B
+  io.self_ready := true.B
 
-    val output_ctrl = Module(
-        new OutputCtrl(in_elementWidth, out_elementWidth, dataWidth) 
-    )
-    output_ctrl.io.accumulate_valid := io.accumulate_valid
-    output_ctrl.io.next_ready       := io.next_ready
-    io.self_valid := output_ctrl.io.self_valid
-    io.self_ready := output_ctrl.io.self_ready
-    val output_counter_value = Wire(UInt(log2Ceil(out_elementWidth / in_elementWidth).W))
-    output_counter_value := output_ctrl.io.output_counter_value
-
-    io.self_ready := output_ctrl.io.self_ready
-
-    // For each input element, on output element is needed
-    val output_regs = RegInit(VecInit.fill(out_elementWidth / in_elementWidth, dataWidth / out_elementWidth)(0.S(out_elementWidth.W)))
-
-    for (i <- 0 until dataWidth / out_elementWidth) {
-      for (j <- 0 until out_elementWidth / in_elementWidth) {
-        when(output_ctrl.io.self_ready && io.accumulate_valid){
-          output_regs(j)(i) := io.data_i(j)(i)
-        }.otherwise {
-          output_regs(j)(i) := output_regs(j)(i)
-        }
+  switch(state) {
+    is(WaitingInput) {
+      io.self_valid  := false.B
+      reset_counter  := true.B
+      counter_active := false.B
+      io.self_ready  := true.B
+    }
+    is(Busy) {
+      when(output_counter.io.value === (out_elementWidth / in_elementWidth - 1).U(8.W)) {
+        io.self_valid  := true.B
+        reset_counter  := false.B
+        counter_active := true.B
+        io.self_ready  := io.next_ready
+      }.otherwise {
+        io.self_valid  := true.B
+        reset_counter  := false.B
+        counter_active := true.B
+        io.self_ready  := false.B
       }
     }
+  }
 
-    io.data_o := Cat(output_regs(output_counter_value).reverse)
 }
 
+class OutputStage(
+  in_elementWidth:  Int,
+  out_elementWidth: Int,
+  dataWidth:        Int = 512
+) extends Module {
 
+  val io = IO(new Bundle {
+    val data_i           =
+      Flipped(Vec(out_elementWidth / in_elementWidth, Vec(dataWidth / out_elementWidth, SInt(out_elementWidth.W))))
+    val data_o           = Output(UInt(dataWidth.W))
+    val accumulate_valid = Input(Bool())
+    val next_ready       = Input(Bool())
+    val self_ready       = Output(Bool())
+    val self_valid       = Output(Bool())
+  })
 
+  val output_ctrl = Module(
+    new OutputCtrl(in_elementWidth, out_elementWidth, dataWidth)
+  )
+  output_ctrl.io.accumulate_valid := io.accumulate_valid
+  output_ctrl.io.next_ready       := io.next_ready
+  io.self_valid                   := output_ctrl.io.self_valid
+  io.self_ready                   := output_ctrl.io.self_ready
+  val output_counter_value = Wire(UInt(log2Ceil(out_elementWidth / in_elementWidth).W))
+  output_counter_value := output_ctrl.io.output_counter_value
+
+  io.self_ready := output_ctrl.io.self_ready
+
+  // For each input element, on output element is needed
+  val output_regs = RegInit(
+    VecInit.fill(out_elementWidth / in_elementWidth, dataWidth / out_elementWidth)(0.S(out_elementWidth.W))
+  )
+
+  for (i <- 0 until dataWidth / out_elementWidth) {
+    for (j <- 0 until out_elementWidth / in_elementWidth) {
+      when(output_ctrl.io.self_ready && io.accumulate_valid) {
+        output_regs(j)(i) := io.data_i(j)(i)
+      }.otherwise {
+        output_regs(j)(i) := output_regs(j)(i)
+      }
+    }
+  }
+
+  io.data_o := Cat(output_regs(output_counter_value).reverse)
+}
 
 class ElementwiseAddToLong(
-  in_elementWidth: Int,
+  in_elementWidth:  Int,
   out_elementWidth: Int
 )(implicit extensionParam: DataPathExtensionParam)
     extends DataPathExtension {
@@ -338,7 +333,9 @@ class ElementwiseAddToLong(
     s"Data width ${extensionParam.dataWidth} must be a multiple of output element width $out_elementWidth"
   )
 
-  val intermediate_data = VecInit.fill(out_elementWidth / in_elementWidth, extensionParam.dataWidth / out_elementWidth)(0.S(out_elementWidth.W))
+  val intermediate_data = VecInit.fill(out_elementWidth / in_elementWidth, extensionParam.dataWidth / out_elementWidth)(
+    0.S(out_elementWidth.W)
+  )
   val intermediate_valid = Wire(Bool())
   val intermediate_ready = Wire(Bool())
 
@@ -349,23 +346,21 @@ class ElementwiseAddToLong(
   )
   accumulate_stage.io.data_i := ext_data_i.bits
   accumulate_stage.io.previous_valid := ext_data_i.valid
-  accumulate_stage.io.output_ready := intermediate_ready
-  accumulate_stage.io.pooling_size := ext_csr_i(0).asUInt
-  intermediate_data := accumulate_stage.io.data_o
-  ext_data_i.ready := accumulate_stage.io.self_ready
-  intermediate_valid := accumulate_stage.io.self_valid
-
-
+  accumulate_stage.io.output_ready   := intermediate_ready
+  accumulate_stage.io.pooling_size   := ext_csr_i(0).asUInt
+  intermediate_data                  := accumulate_stage.io.data_o
+  ext_data_i.ready                   := accumulate_stage.io.self_ready
+  intermediate_valid                 := accumulate_stage.io.self_valid
 
   val output_stage = Module(
-    new OutputStage(in_elementWidth, out_elementWidth, extensionParam.dataWidth) 
+    new OutputStage(in_elementWidth, out_elementWidth, extensionParam.dataWidth)
   )
-  output_stage.io.data_i := intermediate_data
+  output_stage.io.data_i           := intermediate_data
   output_stage.io.accumulate_valid := intermediate_valid
-  output_stage.io.next_ready := ext_data_o.ready
-  ext_data_o.bits := output_stage.io.data_o
-  ext_data_o.valid := output_stage.io.self_valid
-  intermediate_ready := output_stage.io.self_ready
+  output_stage.io.next_ready       := ext_data_o.ready
+  ext_data_o.bits                  := output_stage.io.data_o
+  ext_data_o.valid                 := output_stage.io.self_valid
+  intermediate_ready               := output_stage.io.self_ready
 
   ext_busy_o := accumulate_stage.io.self_ready || output_stage.io.self_valid
 

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -362,6 +362,6 @@ class ElementwiseAddToLong(
   ext_data_o.valid                 := output_stage.io.self_valid
   intermediate_ready               := output_stage.io.self_ready
 
-  ext_busy_o := accumulate_stage.io.self_ready || output_stage.io.self_valid
+  ext_busy_o := !accumulate_stage.io.self_ready || !output_stage.io.self_valid
 
 }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAddToLong.scala
@@ -362,6 +362,6 @@ class ElementwiseAddToLong(
   ext_data_o.valid                 := output_stage.io.self_valid
   intermediate_ready               := output_stage.io.self_ready
 
-  ext_busy_o := !accumulate_stage.io.self_ready || !output_stage.io.self_valid
+  ext_busy_o := !accumulate_stage.io.self_ready
 
 }

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/ElementwiseAddToLongTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/ElementwiseAddToLongTester.scala
@@ -1,0 +1,101 @@
+package snax.DataPathExtension
+import scala.util.Random
+
+import chiseltest._
+import snax.DataPathExtension.HasElementwiseAdd
+
+class ElementwiseAddToLong3Tester extends DataPathExtensionTester(TreadleBackendAnnotation) {
+
+  def hasExtension = new HasElementwiseAddToLong(in_elementWidth = 8, out_elementWidth = 32, dataWidth = 512)
+
+  val amount_of_vectors = 3
+  val csr_vec           = Seq(amount_of_vectors)
+
+  val inputData  = collection.mutable.Buffer[BigInt]()
+  val outputData = collection.mutable.Buffer[BigInt]()
+
+  for (_ <- 0 until 128) {
+    val InputMatrix1: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix2: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix3: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    inputData.append(BigInt(InputMatrix1.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix2.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix3.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+
+    val OutputMatrix  = InputMatrix1.zip(InputMatrix2.zip(InputMatrix3)).map { case (a, (b, c)) =>
+      a.zip(b.zip(c)).map { case (x, (y, z)) => x + y + z }
+    }
+    val OutputMatrix1 = OutputMatrix.slice(0,2)
+    val OutputMatrix2 = OutputMatrix.slice(2,4)
+    val OutputMatrix3 = OutputMatrix.slice(4,6)
+    val OutputMatrix4 = OutputMatrix.slice(6,8)
+    outputData.append(BigInt(OutputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+    outputData.append(BigInt(OutputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+    outputData.append(BigInt(OutputMatrix3.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+    outputData.append(BigInt(OutputMatrix4.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+  }
+
+  val input_data_vec = inputData.toSeq
+
+  val output_data_vec = outputData.toSeq
+}
+
+
+class ElementwiseAddToLong15Tester extends DataPathExtensionTester(TreadleBackendAnnotation) {
+
+  def hasExtension = new HasElementwiseAddToLong(in_elementWidth = 8, out_elementWidth = 32, dataWidth = 512)
+
+  val amount_of_vectors = 15
+  val csr_vec           = Seq(amount_of_vectors)
+
+  val inputData  = collection.mutable.Buffer[BigInt]()
+  val outputData = collection.mutable.Buffer[BigInt]()
+
+  for (_ <- 0 until 128) {
+    val InputMatrix1: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix2: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix3: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix4: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix5: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix6: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix7: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix8: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix9: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix10: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))  
+    val InputMatrix11: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix12: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix13: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix14: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    val InputMatrix15: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
+    inputData.append(BigInt(InputMatrix1.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix2.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix3.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix4.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix5.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix6.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix7.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix8.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix9.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix10.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix11.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix12.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix13.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
+    inputData.append(BigInt(InputMatrix14.flatten.map { i => f"${i & 0xff}%
+
+    val OutputMatrix  = InputMatrix1.zip(InputMatrix2.zip(InputMatrix3)).map { case (a, (b, c)) =>
+      a.zip(b.zip(c)).map { case (x, (y, z)) => x + y + z }
+    }
+    val OutputMatrix1 = OutputMatrix.slice(0,2)
+    val OutputMatrix2 = OutputMatrix.slice(2,4)
+    val OutputMatrix3 = OutputMatrix.slice(4,6)
+    val OutputMatrix4 = OutputMatrix.slice(6,8)
+    outputData.append(BigInt(OutputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+    outputData.append(BigInt(OutputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+    outputData.append(BigInt(OutputMatrix3.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+    outputData.append(BigInt(OutputMatrix4.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+  }
+
+  val input_data_vec = inputData.toSeq
+
+  val output_data_vec = outputData.toSeq
+}

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/ElementwiseAddToLongTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/ElementwiseAddToLongTester.scala
@@ -2,7 +2,6 @@ package snax.DataPathExtension
 import scala.util.Random
 
 import chiseltest._
-import snax.DataPathExtension.HasElementwiseAdd
 
 class ElementwiseAddToLong3Tester extends DataPathExtensionTester(TreadleBackendAnnotation) {
 
@@ -25,70 +24,10 @@ class ElementwiseAddToLong3Tester extends DataPathExtensionTester(TreadleBackend
     val OutputMatrix  = InputMatrix1.zip(InputMatrix2.zip(InputMatrix3)).map { case (a, (b, c)) =>
       a.zip(b.zip(c)).map { case (x, (y, z)) => x + y + z }
     }
-    val OutputMatrix1 = OutputMatrix.slice(0,2)
-    val OutputMatrix2 = OutputMatrix.slice(2,4)
-    val OutputMatrix3 = OutputMatrix.slice(4,6)
-    val OutputMatrix4 = OutputMatrix.slice(6,8)
-    outputData.append(BigInt(OutputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    outputData.append(BigInt(OutputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    outputData.append(BigInt(OutputMatrix3.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    outputData.append(BigInt(OutputMatrix4.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-  }
-
-  val input_data_vec = inputData.toSeq
-
-  val output_data_vec = outputData.toSeq
-}
-
-
-class ElementwiseAddToLong15Tester extends DataPathExtensionTester(TreadleBackendAnnotation) {
-
-  def hasExtension = new HasElementwiseAddToLong(in_elementWidth = 8, out_elementWidth = 32, dataWidth = 512)
-
-  val amount_of_vectors = 15
-  val csr_vec           = Seq(amount_of_vectors)
-
-  val inputData  = collection.mutable.Buffer[BigInt]()
-  val outputData = collection.mutable.Buffer[BigInt]()
-
-  for (_ <- 0 until 128) {
-    val InputMatrix1: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix2: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix3: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix4: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix5: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix6: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix7: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix8: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix9: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix10: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))  
-    val InputMatrix11: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix12: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix13: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix14: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    val InputMatrix15: Array[Array[Int]] = Array.fill(8, 8)(Random.between(-128, 127))
-    inputData.append(BigInt(InputMatrix1.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix2.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix3.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix4.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix5.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix6.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix7.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix8.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix9.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix10.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix11.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix12.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix13.flatten.map { i => f"${i & 0xff}%02X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(InputMatrix14.flatten.map { i => f"${i & 0xff}%
-
-    val OutputMatrix  = InputMatrix1.zip(InputMatrix2.zip(InputMatrix3)).map { case (a, (b, c)) =>
-      a.zip(b.zip(c)).map { case (x, (y, z)) => x + y + z }
-    }
-    val OutputMatrix1 = OutputMatrix.slice(0,2)
-    val OutputMatrix2 = OutputMatrix.slice(2,4)
-    val OutputMatrix3 = OutputMatrix.slice(4,6)
-    val OutputMatrix4 = OutputMatrix.slice(6,8)
+    val OutputMatrix1 = OutputMatrix.slice(0, 2)
+    val OutputMatrix2 = OutputMatrix.slice(2, 4)
+    val OutputMatrix3 = OutputMatrix.slice(4, 6)
+    val OutputMatrix4 = OutputMatrix.slice(6, 8)
     outputData.append(BigInt(OutputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
     outputData.append(BigInt(OutputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
     outputData.append(BigInt(OutputMatrix3.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))

--- a/target/snitch_cluster/cfg/snax_compiler_test_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_compiler_test_cluster.hjson
@@ -171,6 +171,7 @@
             reader_extensions: {
                 HasMaxPool: {},
                 HasElementwiseAdd: {},
+                HasElementwiseAddToLong: {},
                 HasRescaleDownEfficient: {},
                 HasRescaleUp: {},
 

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -65,6 +65,7 @@ SUBDIRS += snax-xdma-reshape-comparison
 SUBDIRS += snax-xdma-elementwise-add
 SUBDIRS += snax-xdma-rescale-down
 SUBDIRS += snax-xdma-rescale-up
+SUBDIRS += snax-xdma-avgpool
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_versacore_cluster.hjson)
 SUBDIRS += snax-versacore-matmul

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Yunhao Deng <yunhao.deng@kuleuven.be>
+
+APP     = snax-xdma-avgpool
+SRCS    = src/snax-xdma-avgpool.c
+INCDIRS = data
+INCDIRS += ../../snax/xdma/include
+
+RISCV_LDFLAGS += ../../snax/xdma/build/snax-xdma-lib.o
+
+include ../common.mk
+include ./data/Makefile
+$(DEP): $(DATA_H)

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/Makefile
@@ -1,0 +1,23 @@
+# Copyright 2023 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Xiaoling Yi <xiaoling.yi@esat.kuleuven.be>
+
+# Usage of absolute paths is required to externally include this Makefile
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+DATA_DIR := $(realpath $(MK_DIR))
+
+DATA_CFG ?= $(DATA_DIR)/params.hjson
+
+DATA_H = $(DATA_DIR)/data.h
+
+$(DATA_H): $(DATA_DIR)/datagen.py $(DATA_CFG)
+	$< -c $(DATA_CFG) > $@
+
+.PHONY: clean-data clean
+
+clean-data:
+	rm -f $(DATA_H)
+
+clean: clean-data

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/datagen.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Jonas Crols <jonas.crols@student.kuleuven.be>
+
+import argparse
+import os
+import pathlib
+import sys
+
+import hjson
+import numpy as np
+
+# Add data utility path
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../../../util/sim/"))
+from data_utils import format_scalar_definition, format_vector_definition  # noqa E402
+
+np.random.seed(320)
+
+
+# Add stdint.h header
+def emit_header_file(**kwargs):
+    emit_str = ["#include <stdint.h>"]
+    emit_str += emit_elementwise_add_data(**kwargs)
+    return "\n\n".join(emit_str)
+
+
+def emit_elementwise_add_data(**kwargs):
+    tile_width = None
+    element_width = kwargs["BIT_WIDTH"]
+    
+    data_in_type = "uint8_t"
+    data_out_type = "uint8_t"
+
+    emit_str = []
+    padded_M = kwargs["M"] 
+    padded_N = kwargs["N"]
+    channel_count = kwargs["channels"]
+    m_kernel = kwargs["m_kernel"]
+    n_kernel = kwargs["n_kernel"]
+    m_stride = kwargs["m_stride"]
+    n_stride = kwargs["n_stride"]
+
+    # First input matrix for elementwise add
+    matrix_data = np.zeros((padded_M, padded_N), dtype=np.uint8)
+    matrix_data[: kwargs["M"], : kwargs["N"]] = np.random.randint(
+        low=128, high=127 , size=(kwargs["M"], kwargs["N"], channel_count), dtype=np.uint8
+    )
+    input_matrix = matrix_data
+    input_matrix = input_matrix.flatten()
+
+    # Emit input matrix
+    emit_str += [
+        format_scalar_definition("uint8_t", "matrix_size", matrix_data.size)
+    ]
+    emit_str += [format_vector_definition(data_in_type, "input_matrix", input_matrix)]
+
+    # Emit output matrix
+    output_matrix = maxpool_golden(
+        a_vals=matrix_data,
+        m=padded_M,
+        n=padded_N,
+        channels=channel_count,
+        m_kernel=m_kernel,
+        n_kernel=n_kernel,
+        m_stride=m_stride,
+        n_stride=n_stride,
+    )
+
+    output_matrix = output_matrix.flatten()
+    emit_str += [
+        format_vector_definition(data_out_type, "golden_output_matrix", output_matrix)
+    ]
+
+    # Emit the configuration for XDMA
+    spatial_stride_src = None
+    spatial_stride_dst = None
+    temporal_strides_src = []
+    temporal_strides_dst = []
+    temporal_bounds_src = []
+    temporal_bounds_dst = []
+
+    # Input Side (Reader)
+    spatial_stride_src = 8
+    temporal_bounds_src = [
+        3,3,13,13,1
+    ]
+    temporal_strides_src = [
+        64, 1792, 128, 3584, 0
+    ]
+
+    # Output Side (Writer)
+
+    spatial_stride_dst = 8
+    temporal_bounds_dst = [
+        169
+    ]
+    temporal_strides_dst = [
+        64,
+    ]
+
+    emit_str += [
+        format_scalar_definition("uint32_t", "spatial_stride_src", spatial_stride_src)
+    ]
+    emit_str += [
+        format_scalar_definition("uint32_t", "spatial_stride_dst", spatial_stride_dst)
+    ]
+    emit_str += [
+        format_vector_definition("uint32_t", "temporal_bounds_src", temporal_bounds_src)
+    ]
+    emit_str += [
+        format_vector_definition("uint32_t", "temporal_bounds_dst", temporal_bounds_dst)
+    ]
+    emit_str += [
+        format_vector_definition(
+            "uint32_t", "temporal_strides_src", temporal_strides_src
+        )
+    ]
+    emit_str += [
+        format_vector_definition(
+            "uint32_t", "temporal_strides_dst", temporal_strides_dst
+        )
+    ]
+    emit_str += [
+        format_scalar_definition(
+            "uint32_t", "temporal_dimension_src", len(temporal_bounds_src)
+        )
+    ]
+    emit_str += [
+        format_scalar_definition(
+            "uint32_t", "temporal_dimension_dst", len(temporal_bounds_dst)
+        )
+    ]
+
+    return emit_str
+
+
+def maxpool_golden(
+    a_vals: np.ndarray,
+    m: int,
+    n: int,
+    channels: int,
+    m_kernel: int,
+    n_kernel: int,
+    m_stride: int,
+    n_stride: int,
+) -> np.ndarray:
+    """
+    Compute the golden output for maxpool operation.
+    This function simulates the maxpool operation on the input tensor.
+    """
+    output = np.empty(
+        (
+            ((m - m_kernel) // m_stride + 1),
+            ((n - n_kernel) // n_stride + 1),
+            channels,
+        ),
+        dtype=np.int8,
+    )
+    # Iterate over each channel and apply max pooling
+    for i in range(0, ((m - m_kernel) // m_stride + 1) * m_stride, m_stride):
+        for j in range(0, ((n - n_kernel) // n_stride + 1) * n_stride, n_stride):
+            for c in range(channels):
+                # Extract the kernel region
+                kernel_region = a_vals[i : i + m_kernel, j : j + n_kernel, c]
+                # Compute the maximum value in the kernel region
+                max_value = (int(np.sum(kernel_region)) * 1242757) >> 25  # Scale down to uint8 range
+                output[i // m_stride, j // n_stride, c] = max_value
+    return output
+
+
+def main():
+    # Parsing cmd args
+    parser = argparse.ArgumentParser(description="Generating data for kernels")
+    parser.add_argument(
+        "-c",
+        "--cfg",
+        type=pathlib.Path,
+        required=True,
+        help="Select param config file kernel",
+    )
+    args = parser.parse_args()
+
+    # Load param config file
+    with args.cfg.open() as f:
+        param = hjson.loads(f.read())
+
+    # Emit header file
+    print(emit_header_file(**param))
+
+
+if __name__ == "__main__":
+    main()

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/datagen.py
@@ -15,7 +15,12 @@ import hjson
 import numpy as np
 
 # Add data utility path
-sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../../../util/sim/"))
+sys.path.append(
+    os.path.join(
+        os.path.dirname(__file__),
+        "../../../../../../util/sim/",
+    )
+)
 from data_utils import format_scalar_definition, format_vector_definition  # noqa E402
 from snax_utils import postprocessing_simd_golden_model_V3, sumpool_golden  # noqa E402
 
@@ -31,12 +36,12 @@ def emit_header_file(**kwargs):
 
 
 def emit_avgpool_data(**kwargs):
-    
+
     data_in_type = "int8_t"
     data_out_type = "int8_t"
 
     emit_str = []
-    padded_M = kwargs["M"] 
+    padded_M = kwargs["M"]
     padded_N = kwargs["N"]
     channel_count = kwargs["channels"]
     m_kernel = kwargs["m_kernel"]
@@ -46,16 +51,29 @@ def emit_avgpool_data(**kwargs):
 
     # First input matrix for elementwise add
     matrix_data = np.random.randint(
-        low=-128, high=127 , size=(kwargs["M"], kwargs["N"], channel_count), dtype=np.int8
+        low=-128,
+        high=127,
+        size=(kwargs["M"], kwargs["N"], channel_count),
+        dtype=np.int8,
     )
     input_matrix = matrix_data
     input_matrix = input_matrix.flatten()
 
     # Emit input matrix
     emit_str += [
-        format_scalar_definition("uint32_t", "matrix_size", matrix_data.size)
+        format_scalar_definition(
+            "uint32_t",
+            "matrix_size",
+            matrix_data.size,
+        )
     ]
-    emit_str += [format_vector_definition(data_in_type, "input_matrix", input_matrix)]
+    emit_str += [
+        format_vector_definition(
+            data_in_type,
+            "input_matrix",
+            input_matrix,
+        )
+    ]
 
     # Emit output matrix
     output_matrix = sumpool_golden(
@@ -68,24 +86,31 @@ def emit_avgpool_data(**kwargs):
         m_stride=m_stride,
         n_stride=n_stride,
     )
-    
 
     output_matrix = output_matrix.flatten()
-    
+
     shift = 25
     multiplier = (2**25) // (m_kernel * n_kernel)
-    
+
     for i in range(len(output_matrix)):
         output_matrix[i] = postprocessing_simd_golden_model_V3(
             output_matrix[i], 0, 0, shift, 127, -128, True, multiplier
         )
-    
+
     emit_str += [
-        format_scalar_definition("uint32_t", "output_matrix_size", output_matrix.size)
+        format_scalar_definition(
+            "uint32_t",
+            "output_matrix_size",
+            output_matrix.size,
+        )
     ]
-    
+
     emit_str += [
-        format_vector_definition(data_out_type, "golden_output_matrix", output_matrix)
+        format_vector_definition(
+            data_out_type,
+            "golden_output_matrix",
+            output_matrix,
+        )
     ]
 
     # Emit the configuration for XDMA
@@ -98,34 +123,44 @@ def emit_avgpool_data(**kwargs):
 
     # Input Side (Reader)
     spatial_stride_src = 8
-    temporal_bounds_src = [
-        3,3,13,13,1
-    ]
-    temporal_strides_src = [
-        64, 1792, 128, 3584, 0
-    ]
+    temporal_bounds_src = [3, 3, 13, 13, 1]
+    temporal_strides_src = [64, 1792, 128, 3584, 0]
 
     # Output Side (Writer)
 
     spatial_stride_dst = 8
-    temporal_bounds_dst = [
-        169
-    ]
+    temporal_bounds_dst = [169]
     temporal_strides_dst = [
         64,
     ]
 
     emit_str += [
-        format_scalar_definition("uint32_t", "spatial_stride_src", spatial_stride_src)
+        format_scalar_definition(
+            "uint32_t",
+            "spatial_stride_src",
+            spatial_stride_src,
+        )
     ]
     emit_str += [
-        format_scalar_definition("uint32_t", "spatial_stride_dst", spatial_stride_dst)
+        format_scalar_definition(
+            "uint32_t",
+            "spatial_stride_dst",
+            spatial_stride_dst,
+        )
     ]
     emit_str += [
-        format_vector_definition("uint32_t", "temporal_bounds_src", temporal_bounds_src)
+        format_vector_definition(
+            "uint32_t",
+            "temporal_bounds_src",
+            temporal_bounds_src,
+        )
     ]
     emit_str += [
-        format_vector_definition("uint32_t", "temporal_bounds_dst", temporal_bounds_dst)
+        format_vector_definition(
+            "uint32_t",
+            "temporal_bounds_dst",
+            temporal_bounds_dst,
+        )
     ]
     emit_str += [
         format_vector_definition(
@@ -147,32 +182,30 @@ def emit_avgpool_data(**kwargs):
             "uint32_t", "temporal_dimension_dst", len(temporal_bounds_dst)
         )
     ]
-    
-    
+
+    emit_str += [format_scalar_definition("uint32_t", "shift_i", shift)]
+
     emit_str += [
-        format_scalar_definition("uint32_t", "shift_i", shift)
+        format_scalar_definition(
+            "uint32_t",
+            "multiplier_i",
+            multiplier,
+        )
     ]
-    
+
+    emit_str += [format_scalar_definition("uint32_t", "input_zp_i", 0)]
+
+    emit_str += [format_scalar_definition("uint32_t", "output_zp_i", 0)]
+
     emit_str += [
-        format_scalar_definition("uint32_t", "multiplier_i", multiplier)
-    ]
-    
-    emit_str += [
-        format_scalar_definition("uint32_t", "input_zp_i", 0)
-    ]
-    
-    emit_str += [
-        format_scalar_definition("uint32_t", "output_zp_i", 0)
-    ]
-    
-    emit_str += [
-        format_scalar_definition("uint32_t", "kernel_size", m_kernel * n_kernel)
+        format_scalar_definition(
+            "uint32_t",
+            "kernel_size",
+            m_kernel * n_kernel,
+        )
     ]
 
     return emit_str
-
-
-
 
 
 def main():

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/params.hjson
@@ -1,0 +1,15 @@
+// Copyright 2023 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Jonas Crols <jonas.crols@student.kuleuven.be>
+
+{
+    M: 56, // Number of rows / height
+    N: 33, // Number of columns / width
+    channels: 64, // Number of channels
+    m_kernel: 3, // Kernel size in the M dimension
+    n_kernel: 3, // Kernel size in the N dimension
+    m_stride: 2, // Stride in the M dimension
+    n_stride: 2, // Stride in the N dimension
+}

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/params.hjson
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/data/params.hjson
@@ -5,8 +5,8 @@
 // Jonas Crols <jonas.crols@student.kuleuven.be>
 
 {
-    M: 56, // Number of rows / height
-    N: 33, // Number of columns / width
+    M: 28, // Number of rows / height
+    N: 28, // Number of columns / width
     channels: 64, // Number of channels
     m_kernel: 3, // Kernel size in the M dimension
     n_kernel: 3, // Kernel size in the N dimension

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/src/snax-xdma-avgpool.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/src/snax-xdma-avgpool.c
@@ -1,0 +1,99 @@
+// Copyright 2024 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Jonas Crols <jonas.crols@student.kuleuven.be>
+
+#include "data.h"
+#include "snax-xdma-lib.h"
+#include "snrt.h"
+
+int main() {
+    // Set err value for checking
+    int err = 0;
+    // Obtain the start address of the TCDM memory
+    uint32_t dma_load_input_start;
+    uint32_t dma_load_input_end;
+    uint32_t tcdm_baseaddress = snrt_cluster_base_addrl();
+    // Put the first input at the starting of tcdm
+    void *tcdm_in = (void *)tcdm_baseaddress;
+
+    // Put the output at the middle of tcdm
+    void *tcdm_out =
+        (void *)(tcdm_baseaddress +
+                 (matrix_size * sizeof(input_matrix[0]) * 8 + 7) / 8);
+
+    printf("tcdm_out: %p\n", tcdm_out);
+
+    if (snrt_is_dm_core()) {
+        // First we need to transfer the input data from L3->TCDM
+        snrt_dma_start_1d(tcdm_in, input_matrix,
+                          matrix_size * sizeof(input_matrix[0]));
+        snrt_dma_wait_all();
+
+        // --------------------- Configure the Ext --------------------- //
+        int32_t input_zp_i = 0;
+        uint32_t multiplier_i = 1242756;
+        int32_t output_zp_i = 0;
+        uint32_t shift_i = 25;
+
+        uint32_t ext_param_add[1] = {9};
+        uint32_t ext_param_rescale[4] = {input_zp_i, multiplier_i, output_zp_i,
+                                 shift_i};
+        if (xdma_disable_src_ext(0) != 0) {
+            printf("Error in disabling reader xdma extension 0\n");
+            err++;
+        }
+
+        if (xdma_disable_src_ext(1) != 0) {
+            printf("Error in disabling reader xdma extension 1\n");
+            err++;
+        }
+
+        if (xdma_disable_src_ext(2) != 0) {
+            printf("Error in disabling reader xdma extension 2\n");
+            err++;
+        }
+
+        if (xdma_disable_src_ext(3) != 0) {
+            printf("Error in disabling reader xdma extension 3\n");
+            err++;
+        }
+
+        if (xdma_disable_dst_ext(0) != 0) {
+            printf("Error in disabling writer xdma extension 0\n");
+            err++;
+        }
+
+        if (xdma_disable_dst_ext(1) != 0) {
+            printf("Error in disabling writer xdma extension 1\n");
+            err++;
+        }
+
+        // --------------------- Configure the AGU --------------------- //
+        xdma_memcpy_nd(tcdm_in, tcdm_out, spatial_stride_src,
+                       spatial_stride_dst, temporal_dimension_src,
+                       temporal_strides_src, temporal_bounds_src,
+                       temporal_dimension_dst, temporal_strides_dst,
+                       temporal_bounds_dst, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF);
+        printf("xdma_memcpy_nd done\n");
+        int task_id = xdma_start();
+        printf("got out of xdma_start, csr address: %d\n", task_id);
+        xdma_local_wait(task_id);
+        printf("xdma task %d is done in %d cycles\n", task_id,
+               xdma_last_task_cycle());
+
+        // --------------------- Checking the Results --------------------- //
+        uint8_t *golden_result = (uint8_t *)golden_output_matrix;
+        uint8_t *tcdm_result = (uint8_t *)tcdm_out;
+
+        for (int i = 0; i < matrix_size; i++) {
+            if (tcdm_result[i] != golden_result[i]) {
+                printf("The sum is incorrect at byte %d! \n", i << 2);
+            }
+        }
+        printf("Checking is done. All values are right\n");
+    }
+
+    return 0;
+}

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/src/snax-xdma-avgpool.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/src/snax-xdma-avgpool.c
@@ -34,7 +34,7 @@ int main() {
         // --------------------- Configure the Ext --------------------- //
         uint32_t ext_param_add[1] = {kernel_size};
         uint32_t ext_param_rescale[4] = {input_zp_i, multiplier_i, output_zp_i,
-                                 shift_i};
+                                         shift_i};
         if (xdma_disable_src_ext(0) != 0) {
             printf("Error in disabling reader xdma extension 0\n");
             err++;
@@ -89,7 +89,10 @@ int main() {
 
         for (int i = 0; i < output_matrix_size; i++) {
             if (tcdm_result[i] != golden_result[i]) {
-                printf("The sum is incorrect at byte %d: Golden: %d, Received: %d\n", i << 2, golden_result[i], tcdm_result[i]);
+                printf(
+                    "The sum is incorrect at byte %d: Golden: %d, Received: "
+                    "%d\n",
+                    i << 2, golden_result[i], tcdm_result[i]);
             }
         }
         printf("Checking is done. All values are right\n");

--- a/target/snitch_cluster/sw/apps/snax-xdma-avgpool/src/snax-xdma-avgpool.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-avgpool/src/snax-xdma-avgpool.c
@@ -32,12 +32,7 @@ int main() {
         snrt_dma_wait_all();
 
         // --------------------- Configure the Ext --------------------- //
-        int32_t input_zp_i = 0;
-        uint32_t multiplier_i = 1242756;
-        int32_t output_zp_i = 0;
-        uint32_t shift_i = 25;
-
-        uint32_t ext_param_add[1] = {9};
+        uint32_t ext_param_add[1] = {kernel_size};
         uint32_t ext_param_rescale[4] = {input_zp_i, multiplier_i, output_zp_i,
                                  shift_i};
         if (xdma_disable_src_ext(0) != 0) {
@@ -50,13 +45,18 @@ int main() {
             err++;
         }
 
-        if (xdma_disable_src_ext(2) != 0) {
-            printf("Error in disabling reader xdma extension 2\n");
+        if (xdma_enable_src_ext(2, ext_param_add) != 0) {
+            printf("Error in enabling reader xdma extension 2\n");
             err++;
         }
 
-        if (xdma_disable_src_ext(3) != 0) {
-            printf("Error in disabling reader xdma extension 3\n");
+        if (xdma_enable_src_ext(3, ext_param_rescale) != 0) {
+            printf("Error in enabling reader xdma extension 3\n");
+            err++;
+        }
+
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
             err++;
         }
 
@@ -84,12 +84,12 @@ int main() {
                xdma_last_task_cycle());
 
         // --------------------- Checking the Results --------------------- //
-        uint8_t *golden_result = (uint8_t *)golden_output_matrix;
-        uint8_t *tcdm_result = (uint8_t *)tcdm_out;
+        int8_t *golden_result = (int8_t *)golden_output_matrix;
+        int8_t *tcdm_result = (int8_t *)tcdm_out;
 
-        for (int i = 0; i < matrix_size; i++) {
+        for (int i = 0; i < output_matrix_size; i++) {
             if (tcdm_result[i] != golden_result[i]) {
-                printf("The sum is incorrect at byte %d! \n", i << 2);
+                printf("The sum is incorrect at byte %d: Golden: %d, Received: %d\n", i << 2, golden_result[i], tcdm_result[i]);
             }
         }
         printf("Checking is done. All values are right\n");

--- a/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
@@ -63,6 +63,11 @@ int main() {
             err++;
         }
 
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
+            err++;
+        }
+
         if (xdma_disable_dst_ext(0) != 0) {
             printf("Error in disabling writer xdma extension 0\n");
             err++;

--- a/target/snitch_cluster/sw/apps/snax-xdma-maxpool/src/snax-xdma-maxpool.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-maxpool/src/snax-xdma-maxpool.c
@@ -78,6 +78,11 @@ int main() {
             err++;
         }
 
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
+            err++;
+        }
+
         if (xdma_disable_dst_ext(0) != 0) {
             printf("Error in disabling xdma writer extension 0\n");
             err++;

--- a/target/snitch_cluster/sw/apps/snax-xdma-memset/src/snax-xdma-memset.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-memset/src/snax-xdma-memset.c
@@ -60,6 +60,11 @@ int main() {
             err++;
         }
 
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
+            err++;
+        }
+
         if (xdma_enable_dst_ext(0, ext_param_t1) != 0) {
             printf("Error in enabling xdma writer extension 0\n");
             err++;

--- a/target/snitch_cluster/sw/apps/snax-xdma-rescale-down/src/snax-xdma-rescale-down.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-rescale-down/src/snax-xdma-rescale-down.c
@@ -45,13 +45,18 @@ int main() {
             err++;
         }
 
-        if (xdma_enable_src_ext(2, ext_param) != 0) {
-            printf("Error in enabling reader xdma extension 2\n");
+        if (xdma_disable_src_ext(2) != 0) {
+            printf("Error in disabling reader xdma extension 2\n");
             err++;
         }
 
-        if (xdma_disable_src_ext(3) != 0) {
-            printf("Error in disabling reader xdma extension 3\n");
+        if (xdma_enable_src_ext(3, ext_param) != 0) {
+            printf("Error in enabling reader xdma extension 3\n");
+            err++;
+        }
+
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
             err++;
         }
 

--- a/target/snitch_cluster/sw/apps/snax-xdma-rescale-up/src/snax-xdma-rescale-up.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-rescale-up/src/snax-xdma-rescale-up.c
@@ -54,8 +54,13 @@ int main() {
             err++;
         }
 
-        if (xdma_enable_src_ext(3, ext_param) != 0) {
-            printf("Error in enabling reader xdma extension 3\n");
+        if (xdma_disable_src_ext(3) != 0) {
+            printf("Error in disabling reader xdma extension 3\n");
+            err++;
+        }
+
+        if (xdma_enable_src_ext(4, ext_param) != 0) {
+            printf("Error in enabling reader xdma extension 4\n");
             err++;
         }
 

--- a/target/snitch_cluster/sw/apps/snax-xdma-reshape-comparison/src/snax-xdma-reshape-comparison.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-reshape-comparison/src/snax-xdma-reshape-comparison.c
@@ -49,6 +49,11 @@ int main() {
             err++;
         }
 
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
+            err++;
+        }
+
         if (xdma_disable_src_ext(0) != 0) {
             printf("Error in disabling xdma reader extension 0\r\n");
             err++;

--- a/target/snitch_cluster/sw/apps/snax-xdma-transpose/src/snax-xdma-transpose.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-transpose/src/snax-xdma-transpose.c
@@ -45,6 +45,16 @@ int main() {
             err++;
         }
 
+        if (xdma_disable_src_ext(3) != 0) {
+            printf("Error in disabling reader xdma extension 3\n");
+            err++;
+        }
+
+        if (xdma_disable_src_ext(4) != 0) {
+            printf("Error in disabling reader xdma extension 4\n");
+            err++;
+        }
+
         if (xdma_disable_dst_ext(0) != 0) {
             printf("Error in disabling writer xdma extension 1\n");
             err++;

--- a/target/snitch_cluster/sw/snax-compiler-test-run.yaml
+++ b/target/snitch_cluster/sw/snax-compiler-test-run.yaml
@@ -13,3 +13,4 @@ runs:
   - elf: apps/snax-xdma-elementwise-add/build/snax-xdma-elementwise-add.elf
   - elf: apps/snax-xdma-rescale-down/build/snax-xdma-rescale-down.elf
   - elf: apps/snax-xdma-rescale-up/build/snax-xdma-rescale-up.elf
+  - elf: apps/snax-xdma-avgpool/build/snax-xdma-avgpool.elf

--- a/target/snitch_cluster/sw/snax/xdma/include/snax-xdma-csr-addr.h
+++ b/target/snitch_cluster/sw/snax/xdma/include/snax-xdma-csr-addr.h
@@ -27,11 +27,11 @@
 // The channel and strobe region of the reader of XDMA
 #define XDMA_SRC_ENABLED_CHAN_PTR XDMA_SRC_TEMP_STRIDE_PTR + XDMA_SRC_TEMP_DIM
 #define XDMA_SRC_BYPASS_PTR XDMA_SRC_ENABLED_CHAN_PTR + 1
-#define XDMA_SRC_EXT_NUM 1
+#define XDMA_SRC_EXT_NUM 4
 #define XDMA_SRC_EXT_CSR_PTR XDMA_SRC_BYPASS_PTR + 1
-#define XDMA_SRC_EXT_CSR_NUM 1
+#define XDMA_SRC_EXT_CSR_NUM 10
 #define XDMA_SRC_EXT_CUSTOM_CSR_NUM \
-    { 1 }
+    { 1, 1, 4, 4 }
 
 // The stride and bound region of the writer of XDMA
 #define XDMA_DST_TEMP_DIM 5

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -639,3 +639,38 @@ def align_wide_addr(addr, alignment=64):
     if addr % alignment:
         addr = ((addr // alignment) + 1) * alignment
     return addr
+
+
+def sumpool_golden(
+    a_vals: np.ndarray,
+    m: int,
+    n: int,
+    channels: int,
+    m_kernel: int,
+    n_kernel: int,
+    m_stride: int,
+    n_stride: int,
+) -> np.ndarray:
+    """
+    Compute the golden output for maxpool operation.
+    This function simulates the maxpool operation on the input tensor.
+    a should be a 3D array with shape (m, n, channels).
+    """
+    output = np.empty(
+        (
+            ((m - m_kernel) // m_stride + 1),
+            ((n - n_kernel) // n_stride + 1),
+            channels,
+        ),
+        dtype=np.int32,
+    )
+    # Iterate over each channel and apply max pooling
+    for i in range(0, ((m - m_kernel) // m_stride + 1) * m_stride, m_stride):
+        for j in range(0, ((n - n_kernel) // n_stride + 1) * n_stride, n_stride):
+            for c in range(channels):
+                # Extract the kernel region
+                kernel_region = a_vals[i : i + m_kernel, j : j + n_kernel, c]
+                # Compute the maximum value in the kernel region
+                sum_value = int(np.sum(kernel_region)) # Scale down to uint8 range
+                output[i // m_stride, j // n_stride, c] = sum_value
+    return output

--- a/util/sim/snax_utils.py
+++ b/util/sim/snax_utils.py
@@ -666,11 +666,12 @@ def sumpool_golden(
     )
     # Iterate over each channel and apply max pooling
     for i in range(0, ((m - m_kernel) // m_stride + 1) * m_stride, m_stride):
-        for j in range(0, ((n - n_kernel) // n_stride + 1) * n_stride, n_stride):
+        for j in range(0, ((n - n_kernel) // n_stride + 1) * n_stride,
+                       n_stride):
             for c in range(channels):
                 # Extract the kernel region
-                kernel_region = a_vals[i : i + m_kernel, j : j + n_kernel, c]
+                kernel_region = a_vals[i: i + m_kernel, j: j + n_kernel, c]
                 # Compute the maximum value in the kernel region
-                sum_value = int(np.sum(kernel_region)) # Scale down to uint8 range
+                sum_value = int(np.sum(kernel_region))
                 output[i // m_stride, j // n_stride, c] = sum_value
     return output


### PR DESCRIPTION
This PR adds the ability to do average pooling by adding the ElementwiseAddToLong Extension to the XDMA. by chaining this extension with the RescaleDownEfficient Extension, AveragePooling can be performed on a tensor.
This PR adds a Scala-Tester for the ElementWiseAddToLong Extension, and a sw application for average pooling. 