### PR TITLE
Add chiplet address adapter

### DIFF
--- a/docs/schema/snitch_cluster.schema.json
+++ b/docs/schema/snitch_cluster.schema.json
@@ -19,6 +19,11 @@
             "description": "Address from which all harts of the cluster start to boot. The default setting is `0x8000_0000`.",
             "default": 2147483648
         },
+        "chip_id_width": {
+            "type": "number",
+            "description": "Width of the chip id.",
+            "default": 8
+        },        
         "cluster_base_addr": {
             "type": "number",
             "description": "Base address of this cluster.",

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -1450,12 +1450,15 @@ DmaXbarCfg.NoMstPorts
       // For the chiplet system, we need to append the chip id to the aw/ar addr of axi requests
       always_comb begin : dm_append_chip_id
         wide_axi_mst_req[SDMAMst] = axi_dma_req;
-        wide_axi_mst_req[SDMAMst].ar.addr = {chip_id_i,axi_dma_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
-        wide_axi_mst_req[SDMAMst].aw.addr = {chip_id_i,axi_dma_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
-      end  
+        wide_axi_mst_req[SDMAMst].ar.addr = {
+          chip_id_i, axi_dma_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+        };
+        wide_axi_mst_req[SDMAMst].aw.addr = {
+          chip_id_i, axi_dma_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+        };
+      end
       assign axi_dma_res = wide_axi_mst_rsp[SDMAMst];
-      assign dma_events = dma_core_events;
-    
+      assign dma_events  = dma_core_events;
     end
   end
 
@@ -1464,7 +1467,7 @@ DmaXbarCfg.NoMstPorts
 
     hive_req_t [HiveSize-1:0] hive_req_reshape;
     hive_rsp_t [HiveSize-1:0] hive_rsp_reshape;
-    axi_mst_dma_req_t  hive_axi_mst_req;
+    axi_mst_dma_req_t hive_axi_mst_req;
     snitch_icache_pkg::icache_l0_events_t [HiveSize-1:0] icache_events_reshape;
 
     for (genvar j = 0; j < NrCores; j++) begin : gen_hive_matrix
@@ -1512,17 +1515,21 @@ DmaXbarCfg.NoMstPorts
     // For the chiplet system, we need to append the chip id to the aw/ar addr of axi requests
     always_comb begin : hive_append_chip_id
       wide_axi_mst_req[ICache+i] = hive_axi_mst_req;
-      wide_axi_mst_req[ICache+i].ar.addr = {chip_id_i,hive_axi_mst_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
-      wide_axi_mst_req[ICache+i].aw.addr = {chip_id_i,hive_axi_mst_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
+      wide_axi_mst_req[ICache+i].ar.addr = {
+        chip_id_i, hive_axi_mst_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+      };
+      wide_axi_mst_req[ICache+i].aw.addr = {
+        chip_id_i, hive_axi_mst_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+      };
     end
   end
 
   // --------
   // PTW Demux
   // --------
-  reqrsp_req_t ptw_to_axi_req;
-  reqrsp_rsp_t ptw_to_axi_rsp;
-  axi_mst_req_t  ptw_axi_req;
+  reqrsp_req_t  ptw_to_axi_req;
+  reqrsp_rsp_t  ptw_to_axi_rsp;
+  axi_mst_req_t ptw_axi_req;
   reqrsp_mux #(
       .NrPorts(NrHives),
       .AddrWidth(PhysicalAddrWidth),
@@ -1560,8 +1567,12 @@ DmaXbarCfg.NoMstPorts
   // For the chiplet system, we need to append the chip id to the aw/ar addr of axi requests
   always_comb begin : ptw_append_chip_id
     narrow_axi_mst_req[PTW] = ptw_axi_req;
-    narrow_axi_mst_req[PTW].ar.addr = {chip_id_i,ptw_axi_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
-    narrow_axi_mst_req[PTW].aw.addr = {chip_id_i,ptw_axi_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
+    narrow_axi_mst_req[PTW].ar.addr = {
+      chip_id_i, ptw_axi_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+    };
+    narrow_axi_mst_req[PTW].aw.addr = {
+      chip_id_i, ptw_axi_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+    };
   end
   // --------
   // Coes SoC
@@ -1578,7 +1589,7 @@ DmaXbarCfg.NoMstPorts
 
   reqrsp_req_t core_to_axi_req;
   reqrsp_rsp_t core_to_axi_rsp;
-  axi_mst_req_t  core_axi_req;
+  axi_mst_req_t core_axi_req;
   user_t cluster_user;
   // Atomic ID, needs to be unique ID of cluster
   // cluster_id + HartIdOffset + 1 (because 0 is for non-atomic masters)
@@ -1620,8 +1631,12 @@ DmaXbarCfg.NoMstPorts
   // For the chiplet system, we need to append the chip id to the aw/ar addr of axi requests
   always_comb begin : core_append_chip_id
     narrow_axi_mst_req[CoreReq] = core_axi_req;
-    narrow_axi_mst_req[CoreReq].ar.addr = {chip_id_i,core_axi_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
-    narrow_axi_mst_req[CoreReq].aw.addr = {chip_id_i,core_axi_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]};
+    narrow_axi_mst_req[CoreReq].ar.addr = {
+      chip_id_i, core_axi_req.ar.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+    };
+    narrow_axi_mst_req[CoreReq].aw.addr = {
+      chip_id_i, core_axi_req.aw.addr[PhysicalAddrWidth-ChipIdWidth-1:0]
+    };
   end
 
   // -----------------

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -62,6 +62,7 @@ ${',' if not loop.last else ''}
 package ${cfg['name']}_pkg;
 
   // Addressing Parameters
+  localparam int unsigned ChipIdWidth = ${cfg['chip_id_width']};
   localparam logic [ 9:0] HartBaseID = ${to_sv_hex(cfg['cluster_base_hartid'], 10)};
   localparam logic [${cfg['addr_width']-1}:0] ClusterBaseAddr = ${to_sv_hex(cfg['cluster_base_addr'], cfg['addr_width'])};
   localparam logic [31:0] BootAddr = ${to_sv_hex(cfg['boot_addr'], 32)};
@@ -286,6 +287,7 @@ module ${cfg['name']}_wrapper (
   //-----------------------------
   input  logic                                   clk_i,
   input  logic                                   rst_ni,
+  input  logic [${cfg['pkg_name']}::ChipIdWidth-1:0] chip_id_i,
 % if cfg['observable_pin_width'] > 0:
   //-----------------------------
   // Observable pins
@@ -550,6 +552,7 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
 
   // Snitch cluster under test.
   snitch_cluster #(
+    .ChipIdWidth (${cfg['pkg_name']}::ChipIdWidth),
     .PhysicalAddrWidth (${cfg['addr_width']}),
     .NarrowDataWidth (${cfg['data_width']}),
     .WideDataWidth (${cfg['dma_data_width']}),
@@ -658,8 +661,9 @@ total_snax_tcdm_ports = total_snax_narrow_ports + total_snax_wide_ports
     //-----------------------------
     // Clock and reset
     //-----------------------------
-    .clk_i  ( clk_i  ),
-    .rst_ni ( rst_ni ),
+    .clk_i     ( clk_i  ),
+    .rst_ni    ( rst_ni ),
+    .chip_id_i ( chip_id_i ),
 % if cfg['observable_pin_width'] > 0:
     //-----------------------------
     // Observable pins

--- a/hw/templates/testharness.sv.tpl
+++ b/hw/templates/testharness.sv.tpl
@@ -27,6 +27,7 @@ module testharness import ${cfg["cluster"]["name"]}_pkg::*; (
   ${cfg["cluster"]["name"]}_wrapper i_${cfg["cluster"]["name"]} (
     .clk_i                ( clk_i           ),
     .rst_ni               ( rst_ni          ),
+    .chip_id_i            ( '0              ),
     .hart_base_id_i       ( HartBaseID      ),
     .cluster_base_addr_i  ( ClusterBaseAddr ),
     .boot_addr_i          ( BootAddr        ),


### PR DESCRIPTION
**Summary**
This PR adds chip_id support to the Snax cluster, enabling Snitch cores in a multi-chip simulation to access their chiplet's local memory by extending the address of AXI requests.

**Problem**
The Snitch core is a 32-bit core, meaning it can natively only address a 4GB space. In a multi-chiplet system, the local L2 memory of each chiplet is mapped to a different, higher address region (e.g., 0x0000_7000_0000 for chiplet (1,0), 0x1000_7000_0000 for chiplet (1,0) ). A Snitch core in a remote chiplet cannot directly issue a load/store to this full address.

Previously, a transaction from snitch core at chiplet (1,0) to the chiplet local L2 would be incorrectly routed to the L2 memory of chiplet (0,0). The only software workaround was to use a DMA or special asm code, which is cumbersome and inefficient for simple memory accesses.

**Solution**
This PR modifies the AXI request paths from the Snitch core. For multi-chip simulation, the chip_id[7:0] is appended to the upper bits of the awaddr and araddr signals on the AXI master ports from the snitch to the SoC. This effectively "swizzles" the address, allowing the 32-bit core to target the correct address bits for its local chiplet memory without being aware of the full system map.

**Key Changes:**
- The core's 32-bit address is combined with the chip_id[7:0] to form a full system address (e.g., 0x1000_7000_0000).
- Single-chip simulation remains unchanged and is unaffected by this logic.
- This provides a transparent hardware mechanism for software to access chiplet-local memory without complex workarounds.
