### PR TITLE
add-pipe-reg-after-muls

### DIFF
--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Accumulator.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Accumulator.scala
@@ -82,9 +82,7 @@ class Accumulator(
 
   // accumulation update logic, considering the handshake and the accumulator enable at runtime
   val accUpdate = VecInit(
-    (0 until numElements).map(i =>
-      io.in1.fire && io.enable(i) && (!io.accAddExtIn || (io.in2.fire && io.accAddExtIn))
-    )
+    (0 until numElements).map(i => io.in1.fire && io.enable(i) && (!io.accAddExtIn || (io.in2.fire && io.accAddExtIn)))
   )
 
   // Connect the inputs of each AccumulatorBlock

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Accumulator.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Accumulator.scala
@@ -39,12 +39,17 @@ class AccumulatorBlock(
   ).io
 
   // connection description
-  adder.in_a := io.in1
-  adder.in_b := Mux(io.accAddExtIn, io.in2, accumulatorReg)
+  adder.in.bits.in_a := io.in1
+  adder.in.bits.in_b := Mux(io.accAddExtIn, io.in2, accumulatorReg)
+  adder.in.valid     := io.enable
+  // the register will always accept the adder's output, so the ready signal is always true
+  adder.out.ready    := true.B
 
-  // update accumulator register enable signal
-  val accUpdate = io.enable
-  accumulatorReg := Mux(accUpdate, adder.out_c, accumulatorReg)
+  // update accumulator register based on the adder's output handshake
+  // This is robust to pipeline depth within the adder
+  when(adder.out.fire) {
+    accumulatorReg := adder.out.bits
+  }
 
   // output of the accumulator register
   io.out := accumulatorReg
@@ -65,6 +70,7 @@ class Accumulator(
     val accAddExtIn = Input(Bool())
     val enable      = Input(Vec(numElements, Bool()))
     val out         = DecoupledIO(Vec(numElements, UInt(outputType.width.W)))
+    val inputReady  = Output(Bool())
   })
 
   // Create an array of AccumulatorBlock instances
