### PR TITLE
add priority signal to tcdm arbitration

### DIFF
--- a/hw/chisel/src/main/scala/snax/sparse_interconnect/InterconnectTypes.scala
+++ b/hw/chisel/src/main/scala/snax/sparse_interconnect/InterconnectTypes.scala
@@ -20,17 +20,17 @@ object AmoOp extends ChiselEnum {
 
 /** TCDM Request Type */
 class TcdmReq(
-  addrWidth: Int,
-  dataWidth: Int,
-  strbWidth: Int,
-  userWidth: Int
+  addrWidth:     Int,
+  dataWidth:     Int,
+  strbWidth:     Int,
+  priorityWidth: Int
 ) extends Bundle {
-  val addr  = UInt(addrWidth.W)
-  val write = Bool()
-  val amo   = AmoOp()
-  val data  = UInt(dataWidth.W)
-  val strb  = UInt(strbWidth.W)
-  val user  = UInt(userWidth.W)
+  val addr     = UInt(addrWidth.W)
+  val write    = Bool()
+  val amo      = AmoOp()
+  val data     = UInt(dataWidth.W)
+  val strb     = UInt(strbWidth.W)
+  val priority = UInt(priorityWidth.W)
 }
 
 /** TCDM Response Type */

--- a/hw/chisel/src/main/scala/snax/sparse_interconnect/PriorityRoundRobinArbiter.scala
+++ b/hw/chisel/src/main/scala/snax/sparse_interconnect/PriorityRoundRobinArbiter.scala
@@ -1,0 +1,33 @@
+package snax.sparse_interconnect
+
+import chisel3._
+import chisel3.util._
+
+class PriorityRequest(priorityWidth: Int) extends Bundle {
+  val valid    = Bool()
+  val priority = UInt(priorityWidth.W) // Example width for priority
+}
+
+class PriorityRoundRobinArbiter(NumInp: Int, priorityWidth: Int) extends Module {
+
+  val io = IO(new Bundle {
+    val requests  = Input(Vec(NumInp, new PriorityRequest(priorityWidth)))
+    val selection = Decoupled(UInt(log2Ceil(NumInp).W))
+  })
+
+  // Instantiate normal round-robin arbiter
+  val arbiter = Module(new RoundRobinArbiter(NumInp))
+
+  // Determine the highest valid priority among the requests
+  val effectivePriorities = io.requests.map(req => Mux(req.valid, req.priority, 0.U))
+  val maxPriority         = effectivePriorities.reduce((a, b) => Mux(a > b, a, b))
+
+  // Mask requests that do not have the highest priority
+  for (i <- 0 until NumInp) {
+    arbiter.io.requests(i) := io.requests(i).valid && (io.requests(i).priority === maxPriority)
+  }
+
+  // Connect arbiter output to module output
+  io.selection <> arbiter.io.selection
+
+}

--- a/hw/chisel/src/main/scala/snax/sparse_interconnect/SparseInterconnect.scala
+++ b/hw/chisel/src/main/scala/snax/sparse_interconnect/SparseInterconnect.scala
@@ -11,13 +11,13 @@ class SparseInterconnect(
   tcdmAddrWidth: Int,
   dataWidth:     Int,
   strbWidth:     Int,
-  userWidth:     Int,
+  priorityWidth: Int,
   sparse_config: SparseConfig
 ) extends Module {
   val io = IO(new Bundle {
-    val tcdmReqs = Vec(NumInp, Flipped(Decoupled(new TcdmReq(tcdmAddrWidth, dataWidth, strbWidth, userWidth))))
+    val tcdmReqs = Vec(NumInp, Flipped(Decoupled(new TcdmReq(tcdmAddrWidth, dataWidth, strbWidth, priorityWidth))))
     val tcdmRsps = Vec(NumInp, Decoupled(new TcdmRsp(dataWidth)))
-    val memReqs  = Vec(NumOut, Decoupled(new TcdmReq(memAddrWidth, dataWidth, strbWidth, userWidth)))
+    val memReqs  = Vec(NumOut, Decoupled(new TcdmReq(memAddrWidth, dataWidth, strbWidth, priorityWidth)))
     val memRsps  = Vec(NumOut, Flipped(Decoupled(new TcdmRsp(dataWidth))))
   })
 
@@ -43,7 +43,7 @@ class SparseInterconnect(
   // one arbitration module per output memory bank
   val arbiters = Seq.fill(NumOut)(
     Module(
-      new ArbitrationTree(sparse_config.inputsPerBank, memAddrWidth, dataWidth, strbWidth, userWidth)
+      new ArbitrationTree(sparse_config.inputsPerBank, memAddrWidth, dataWidth, strbWidth, priorityWidth)
     )
   )
 
@@ -135,8 +135,8 @@ object SparseInterconnectGen {
     val strbWidth     = parsedArgs.get("strbWidth").map(_.toInt).getOrElse {
       throw new IllegalArgumentException("strbWidth argument is required")
     }
-    val userWidth     = parsedArgs.get("userWidth").map(_.toInt).getOrElse {
-      throw new IllegalArgumentException("userWidth argument is required")
+    val priorityWidth = parsedArgs.get("priorityWidth").map(_.toInt).getOrElse {
+      throw new IllegalArgumentException("priorityWidth argument is required")
     }
 
     // Parse the sparse configuration string
@@ -158,7 +158,7 @@ object SparseInterconnectGen {
         tcdmAddrWidth,
         dataWidth,
         strbWidth,
-        userWidth,
+        priorityWidth,
         sparseConfig
       ),
       Array("--target-dir", outPath)

--- a/hw/chisel/src/test/scala/snax/sparse_interconnect/PriorityArbiterTest.scala
+++ b/hw/chisel/src/test/scala/snax/sparse_interconnect/PriorityArbiterTest.scala
@@ -1,0 +1,73 @@
+package snax.sparse_interconnect
+
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PriorityRoundRobinArbiterTest extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "PriorityRoundRobinArbiter"
+
+  it should "perform basic round-robin arbitration without priorities" in {
+    test(new PriorityRoundRobinArbiter(NumInp = 4, priorityWidth = 2)) { dut =>
+      // Initialize inputs with two valid requests with same priority
+      dut.io.requests.foreach(_.valid.poke(false.B))
+      dut.io.selection.ready.poke(true.B)
+      dut.io.requests(0).valid.poke(true.B)
+      dut.io.requests(0).priority.poke(1.U)
+      dut.io.requests(1).valid.poke(true.B)
+      dut.io.requests(1).priority.poke(1.U)
+
+      // First valid request is selected
+      dut.io.selection.bits.expect(0.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+
+      // Second valid request is selected in round-robin fashion
+      dut.io.selection.bits.expect(1.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+
+      // Select first request again (wrap-around)
+      dut.io.selection.bits.expect(0.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+    }
+  }
+
+  it should "perform basic round-robin arbitration with priorities" in {
+    test(new PriorityRoundRobinArbiter(NumInp = 4, priorityWidth = 2)) { dut =>
+      // Initialize inputs with two valid requests with same priority
+      dut.io.requests.foreach(_.valid.poke(false.B))
+      dut.io.selection.ready.poke(true.B)
+      dut.io.requests(0).valid.poke(true.B)
+      dut.io.requests(0).priority.poke(0.U)
+      dut.io.requests(1).valid.poke(true.B)
+      dut.io.requests(1).priority.poke(1.U)
+      dut.io.requests(2).valid.poke(true.B)
+      dut.io.requests(2).priority.poke(2.U)
+
+      // Last request is selected first (highest priority)
+      dut.io.selection.bits.expect(2.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+      dut.io.requests(2).valid.poke(false.B)
+
+      // Second request has next priority
+      dut.io.selection.bits.expect(1.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+
+      // Second request is still selected when first request has lower priority
+      dut.io.selection.bits.expect(1.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+      dut.io.requests(1).valid.poke(false.B)
+
+      // Finally, first request (lowest priority) is selected
+      dut.io.selection.bits.expect(0.U)
+      dut.io.selection.valid.expect(true.B)
+      dut.clock.step()
+    }
+  }
+
+}

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -415,6 +415,7 @@ module snitch_cluster
   typedef struct packed {
     logic [CoreIDWidth-1:0] core_id;
     bit                     is_core;
+    logic                   tcdm_priority;
   } tcdm_user_t;
 
   // Regbus peripherals.

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -134,6 +134,7 @@ package ${cfg['name']}_pkg;
   typedef struct packed {
     logic [CoreIDWidth-1:0] core_id;
     bit                     is_core;
+    logic                   tcdm_priority;
   } tcdm_user_t;
 
   `TCDM_TYPEDEF_ALL(tcdm, tcdm_addr_t, data_t, strb_t, tcdm_user_t)

--- a/hw/templates/sparse_interconnect_wrapper.sv.tpl
+++ b/hw/templates/sparse_interconnect_wrapper.sv.tpl
@@ -64,9 +64,8 @@ SparseInterconnect sparse_interconnect_i (
         .io_tcdmReqs_${idx}_bits_amo   ( req_i[${idx}].q.amo   ),
         .io_tcdmReqs_${idx}_bits_data  ( req_i[${idx}].q.data  ),
         .io_tcdmReqs_${idx}_bits_strb  ( req_i[${idx}].q.strb  ),
+        .io_tcdmReqs_${idx}_bits_priority  ( req_i[${idx}].q.user.tcdm_priority   ),
     % endfor
-    // user signal is not used
-    // .io_tcdmReqs_${idx}_bits_user  ( req_i[${idx}].q.user  ),
 
     // Tcdm Responses, the ready signal is set to 1, it is ignored by the tcdm
     % for idx in range(cfg["sparse_interconnect_cfg"]["NumInp"]):

--- a/util/snaxgen/snaxgen.py
+++ b/util/snaxgen/snaxgen.py
@@ -732,8 +732,8 @@ def main():
             + str(cfg["cluster"]["data_width"])
             + " --strbWidth "
             + str(int(cfg["cluster"]["data_width"] / 8))
-            + " --userWidth "
-            + str(0)
+            + " --priorityWidth "
+            + str(1)
             + " --sparseConfig "
             + f"\"{cfg['cluster']['sparse_interconnect_cfg']['sparse_config']}\""
             + " --hw-target-dir "


### PR DESCRIPTION
This PR adds a priority signal to each TCDM request, which is handled by the arbiter.
The signal is instantiated to be 1 bit and is set to 0 for everything right now, so it isn't used yet.

I think this is necessary to remove a deadlock happening in #574 , so I want to merge this first, then connect iDMA to narrow (with high priority) and then later set the priority for requests coming from streamers.