### PR TITLE
Update the fpnew version

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -25,7 +25,7 @@ dependencies:
   axi:                { git: https://github.com/pulp-platform/axi,                version:  0.39.1  }
   axi_riscv_atomics:  { git: https://github.com/pulp-platform/axi_riscv_atomics,  version:  0.8.2   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells,       version:  1.28.0  }
-  FPnew:              { git: https://github.com/pulp-platform/cvfpu.git,      rev:      pulp-v0.1.3 }
+  FPnew:              { git: https://github.com/pulp-platform/cvfpu.git,      rev:      pulp-v0.2.3 }
   register_interface: { git: https://github.com/pulp-platform/register_interface, version:  0.4.2   }
   tech_cells_generic: { git: https://github.com/pulp-platform/tech_cells_generic, version:  0.2.11  }
   riscv-dbg:          { git: https://github.com/pulp-platform/riscv-dbg,          version:  0.8.0   }


### PR DESCRIPTION
This pull request updates the `FPnew` dependency in the `Bender.yml` file to a newer version. No other changes are included.

* Upgraded the `FPnew` dependency from revision `pulp-v0.1.3` to `pulp-v0.2.3` in `Bender.yml`
* This is from the requirement of cva6 integration at the HeMAiA-level where cva6 uses the pulp-v0.2.3 version https://github.com/KULeuven-MICAS/cva6/blob/kfc/hemaia-integration/Bender.yml
* For the current usage, this PR has no side effects since we do not use the FPU in the snax.