@@ -76,7 +82,9 @@ class Accumulator(
 
   // accumulation update logic, considering the handshake and the accumulator enable at runtime
   val accUpdate = VecInit(
-    (0 until numElements).map(i => io.in1.fire && io.enable(i) && (!io.accAddExtIn || (io.in2.fire && io.accAddExtIn)))
+    (0 until numElements).map(i =>
+      io.in1.fire && io.enable(i) && (!io.accAddExtIn || (io.in2.fire && io.accAddExtIn))
+    )
   )
 
   // Connect the inputs of each AccumulatorBlock
@@ -87,6 +95,7 @@ class Accumulator(
     accumulator_blocks(i).io.enable      := accUpdate(i)
   }
 
+  val inputDataReady = io.in1.ready && io.enable(0) && (!io.accAddExtIn || (io.in2.ready && io.accAddExtIn))
   val inputDataFire  = RegNext(accUpdate(0), false.B) // assuming all accUpdate are the same for handshake
   val keepOutput     = RegInit(false.B)
   val keepOutputNext = io.out.valid && !io.out.ready
@@ -97,8 +106,11 @@ class Accumulator(
   io.in2.ready := (!keepOutput) && (!keepOutputNext)
 
   // Connect the outputs of each AccumulatorBlock to the output interface
-  io.out.bits  := accumulator_blocks.map(_.io.out)
+  io.out.bits  := VecInit(accumulator_blocks.map(_.io.out))
   io.out.valid := inputDataFire || keepOutput
+
+  // input ready
+  io.inputReady := inputDataReady
 }
 
 object AccumulatorEmitterUInt extends App {

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Adder.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Adder.scala
@@ -9,7 +9,14 @@ package snax_acc.versacore
 
 import chisel3._
 
+import chisel3.util._
+
 import fp_unit._
+
+class AdderReq(inputTypeA: DataType, inputTypeB: DataType) extends Bundle {
+  val in_a = UInt(inputTypeA.width.W)
+  val in_b = UInt(inputTypeB.width.W)
+}
 
 /** AdderIO defines the input and output interfaces for the Adder module. */
 class AdderIO(
@@ -17,9 +24,8 @@ class AdderIO(
   inputTypeB: DataType,
   inputTypeC: DataType
 ) extends Bundle {
-  val in_a  = Input(UInt(inputTypeA.width.W))
-  val in_b  = Input(UInt(inputTypeB.width.W))
-  val out_c = Output(UInt(inputTypeC.width.W))
+  val in  = Flipped(Decoupled(new AdderReq(inputTypeA, inputTypeB)))
+  val out = Decoupled(UInt(inputTypeC.width.W))
 }
 
 /** Adder is a module that performs addition on two inputs based on the specified operation type. */
@@ -32,9 +38,16 @@ class Adder(
 
   val io = IO(new AdderIO(inputTypeA, inputTypeB, inputTypeC))
 
+  // Combinational handshake
+  io.in.ready  := io.out.ready
+  io.out.valid := io.in.valid
+
+  val out_c = Wire(UInt(inputTypeC.width.W))
+  io.out.bits := out_c
+
   (inputTypeA, inputTypeB, inputTypeC) match {
     case (_: IntType, _: IntType, _: IntType) =>
-      io.out_c := (io.in_a.asTypeOf(SInt(inputTypeC.width.W)) + io.in_b.asTypeOf(
+      out_c := (io.in.bits.in_a.asTypeOf(SInt(inputTypeC.width.W)) + io.in.bits.in_b.asTypeOf(
         SInt(inputTypeC.width.W)
       )).asUInt
 
@@ -42,9 +55,9 @@ class Adder(
 
     case (a: FpType, b: FpType, c: FpType) => {
       val fpAddFp = Module(new FpAddFpBlackBox("fp_add", a, b, c))
-      fpAddFp.io.operand_a_i := io.in_a
-      fpAddFp.io.operand_b_i := io.in_b
-      io.out_c               := fpAddFp.io.result_o
+      fpAddFp.io.operand_a_i := io.in.bits.in_a
+      fpAddFp.io.operand_b_i := io.in.bits.in_b
+      out_c                  := fpAddFp.io.result_o
     }
 
     case (_, _, _) => throw new NotImplementedError()

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/AdderTree.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/AdderTree.scala
@@ -29,10 +29,14 @@ class AdderTree(
   require(isPow2(numElements), "numElements must be a power of 2")
 
   val io = IO(new Bundle {
-    val in  = Input(Vec(numElements, UInt(inputType.width.W)))
-    val out = Output(Vec(numElements, UInt(outputType.width.W)))
+    val in  = Flipped(Decoupled(Vec(numElements, UInt(inputType.width.W))))
+    val out = Decoupled(Vec(numElements, UInt(outputType.width.W)))
     val cfg = Input(UInt(log2Ceil(groupSizes.length + 1).W))
   })
+
+  // Combinational handshake
+  io.in.ready  := io.out.ready
+  io.out.valid := io.in.valid
 
   // Ensure valid size
   groupSizes.foreach(size => require(isPow2(size), "groupSizes must be a power of 2"))
@@ -63,7 +67,7 @@ class AdderTree(
   layers.map(_.map(_ := 0.U.asTypeOf(UInt(outputType.width.W))))
   // Initialize the first layer with input values
   layers(0) := VecInit(
-    io.in.map(_.asTypeOf(adderTreeInputType).asTypeOf(UInt(outputType.width.W)))
+    io.in.bits.map(_.asTypeOf(adderTreeInputType).asTypeOf(UInt(outputType.width.W)))
   )
 
   val realStageNum = MuxLookup(io.cfg, groupSizes(0).U)(groupSizes.zipWithIndex.map { case (size, idx) =>
@@ -85,14 +89,16 @@ class AdderTree(
       // If the current depth is less than or equal to realStageNum,
       // we connect the inputs and outputs normally
       // Otherwise, we connect zeros to save energy
-      adder.io.in_a        := Mux(realStageNum > d.U, layers(d)(i), 0.U)
-      adder.io.in_b        := Mux(realStageNum > d.U, layers(d)(i + step), 0.U)
-      layers(d + 1)(i / 2) := Mux(realStageNum > d.U, adder.io.out_c, 0.U)
+      adder.io.in.bits.in_a := Mux(realStageNum > d.U, layers(d)(i), 0.U)
+      adder.io.in.bits.in_b := Mux(realStageNum > d.U, layers(d)(i + step), 0.U)
+      adder.io.in.valid     := io.in.valid
+      adder.io.out.ready    := io.out.ready
+      layers(d + 1)(i / 2)  := Mux(realStageNum > d.U, adder.io.out.bits, 0.U)
     }
   }
 
   // Generate multiple adder tree outputs based on groupSizes
-  io.out := layers(realStageNum)
+  io.out.bits := layers(realStageNum)
 
 }
 

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Array.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Array.scala
@@ -159,6 +159,10 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
     })
   }
 
+  // Pipeline in_c to match the multiplier + register stage latency
+  val in_c_pipe = Wire(Decoupled(chiselTypeOf(io.array_data.in_c.bits)))
+  io.array_data.in_c -|> in_c_pipe
+
   val inputC = params.arrayDim.zipWithIndex.map { case (dims, dataTypeIdx) =>
     dims.map(dim => {
       dataForwardN(
@@ -168,7 +172,7 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
         Seq(dim(0), dim(2), 1),
         // stride_Mu, stride_Nu, stride_Ku
         Seq(dim(2), 1, 0),
-        io.array_data.in_c.bits
+        in_c_pipe.bits
       )
     })
   }
@@ -218,7 +222,7 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
         (0 until params.arrayDim(dataTypeIdx).length).map(j => j.U -> inputB(dataTypeIdx)(j)(mulIdx))
       )
       // Use top-level valid signals to avoid combinational loops with fire
-      mul.io.in.valid := io.array_data.in_a.valid && io.array_data.in_b.valid
+      mul.io.in.valid     := io.array_data.in_a.valid && io.array_data.in_b.valid
     }
   )
 
@@ -238,13 +242,14 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   // connect output of the multipliers to adder tree
   // insert a register to pipeline the output of the multipliers
   (0 until params.inputTypeA.length).foreach { dataTypeIdx =>
-    val muls      = multipliers(dataTypeIdx)
-    val tree      = adderTree(dataTypeIdx)
-    val output_bits = VecInit(muls.map(_.io.out.bits))
+    val muls         = multipliers(dataTypeIdx)
+    val tree         = adderTree(dataTypeIdx)
+    val output_bits  = VecInit(muls.map(_.io.out.bits))
     val output_valid = muls.map(_.io.out.valid).reduce(_ && _)
 
-    val muls_out_data = Wire(Decoupled(Vec(params.multiplierNum(dataTypeIdx), UInt(params.inputTypeC(dataTypeIdx).width.W))))
-    muls_out_data.bits := output_bits
+    val muls_out_data =
+      Wire(Decoupled(Vec(params.multiplierNum(dataTypeIdx), UInt(params.inputTypeC(dataTypeIdx).width.W))))
+    muls_out_data.bits  := output_bits
     muls_out_data.valid := output_valid
     // The multipliers' ready signal comes from the pipeline register (-|>).
     muls.foreach(_.io.out.ready := muls_out_data.ready)
@@ -269,9 +274,9 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   // connect adder tree output to accumulators
   // and inputC to accumulators
   accumulators.zipWithIndex.foreach { case (acc, dataTypeIdx) =>
-  // the accumulator input1 is from the adder tree
-    acc.io.in1.bits  := adderTree(dataTypeIdx).io.out.bits
-    acc.io.in1.valid := adderTree(dataTypeIdx).io.out.valid
+    // the accumulator input1 is from the adder tree
+    acc.io.in1.bits                     := adderTree(dataTypeIdx).io.out.bits
+    acc.io.in1.valid                    := adderTree(dataTypeIdx).io.out.valid
     // The adder tree's ready signal comes from the accumulator's inputReady, considering both the input1 and input2 are ready in different cases
     adderTree(dataTypeIdx).io.out.ready := acc.io.inputReady
 
@@ -285,9 +290,18 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   }
 
   // handle the control signals for accumulators
-  accumulators.foreach(_.io.in2.valid := io.array_data.in_c.valid)
+  // The in2 valid should come from the pipelined in_c
+  accumulators.foreach(_.io.in2.valid := in_c_pipe.valid)
   accumulators.foreach(_.io.accAddExtIn := io.ctrl.accAddExtIn)
   accumulators.foreach(_.io.out.ready := io.array_data.out_d.ready)
+
+  // Connect the ready signal for the in_c pipeline to the accumulators' in2 ready
+  in_c_pipe.ready := MuxLookup(
+    io.ctrl.dataTypeCfg,
+    accumulators(0).io.in2.ready
+  )(
+    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.in2.ready)
+  )
 
   (0 until params.inputTypeA.length).foreach { dataTypeIdx =>
     (0 until params.multiplierNum(dataTypeIdx)).foreach { accIdx =>
@@ -297,7 +311,7 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
     }
   }
 
-  // The multipliers' ready signal comes from the pipeline register (-|>)
+  // The multipliers' ready signal comes from its pipeline register (-|>)
   val muls_ready = MuxLookup(
     io.ctrl.dataTypeCfg,
     multipliers(0)(0).io.in.ready
@@ -305,26 +319,14 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
     (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> multipliers(dataTypeIdx)(0).io.in.ready)
   )
 
-  // Synchronize in_a and in_b to fire together
-  io.array_data.in_a.ready := io.array_data.in_b.valid && muls_ready
-  io.array_data.in_b.ready := io.array_data.in_a.valid && muls_ready
+  // Top-level input synchronization
+  // A, B and C (if enabled) must fire together to ensure the input wave enters the pipeline correctly.
+  val common_ready         = muls_ready && (in_c_pipe.ready || !io.ctrl.accAddExtIn)
+  val in_c_valid_if_needed = in_c_pipe.valid || !io.ctrl.accAddExtIn
 
-  // Accumulator stage synchronization
-  val acc_inputReady = MuxLookup(
-    io.ctrl.dataTypeCfg,
-    accumulators(0).io.inputReady
-  )(
-    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.inputReady)
-  )
-  val acc_in1_valid = MuxLookup(
-    io.ctrl.dataTypeCfg,
-    accumulators(0).io.in1.valid
-  )(
-    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.in1.valid)
-  )
-
-  // in_c only fires if accAddExtIn is true, both inputs are ready, and accumulator (in1) has valid data
-  io.array_data.in_c.ready := io.ctrl.accAddExtIn && acc_inputReady && acc_in1_valid
+  io.array_data.in_a.ready := io.array_data.in_b.valid && in_c_valid_if_needed     && common_ready
+  io.array_data.in_b.ready := io.array_data.in_a.valid && in_c_valid_if_needed     && common_ready
+  io.array_data.in_c.ready := io.array_data.in_a.valid && io.array_data.in_b.valid && common_ready
 
   io.array_data.in_subtraction.ready := io.array_data.in_a.ready && io.array_data.in_b.ready
 

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Array.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Array.scala
@@ -159,9 +159,13 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
     })
   }
 
-  // Pipeline in_c to match the multiplier + register stage latency
+  // Synchronize and pipeline in_c to match the multiplier + register stage latency
+  val in_c_sync = Wire(Decoupled(chiselTypeOf(io.array_data.in_c.bits)))
+  in_c_sync.bits := io.array_data.in_c.bits
+  // The actual valid/ready logic for in_c_sync is handled in the handshake section later
+
   val in_c_pipe = Wire(Decoupled(chiselTypeOf(io.array_data.in_c.bits)))
-  io.array_data.in_c -|> in_c_pipe
+  in_c_sync -|> in_c_pipe
 
   val inputC = params.arrayDim.zipWithIndex.map { case (dims, dataTypeIdx) =>
     dims.map(dim => {
@@ -221,8 +225,6 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
       )(
         (0 until params.arrayDim(dataTypeIdx).length).map(j => j.U -> inputB(dataTypeIdx)(j)(mulIdx))
       )
-      // Use top-level valid signals to avoid combinational loops with fire
-      mul.io.in.valid     := io.array_data.in_a.valid && io.array_data.in_b.valid
     }
   )
 
@@ -321,12 +323,17 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
 
   // Top-level input synchronization
   // A, B and C (if enabled) must fire together to ensure the input wave enters the pipeline correctly.
-  val common_ready         = muls_ready && (in_c_pipe.ready || !io.ctrl.accAddExtIn)
-  val in_c_valid_if_needed = in_c_pipe.valid || !io.ctrl.accAddExtIn
+  val in_c_active  = io.ctrl.accAddExtIn
+  val common_valid = io.array_data.in_a.valid && io.array_data.in_b.valid && (io.array_data.in_c.valid || !in_c_active)
+  val common_ready = muls_ready               && (in_c_sync.ready || !in_c_active)
 
-  io.array_data.in_a.ready := io.array_data.in_b.valid && in_c_valid_if_needed     && common_ready
-  io.array_data.in_b.ready := io.array_data.in_a.valid && in_c_valid_if_needed     && common_ready
-  io.array_data.in_c.ready := io.array_data.in_a.valid && io.array_data.in_b.valid && common_ready
+  io.array_data.in_a.ready := io.array_data.in_b.valid && (io.array_data.in_c.valid || !in_c_active) && common_ready
+  io.array_data.in_b.ready := io.array_data.in_a.valid && (io.array_data.in_c.valid || !in_c_active) && common_ready
+  io.array_data.in_c.ready := io.array_data.in_a.valid && io.array_data.in_b.valid                   && common_ready
+
+  // Drive the valid signals for the first stage
+  multipliers.foreach(_.foreach(_.io.in.valid := common_valid))
+  in_c_sync.valid := common_valid
 
   io.array_data.in_subtraction.ready := io.array_data.in_a.ready && io.array_data.in_b.ready
 

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Array.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Array.scala
@@ -8,6 +8,7 @@ package snax_acc.versacore
 
 import chisel3._
 import chisel3.util._
+import snax_acc.utils.DecoupledCut._
 
 import fp_unit._
 
@@ -204,18 +205,20 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   // multipliers connection with the output from data feeding network
   (0 until params.inputTypeA.length).foreach(dataTypeIdx =>
     multipliers(dataTypeIdx).zipWithIndex.foreach { case (mul, mulIdx) =>
-      mul.io.in_a := MuxLookup(
+      mul.io.in.bits.in_a := MuxLookup(
         io.ctrl.arrayShapeCfg,
         inputA(dataTypeIdx)(0)(mulIdx)
       )(
         (0 until params.arrayDim(dataTypeIdx).length).map(j => j.U -> inputA(dataTypeIdx)(j)(mulIdx))
       )
-      mul.io.in_b := MuxLookup(
+      mul.io.in.bits.in_b := MuxLookup(
         io.ctrl.arrayShapeCfg,
         inputB(dataTypeIdx)(0)(mulIdx)
       )(
         (0 until params.arrayDim(dataTypeIdx).length).map(j => j.U -> inputB(dataTypeIdx)(j)(mulIdx))
       )
+      // Use top-level valid signals to avoid combinational loops with fire
+      mul.io.in.valid := io.array_data.in_a.valid && io.array_data.in_b.valid
     }
   )
 
@@ -233,10 +236,21 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   )
 
   // connect output of the multipliers to adder tree
-  multipliers.zipWithIndex.foreach { case (muls, dataTypeIdx) =>
-    muls.zipWithIndex.foreach { case (mul, mulIdx) =>
-      adderTree(dataTypeIdx).io.in(mulIdx) := mul.io.out_c
-    }
+  // insert a register to pipeline the output of the multipliers
+  (0 until params.inputTypeA.length).foreach { dataTypeIdx =>
+    val muls      = multipliers(dataTypeIdx)
+    val tree      = adderTree(dataTypeIdx)
+    val output_bits = VecInit(muls.map(_.io.out.bits))
+    val output_valid = muls.map(_.io.out.valid).reduce(_ && _)
+
+    val muls_out_data = Wire(Decoupled(Vec(params.multiplierNum(dataTypeIdx), UInt(params.inputTypeC(dataTypeIdx).width.W))))
+    muls_out_data.bits := output_bits
+    muls_out_data.valid := output_valid
+    // The multipliers' ready signal comes from the pipeline register (-|>).
+    muls.foreach(_.io.out.ready := muls_out_data.ready)
+
+    // Use the -|> operator to insert a pipeline register
+    muls_out_data -|> tree.io.in
   }
 
   // adder tree runtime configuration
@@ -255,7 +269,13 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   // connect adder tree output to accumulators
   // and inputC to accumulators
   accumulators.zipWithIndex.foreach { case (acc, dataTypeIdx) =>
-    acc.io.in1.bits := adderTree(dataTypeIdx).io.out
+  // the accumulator input1 is from the adder tree
+    acc.io.in1.bits  := adderTree(dataTypeIdx).io.out.bits
+    acc.io.in1.valid := adderTree(dataTypeIdx).io.out.valid
+    // The adder tree's ready signal comes from the accumulator's inputReady, considering both the input1 and input2 are ready in different cases
+    adderTree(dataTypeIdx).io.out.ready := acc.io.inputReady
+
+    // the accumulator input2 is from the inputC
     acc.io.in2.bits := MuxLookup(
       io.ctrl.arrayShapeCfg,
       inputC(dataTypeIdx)(0)
@@ -265,7 +285,6 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
   }
 
   // handle the control signals for accumulators
-  accumulators.foreach(_.io.in1.valid := io.array_data.in_a.valid && io.array_data.in_b.valid)
   accumulators.foreach(_.io.in2.valid := io.array_data.in_c.valid)
   accumulators.foreach(_.io.accAddExtIn := io.ctrl.accAddExtIn)
   accumulators.foreach(_.io.out.ready := io.array_data.out_d.ready)
@@ -278,22 +297,34 @@ class SpatialArray(params: SpatialArrayParam) extends Module with RequireAsyncRe
     }
   }
 
-  // input fire signals
-  val acc_in1_fire = MuxLookup(
+  // The multipliers' ready signal comes from the pipeline register (-|>)
+  val muls_ready = MuxLookup(
     io.ctrl.dataTypeCfg,
-    accumulators(0).io.in1.fire
+    multipliers(0)(0).io.in.ready
   )(
-    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.in1.fire)
+    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> multipliers(dataTypeIdx)(0).io.in.ready)
   )
-  val acc_in2_fire = MuxLookup(
+
+  // Synchronize in_a and in_b to fire together
+  io.array_data.in_a.ready := io.array_data.in_b.valid && muls_ready
+  io.array_data.in_b.ready := io.array_data.in_a.valid && muls_ready
+
+  // Accumulator stage synchronization
+  val acc_inputReady = MuxLookup(
     io.ctrl.dataTypeCfg,
-    accumulators(0).io.in2.fire
+    accumulators(0).io.inputReady
   )(
-    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.in2.fire)
+    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.inputReady)
   )
-  io.array_data.in_a.ready := Mux(io.ctrl.accAddExtIn, acc_in1_fire && acc_in2_fire, acc_in1_fire)
-  io.array_data.in_b.ready := Mux(io.ctrl.accAddExtIn, acc_in1_fire && acc_in2_fire, acc_in1_fire)
-  io.array_data.in_c.ready := Mux(io.ctrl.accAddExtIn, acc_in1_fire && acc_in2_fire, false.B)
+  val acc_in1_valid = MuxLookup(
+    io.ctrl.dataTypeCfg,
+    accumulators(0).io.in1.valid
+  )(
+    (0 until params.arrayDim.length).map(dataTypeIdx => dataTypeIdx.U -> accumulators(dataTypeIdx).io.in1.valid)
+  )
+
+  // in_c only fires if accAddExtIn is true, both inputs are ready, and accumulator (in1) has valid data
+  io.array_data.in_c.ready := io.ctrl.accAddExtIn && acc_inputReady && acc_in1_valid
 
   io.array_data.in_subtraction.ready := io.array_data.in_a.ready && io.array_data.in_b.ready
 

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Multiplier.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Multiplier.scala
@@ -48,7 +48,7 @@ class Multiplier(inputTypeA: DataType, inputTypeB: DataType, inputTypeC: DataTyp
       val fpMulInt = Module(new FpMulIntBlackBox("fp_mul_int", a, b, c))
       fpMulInt.io.operand_a_i := io.in.bits.in_a
       fpMulInt.io.operand_b_i := io.in.bits.in_b
-      out_c                  := fpMulInt.io.result_o
+      out_c                   := fpMulInt.io.result_o
     }
 
     case (a: FpType, b: FpType, c: FpType) => {

--- a/hw/chisel_acc/src/main/scala/snax_acc/versacore/Multiplier.scala
+++ b/hw/chisel_acc/src/main/scala/snax_acc/versacore/Multiplier.scala
@@ -9,12 +9,18 @@ package snax_acc.versacore
 
 import chisel3._
 
+import chisel3.util._
+
 import fp_unit._
 
+class MultiplierReq(inputTypeA: DataType, inputTypeB: DataType) extends Bundle {
+  val in_a = UInt(inputTypeA.width.W)
+  val in_b = UInt(inputTypeB.width.W)
+}
+
 class MultiplierIO(inputTypeA: DataType, inputTypeB: DataType, inputTypeC: DataType) extends Bundle {
-  val in_a  = Input(UInt(inputTypeA.width.W))
-  val in_b  = Input(UInt(inputTypeB.width.W))
-  val out_c = Output(UInt(inputTypeC.width.W))
+  val in  = Flipped(Decoupled(new MultiplierReq(inputTypeA, inputTypeB)))
+  val out = Decoupled(UInt(inputTypeC.width.W))
 }
 
 /** Multiplier module that supports different operation types */
@@ -24,25 +30,32 @@ class Multiplier(inputTypeA: DataType, inputTypeB: DataType, inputTypeC: DataTyp
 
   val io = IO(new MultiplierIO(inputTypeA, inputTypeB, inputTypeC))
 
+  // Combinational handshake
+  io.in.ready  := io.out.ready
+  io.out.valid := io.in.valid
+
+  val out_c = Wire(UInt(inputTypeC.width.W))
+  io.out.bits := out_c
+
   (inputTypeA, inputTypeB, inputTypeC) match {
 
     case (_: IntType, _: IntType, _: IntType) =>
-      io.out_c := (io.in_a.asTypeOf(SInt(inputTypeC.width.W)) * io.in_b.asTypeOf(
+      out_c := (io.in.bits.in_a.asTypeOf(SInt(inputTypeC.width.W)) * io.in.bits.in_b.asTypeOf(
         SInt(inputTypeC.width.W)
       )).asUInt
 
     case (a: FpType, b: IntType, c: FpType) => {
       val fpMulInt = Module(new FpMulIntBlackBox("fp_mul_int", a, b, c))
-      fpMulInt.io.operand_a_i := io.in_a
-      fpMulInt.io.operand_b_i := io.in_b
-      io.out_c                := fpMulInt.io.result_o
+      fpMulInt.io.operand_a_i := io.in.bits.in_a
+      fpMulInt.io.operand_b_i := io.in.bits.in_b
+      out_c                  := fpMulInt.io.result_o
     }
 
     case (a: FpType, b: FpType, c: FpType) => {
       val fpMulfp = Module(new FpMulFp(a, b, c))
-      fpMulfp.io.in_a := io.in_a
-      fpMulfp.io.in_b := io.in_b
-      io.out_c        := fpMulfp.io.out
+      fpMulfp.io.in_a := io.in.bits.in_a
+      fpMulfp.io.in_b := io.in.bits.in_b
+      out_c           := fpMulfp.io.out
     }
 
     case (_, _, _) => throw new NotImplementedError()

--- a/hw/chisel_acc/src/test/scala/snax_acc/versacore/AdderTreeTest.scala
+++ b/hw/chisel_acc/src/test/scala/snax_acc/versacore/AdderTreeTest.scala
@@ -22,8 +22,10 @@ class AdderTreeTest extends AnyFunSuite with ChiselScalatestTester {
       def testConfig(cfg: Int, inputValues: Seq[Int], expectedOutput: Seq[Int]): Unit = {
         // Set input values
         inputValues.zipWithIndex.foreach { case (value, idx) =>
-          dut.io.in(idx).poke(value.U)
+          dut.io.in.bits(idx).poke(value.U)
         }
+        dut.io.in.valid.poke(true.B)
+        dut.io.out.ready.poke(true.B)
 
         // Set configuration
         dut.io.cfg.poke(cfg.U)
@@ -32,8 +34,9 @@ class AdderTreeTest extends AnyFunSuite with ChiselScalatestTester {
         dut.clock.step()
 
         // Check expected output
+        dut.io.out.valid.expect(true.B)
         expectedOutput.zipWithIndex.foreach { case (expected, idx) =>
-          dut.io.out(idx).expect(expected.U)
+          dut.io.out.bits(idx).expect(expected.U)
         }
       }
 


### PR DESCRIPTION
* Unified DecoupledIO: All arithmetic units (Multiplier, Adder, AdderTree, and Accumulator) now consistently use DecoupledIO for their interfaces.
* Pipelining with -|>: We inserted a pipeline register between the multipliers and the adder tree using your project's custom -|> operator, which helps break long combinational timing paths.
* Refine Handshaking: In Array.scala