### PR TITLE
Add ElementwiseAdder to SNAX Cluster

### DIFF
--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAdd.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAdd.scala
@@ -34,49 +34,52 @@ class ElementwiseAdd(
     s"Data width ${extensionParam.dataWidth} must be a multiple of element width $elementWidth"
   )
 
+  private val elementPerVector = extensionParam.dataWidth / elementWidth
+
   // Counter to record the steps
   val counter = Module(new snax.utils.BasicCounter(8) {
     override val desiredName = "ElementwiseAddCounter"
   })
-  counter.io.ceil := ext_csr_i(0)
+
+  val operandCount = ext_csr_i(0)(7, 0)
+  counter.io.ceil := operandCount
   counter.io.reset := ext_start_i
   counter.io.tick  := ext_data_i.fire
-  ext_busy_o       := counter.io.value =/= 0.U
 
-  // The wire to connect the output result
-  val ext_data_o_bits = Wire(
-    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
-  )
-
-  // The register to hold the sum of each Element
+  // The register holds the partial sum and then the completed output.
   val regs = RegInit(
     VecInit(
-      Seq.fill(extensionParam.dataWidth / elementWidth)(0.U(elementWidth.W))
+      Seq.fill(elementPerVector)(0.U(elementWidth.W))
     )
   )
+  val outputValid = RegInit(false.B)
 
   val input_data = ext_data_i.bits.asTypeOf(
-    Vec(extensionParam.dataWidth / elementWidth, UInt(elementWidth.W))
+    Vec(elementPerVector, UInt(elementWidth.W))
   )
-  for (i <- 0 until extensionParam.dataWidth / elementWidth) {
-    ext_data_o_bits(i) := regs(i) + input_data(i)
+
+  val nextSum = Wire(Vec(elementPerVector, UInt(elementWidth.W)))
+  for (i <- 0 until elementPerVector) {
+    nextSum(i) := Mux(counter.io.value === 0.U, input_data(i), regs(i) + input_data(i))
   }
 
-  when(ext_data_i.fire) {
-    when(counter.io.value === (ext_csr_i(0) - 1.U(8.W))) {
-      // Reset the registers when the counter reaches the end
-      for (i <- 0 until extensionParam.dataWidth / elementWidth) {
-        regs(i) := 0.U
-      }
-    } otherwise {
-      // Add the input data to the corresponding register
-      for (i <- 0 until extensionParam.dataWidth / elementWidth) {
-        regs(i) := regs(i) + input_data(i)
-      }
-    }
+  val lastInput  = counter.io.value === (operandCount - 1.U)
+  val outputFire = ext_data_o.fire
+  val inputFire  = ext_data_i.fire
+
+  when(ext_start_i) {
+    regs        := VecInit(Seq.fill(elementPerVector)(0.U(elementWidth.W)))
+    outputValid := false.B
+  } .elsewhen(inputFire) {
+    regs        := nextSum
+    outputValid := lastInput
+  } .elsewhen(outputFire) {
+    regs        := VecInit(Seq.fill(elementPerVector)(0.U(elementWidth.W)))
+    outputValid := false.B
   }
 
-  ext_data_o.bits  := Cat(ext_data_o_bits.reverse)
-  ext_data_o.valid := (counter.io.value === (ext_csr_i(0) - 1.U)(7, 0)) & ext_data_i.fire
-  ext_data_i.ready := ext_data_o.ready
+  ext_data_o.bits  := Cat(regs.reverse)
+  ext_data_o.valid := outputValid
+  ext_data_i.ready := !outputValid || ext_data_o.ready
+  ext_busy_o       := (counter.io.value =/= 0.U) || outputValid
 }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAdd.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAdd.scala
@@ -42,12 +42,12 @@ class ElementwiseAdd(
   })
 
   val operandCount = ext_csr_i(0)(7, 0)
-  counter.io.ceil := operandCount
+  counter.io.ceil  := operandCount
   counter.io.reset := ext_start_i
   counter.io.tick  := ext_data_i.fire
 
   // The register holds the partial sum and then the completed output.
-  val regs = RegInit(
+  val regs        = RegInit(
     VecInit(
       Seq.fill(elementPerVector)(0.U(elementWidth.W))
     )
@@ -70,10 +70,10 @@ class ElementwiseAdd(
   when(ext_start_i) {
     regs        := VecInit(Seq.fill(elementPerVector)(0.U(elementWidth.W)))
     outputValid := false.B
-  } .elsewhen(inputFire) {
+  }.elsewhen(inputFire) {
     regs        := nextSum
     outputValid := lastInput
-  } .elsewhen(outputFire) {
+  }.elsewhen(outputFire) {
     regs        := VecInit(Seq.fill(elementPerVector)(0.U(elementWidth.W)))
     outputValid := false.B
   }

--- a/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAdd.scala
+++ b/hw/chisel/src/main/scala/snax/DataPathExtension/ElementwiseAdd.scala
@@ -41,7 +41,8 @@ class ElementwiseAdd(
     override val desiredName = "ElementwiseAddCounter"
   })
 
-  val operandCount = ext_csr_i(0)(7, 0)
+  val csrOperandCount = ext_csr_i(0)(7, 0)
+  val operandCount    = Mux(csrOperandCount === 0.U, 1.U(8.W), csrOperandCount)
   counter.io.ceil  := operandCount
   counter.io.reset := ext_start_i
   counter.io.tick  := ext_data_i.fire

--- a/hw/chisel/src/main/scala/snax/xdma/xdmaTop/XDMATop.scala
+++ b/hw/chisel/src/main/scala/snax/xdma/xdmaTop/XDMATop.scala
@@ -252,51 +252,62 @@ object XDMATopGen extends App {
 
   val toolbox = currentMirror.mkToolBox()
 
-  // Writer Side
-  val writerDatapathExtensionParam = (parsedXdmaCfg \ "writer_extensions").as[JsObject] match {
-    case obj: JsObject =>
-      obj.fields.filter { case (k, _) =>
-        k.startsWith("Has")
-      }.toSeq.map { case (k, v) =>
-        (k, v.as[Map[String, Seq[Int]]].values)
-      }
-    case _ => Seq.empty
-  }
+  def renderDatapathExtensionArgs(extensionName: String, args: JsValue): String =
+    args match {
+      case obj: JsObject =>
+        obj.fields.map { case (paramName, paramValue) =>
+          val renderedParam = paramValue.validate[Int] match {
+            case JsSuccess(intValue, _) => intValue.toString
+            case JsError(_)             =>
+              paramValue.validate[Seq[Int]] match {
+                case JsSuccess(seqValue, _) => s"Seq(${seqValue.mkString(",")})"
+                case JsError(_)             =>
+                  throw new IllegalArgumentException(
+                    s"Invalid XDMA datapath extension parameter $extensionName.$paramName: expected Int or Seq[Int]"
+                  )
+              }
+          }
+          s"$paramName = $renderedParam"
+        }
+          .mkString(", ")
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Invalid XDMA datapath extension parameters for $extensionName: expected an object"
+        )
+    }
 
-  writerDatapathExtensionParam
-    .foreach(i => {
-      writerExtensionParam = writerExtensionParam :+ toolbox
-        .compile(toolbox.parse(s"""
+  def datapathExtensionParams(extensionSide: String): Seq[(String, String)] =
+    (parsedXdmaCfg \ extensionSide).as[JsObject] match {
+      case obj: JsObject =>
+        obj.fields.filter { case (k, _) =>
+          k.startsWith("Has")
+        }.toSeq.map { case (k, v) =>
+          (k, renderDatapathExtensionArgs(k, v))
+        }
+      case _ => Seq.empty
+    }
+
+  def instantiateDatapathExtension(extensionName: String, extensionArgs: String): HasDataPathExtension =
+    toolbox
+      .compile(toolbox.parse(s"""
 import snax.DataPathExtension._
-return new ${i._1}(${i._2
-            .map(list => s"Seq(${list.mkString(",")})")
-            .mkString(", ")})
+return new $extensionName($extensionArgs)
       """))()
-        .asInstanceOf[HasDataPathExtension]
-    })
+      .asInstanceOf[HasDataPathExtension]
+
+  // Writer Side
+  val writerDatapathExtensionParam = datapathExtensionParams("writer_extensions")
+
+  writerDatapathExtensionParam.foreach { case (extensionName, extensionArgs) =>
+    writerExtensionParam = writerExtensionParam :+ instantiateDatapathExtension(extensionName, extensionArgs)
+  }
 
   // Reader Side
-  val readerDatapathExtensionParam = (parsedXdmaCfg \ "reader_extensions").as[JsObject] match {
-    case obj: JsObject =>
-      obj.fields.filter { case (k, _) =>
-        k.startsWith("Has")
-      }.toSeq.map { case (k, v) =>
-        (k, v.as[Map[String, Seq[Int]]].values)
-      }
-    case _ => Seq.empty
-  }
+  val readerDatapathExtensionParam = datapathExtensionParams("reader_extensions")
 
-  readerDatapathExtensionParam
-    .foreach(i => {
-      readerExtensionParam = readerExtensionParam :+ toolbox
-        .compile(toolbox.parse(s"""
-import snax.DataPathExtension._
-return new ${i._1}(${i._2
-            .map(list => s"Seq(${list.mkString(",")})")
-            .mkString(", ")})
-      """))()
-        .asInstanceOf[HasDataPathExtension]
-    })
+  readerDatapathExtensionParam.foreach { case (extensionName, extensionArgs) =>
+    readerExtensionParam = readerExtensionParam :+ instantiateDatapathExtension(extensionName, extensionArgs)
+  }
 
   // Generation of the hardware
   var sv_string = getVerilogString(

--- a/hw/chisel/src/test/scala/snax/DataPathExtension/ElementwiseAddTester.scala
+++ b/hw/chisel/src/test/scala/snax/DataPathExtension/ElementwiseAddTester.scala
@@ -1,82 +1,57 @@
 package snax.DataPathExtension
+
 import scala.util.Random
 
 import chiseltest._
-import snax.DataPathExtension.HasElementwiseAdd
 
-class ElementwiseAdd2Tester extends DataPathExtensionTester(TreadleBackendAnnotation) {
+abstract class ElementWiseAddTester(numOperandPerAdd: Int, numOperand: Int, seed: Int = 0, debugMode: Boolean = false)
+    extends DataPathExtensionTester(TreadleBackendAnnotation, debugMode) {
 
-  def hasExtension = new HasElementwiseAdd(elementWidth = 32, dataWidth = 512)
+  private def elementWidth     = 32
+  private def dataWidth        = 512
+  private def elementPerVector = dataWidth / elementWidth
 
-  val amount_of_vectors = 2
-  val csr_vec           = Seq(amount_of_vectors)
+  require(numOperandPerAdd > 0, "Number of operands per addition must be greater than 0")
+  require(numOperand % elementPerVector == 0, "Total number of operands must be a multiple of one data vector")
+  require(
+    numOperand       % (numOperandPerAdd * elementPerVector) == 0,
+    "Total number of operands must be a multiple of operands per addition"
+  )
 
-  val inputData  = collection.mutable.Buffer[BigInt]()
-  val outputData = collection.mutable.Buffer[BigInt]()
+  def hasExtension = new HasElementwiseAdd(elementWidth = elementWidth, dataWidth = dataWidth)
 
-  for (_ <- 0 until 128) {
-    val inputMatrix1: Array[Array[Int]] = Array.fill(8, 4)(Random.nextInt(Int.MaxValue))
-    val inputMatrix2: Array[Array[Int]] = Array.fill(8, 4)(Random.nextInt(Int.MaxValue))
-    val leftInputMatrix1  = inputMatrix1.map(row => row.slice(0, 2))
-    val rightInputMatrix1 = inputMatrix1.map(row => row.slice(2, 4))
-    val leftInputMatrix2  = inputMatrix2.map(row => row.slice(0, 2))
-    val rightInputMatrix2 = inputMatrix2.map(row => row.slice(2, 4))
-    inputData.append(BigInt(leftInputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(leftInputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(rightInputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(rightInputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+  val csr_vec = Seq(numOperandPerAdd)
 
-    val leftOutputMatrix  =
-      leftInputMatrix1.zip(leftInputMatrix2).map { case (a, b) => a.zip(b).map { case (x, y) => x + y } }
-    val rightOutputMatrix =
-      rightInputMatrix1.zip(rightInputMatrix2).map { case (a, b) => a.zip(b).map { case (x, y) => x + y } }
-    outputData.append(BigInt(leftOutputMatrix.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    outputData.append(BigInt(rightOutputMatrix.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
+  private val random = new Random(seed)
+
+  private val inputData: Array[Array[Int]] =
+    Array.fill(numOperand / elementPerVector, elementPerVector)(random.nextInt())
+
+  private val outputData: Array[Array[Int]] =
+    inputData
+      .grouped(numOperandPerAdd)
+      .map { group =>
+        group.reduce { (left, right) =>
+          left.zip(right).map { case (x, y) => x + y }
+        }
+      }
+      .toArray
+
+  private def packVector(data: Array[Int]): BigInt = {
+    require(data.length == elementPerVector, s"Expected $elementPerVector elements per data vector")
+
+    data.zipWithIndex.foldLeft(BigInt(0)) { case (packed, (value, laneIdx)) =>
+      packed | (BigInt(value.toLong & 0xffffffffL) << (laneIdx * elementWidth))
+    }
   }
 
-  val input_data_vec = inputData.toSeq
+  val input_data_vec = inputData.map(packVector).toSeq
 
-  val output_data_vec = outputData.toSeq
+  val output_data_vec = outputData.map(packVector).toSeq
 }
 
-class ElementwiseAdd3Tester extends DataPathExtensionTester(TreadleBackendAnnotation) {
+class ElementwiseAdd1Tester extends ElementWiseAddTester(numOperandPerAdd = 1, numOperand = 1 * 16 * 256, seed = 1, debugMode = true)
 
-  def hasExtension = new HasElementwiseAdd(elementWidth = 32, dataWidth = 512)
+class ElementwiseAdd2Tester extends ElementWiseAddTester(numOperandPerAdd = 2, numOperand = 2 * 16 * 256, seed = 2, debugMode = true)
 
-  val amount_of_vectors = 3
-  val csr_vec           = Seq(amount_of_vectors)
-
-  val inputData  = collection.mutable.Buffer[BigInt]()
-  val outputData = collection.mutable.Buffer[BigInt]()
-
-  for (_ <- 0 until 128) {
-    val inputMatrix1: Array[Array[Int]] = Array.fill(8, 4)(Random.nextInt(1 << 30))
-    val inputMatrix2: Array[Array[Int]] = Array.fill(8, 4)(Random.nextInt(1 << 30))
-    val inputMatrix3: Array[Array[Int]] = Array.fill(8, 4)(Random.nextInt(1 << 30))
-    val leftInputMatrix1  = inputMatrix1.map(row => row.slice(0, 2))
-    val rightInputMatrix1 = inputMatrix1.map(row => row.slice(2, 4))
-    val leftInputMatrix2  = inputMatrix2.map(row => row.slice(0, 2))
-    val rightInputMatrix2 = inputMatrix2.map(row => row.slice(2, 4))
-    val leftInputMatrix3  = inputMatrix3.map(row => row.slice(0, 2))
-    val rightInputMatrix3 = inputMatrix3.map(row => row.slice(2, 4))
-    inputData.append(BigInt(leftInputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(leftInputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(leftInputMatrix3.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(rightInputMatrix1.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(rightInputMatrix2.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    inputData.append(BigInt(rightInputMatrix3.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-
-    val leftOutputMatrix  = leftInputMatrix1.zip(leftInputMatrix2.zip(leftInputMatrix3)).map { case (a, (b, c)) =>
-      a.zip(b.zip(c)).map { case (x, (y, z)) => x + y + z }
-    }
-    val rightOutputMatrix = rightInputMatrix1.zip(rightInputMatrix2.zip(rightInputMatrix3)).map { case (a, (b, c)) =>
-      a.zip(b.zip(c)).map { case (x, (y, z)) => x + y + z }
-    }
-    outputData.append(BigInt(leftOutputMatrix.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-    outputData.append(BigInt(rightOutputMatrix.flatten.map { i => f"$i%08X" }.reverse.reduce(_ + _), 16))
-  }
-
-  val input_data_vec = inputData.toSeq
-
-  val output_data_vec = outputData.toSeq
-}
+class ElementwiseAdd3Tester extends ElementWiseAddTester(numOperandPerAdd = 3, numOperand = 3 * 16 * 256, seed = 3, debugMode = true)

--- a/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_KUL_cluster.hjson
@@ -174,6 +174,7 @@ Naming convention:
             }
             reader_extensions: {
                 HasTransposer: {row:[8,8], col:[8,8], elementWidth:[8,16]}
+                HasElementwiseAdd: {elementWidth: 32, dataWidth: 512}
             }
         }
         // Xdiv_sqrt: true,

--- a/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson
+++ b/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson
@@ -263,6 +263,7 @@ Naming convention:
             reader_extensions: 
             {
                 HasTransposer: {row:[8,8], col:[8,8], elementWidth:[8,16]}
+                HasElementwiseAdd: {elementWidth: 32, dataWidth: 512}
             }
         }
         xdma: true

--- a/target/snitch_cluster/sw/apps/Makefile
+++ b/target/snitch_cluster/sw/apps/Makefile
@@ -35,6 +35,7 @@ ifeq ($(CFG_OVERRIDE), cfg/snax_KUL_cluster.hjson)
 SUBDIRS += snax-xdma-memset
 SUBDIRS += snax-xdma-reshape-comparison
 SUBDIRS += snax-xdma-transpose
+SUBDIRS += snax-xdma-elementwise-add
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_compiler_test_cluster.hjson)
 SUBDIRS += snax-xdma-memset
@@ -50,9 +51,9 @@ ifeq ($(CFG_OVERRIDE), cfg/snax_versacore_to_cluster.hjson)
 SUBDIRS += snax-versacore-to-matmul
 SUBDIRS += snax-versacore-to-matmul-profile
 SUBDIRS += snax-xdma-memset
-SUBDIRS += snax-xdma-maxpool
 SUBDIRS += snax-xdma-transpose
 SUBDIRS += snax-xdma-reshape-comparison
+SUBDIRS += snax-xdma-elementwise-add
 endif
 ifeq ($(CFG_OVERRIDE), cfg/snax_versacore_dse_cluster.hjson)
 SUBDIRS += snax-versacore-dse-matmul-profile

--- a/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/data/datagen.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Jonas Crols <jonas.crols@student.kuleuven.be>
+# Yunhao Deng <yunhao.deng@kuleuven.be>
 
 import argparse
 import os
@@ -18,10 +18,18 @@ import numpy as np
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../../../util/sim/"))
 from data_utils import format_scalar_definition, format_vector_definition  # noqa E402
 
-np.random.seed(320)
+
+ELEMENT_WIDTH = 32
+ELEMENT_BYTES = ELEMENT_WIDTH // 8
+XDMA_WIDTH_BYTES = 64
+ELEMENTS_PER_XDMA_BEAT = XDMA_WIDTH_BYTES // ELEMENT_BYTES
+RNG_SEED = 320
 
 
-# Add stdint.h header
+def round_up(value, multiple):
+    return ((value + multiple - 1) // multiple) * multiple
+
+
 def emit_header_file(**kwargs):
     emit_str = ["#include <stdint.h>"]
     emit_str += emit_elementwise_add_data(**kwargs)
@@ -29,97 +37,97 @@ def emit_header_file(**kwargs):
 
 
 def emit_elementwise_add_data(**kwargs):
-    tile_width = None
-    element_width = kwargs["BIT_WIDTH"]
-    if element_width == 8 or element_width == 16 or element_width == 32:
-        tile_width = 8
-    else:
+    element_width = int(kwargs["BIT_WIDTH"])
+    if element_width != ELEMENT_WIDTH:
         raise ValueError(
-            f"Invalid BIT_WIDTH: {element_width}, only 8, 16 and 32  are supported"
+            f"Invalid BIT_WIDTH: {element_width}, only {ELEMENT_WIDTH} is supported"
         )
-    data_type = None
-    if element_width == 8:
-        data_type = "uint8_t"
-    elif element_width == 16:
-        data_type = "uint16_t"
-    elif element_width == 32:
-        data_type = "uint32_t"
-    else:
-        raise ValueError(
-            f"Invalid BIT_WIDTH: {element_width}, only 8, 16 and 32 are supported"
-        )
+
+    rows = int(kwargs["M"])
+    cols = int(kwargs["N"])
+    if rows <= 0 or cols <= 0:
+        raise ValueError(f"M and N must be positive, got M={rows}, N={cols}")
+
+    padded_cols = round_up(cols, ELEMENTS_PER_XDMA_BEAT)
+    matrix_shape = (rows, padded_cols)
+    matrix_elements = rows * padded_cols
+    input_bytes = matrix_elements * ELEMENT_BYTES
+    input_bytes_aligned = round_up(input_bytes, XDMA_WIDTH_BYTES)
+    output_bytes = input_bytes
+    tile_count = matrix_elements // ELEMENTS_PER_XDMA_BEAT
+
+    rng = np.random.default_rng(RNG_SEED)
+    int32_info = np.iinfo(np.int32)
+
+    matrix1_data = np.zeros(matrix_shape, dtype=np.int32)
+    matrix2_data = np.zeros(matrix_shape, dtype=np.int32)
+    matrix1_data[:, :cols] = rng.integers(
+        low=int32_info.min,
+        high=int32_info.max,
+        size=(rows, cols),
+        dtype=np.int32,
+    )
+    matrix2_data[:, :cols] = rng.integers(
+        low=int32_info.min,
+        high=int32_info.max,
+        size=(rows, cols),
+        dtype=np.int32,
+    )
+
+    golden_output = (
+        matrix1_data.view(np.uint32) + matrix2_data.view(np.uint32)
+    ).view(np.int32)
+
+    spatial_stride_src = 8
+    spatial_stride_dst = 8
+    temporal_bounds_src = [2, tile_count]
+    temporal_strides_src = [input_bytes_aligned, XDMA_WIDTH_BYTES]
+    temporal_bounds_dst = [tile_count]
+    temporal_strides_dst = [XDMA_WIDTH_BYTES]
 
     emit_str = []
-    padded_M = None
-    padded_N = None
-    padded_M = (kwargs["M"] + tile_width - 1) // tile_width * tile_width
-    padded_N = (kwargs["N"] + tile_width - 1) // tile_width * tile_width
-
-    # First input matrix for elementwise add
-    matrix1_data = np.zeros((padded_M, padded_N), dtype=np.uint32)
-    matrix1_data[: kwargs["M"], : kwargs["N"]] = np.random.randint(
-        low=0, high=1 << element_width, size=(kwargs["M"], kwargs["N"]), dtype=np.uint32
-    )
-    input_matrix1 = matrix1_data
-    input_matrix1 = input_matrix1.ravel()
-
-    # Emit input matrix
+    emit_str += [format_scalar_definition("uint32_t", "matrix_m", rows)]
+    emit_str += [format_scalar_definition("uint32_t", "matrix_n", cols)]
+    emit_str += [format_scalar_definition("uint32_t", "matrix_padded_n", padded_cols)]
     emit_str += [
-        format_scalar_definition("uint32_t", "matrix1_size", matrix1_data.size)
+        format_scalar_definition("uint32_t", "matrix_elements", matrix_elements)
     ]
-    emit_str += [format_vector_definition(data_type, "input_matrix1", input_matrix1)]
-
-    # Second input matrix for elementwise add
-    matrix2_data = np.zeros((padded_M, padded_N), dtype=np.uint32)
-    matrix2_data[: kwargs["M"], : kwargs["N"]] = np.random.randint(
-        low=0, high=1 << element_width, size=(kwargs["M"], kwargs["N"]), dtype=np.uint32
-    )
-    input_matrix2 = matrix2_data
-    input_matrix2 = input_matrix2.ravel()
-
-    # Emit input matrix
+    emit_str += [format_scalar_definition("uint32_t", "input_bytes", input_bytes)]
     emit_str += [
-        format_scalar_definition("uint32_t", "matrix2_size", matrix2_data.size)
+        format_scalar_definition("uint32_t", "input_bytes_aligned", input_bytes_aligned)
     ]
-    emit_str += [format_vector_definition(data_type, "input_matrix2", input_matrix2)]
-
-    # Emit output matrix
-    output_matrix = matrix1_data + matrix2_data
-
-    output_matrix = output_matrix.ravel()
+    emit_str += [format_scalar_definition("uint32_t", "output_bytes", output_bytes)]
+    emit_str += [format_scalar_definition("uint32_t", "tile_count", tile_count)]
     emit_str += [
-        format_vector_definition(data_type, "golden_output_matrix", output_matrix)
+        format_vector_definition(
+            "int32_t",
+            "input_matrix1",
+            matrix1_data.ravel(),
+            alignment=XDMA_WIDTH_BYTES,
+            hex_bits=ELEMENT_WIDTH,
+            cast_hex=True,
+        )
     ]
-
-    # Emit the configuration for XDMA
-    spatial_stride_src = None
-    spatial_stride_dst = None
-    temporal_strides_src = []
-    temporal_strides_dst = []
-    temporal_bounds_src = []
-    temporal_bounds_dst = []
-
-    # Input Side (Reader)
-    spatial_stride_src = 8
-    temporal_bounds_src = [
-        2,
-        input_matrix1.shape[0] // (512 // element_width),
+    emit_str += [
+        format_vector_definition(
+            "int32_t",
+            "input_matrix2",
+            matrix2_data.ravel(),
+            alignment=XDMA_WIDTH_BYTES,
+            hex_bits=ELEMENT_WIDTH,
+            cast_hex=True,
+        )
     ]
-    temporal_strides_src = [
-        input_matrix1.shape[0] * (element_width // 8),
-        64,
+    emit_str += [
+        format_vector_definition(
+            "int32_t",
+            "golden_output_matrix",
+            golden_output.ravel(),
+            alignment=XDMA_WIDTH_BYTES,
+            hex_bits=ELEMENT_WIDTH,
+            cast_hex=True,
+        )
     ]
-
-    # Output Side (Writer)
-
-    spatial_stride_dst = 8
-    temporal_bounds_dst = [
-        input_matrix1.shape[0] // (512 // element_width),
-    ]
-    temporal_strides_dst = [
-        64,
-    ]
-
     emit_str += [
         format_scalar_definition("uint32_t", "spatial_stride_src", spatial_stride_src)
     ]
@@ -157,7 +165,6 @@ def emit_elementwise_add_data(**kwargs):
 
 
 def main():
-    # Parsing cmd args
     parser = argparse.ArgumentParser(description="Generating data for kernels")
     parser.add_argument(
         "-c",
@@ -168,11 +175,9 @@ def main():
     )
     args = parser.parse_args()
 
-    # Load param config file
     with args.cfg.open() as f:
         param = hjson.loads(f.read())
 
-    # Emit header file
     print(emit_header_file(**param))
 
 

--- a/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/data/datagen.py
+++ b/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/data/datagen.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 #
+# Jonas Crols <jonas.crols@student.kuleuven.be>
 # Yunhao Deng <yunhao.deng@kuleuven.be>
 
 import argparse

--- a/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
@@ -9,7 +9,8 @@
 #include "snrt.h"
 
 #ifndef READER_EXT_ELEMENTWISEADDBIT32
-#error "READER_EXT_ELEMENTWISEADDBIT32 is missing. Regenerate the XDMA CSR map with HasElementwiseAdd enabled."
+#error \
+    "READER_EXT_ELEMENTWISEADDBIT32 is missing. Regenerate the XDMA CSR map with HasElementwiseAdd enabled."
 #endif
 
 static uint32_t align_up(uint32_t value, uint32_t alignment) {
@@ -20,9 +21,9 @@ int main() {
     int err = 0;
     uint32_t tcdm_baseaddress = snrt_cluster_base_addrl();
     uint32_t tcdm_input_stride = align_up(input_bytes, XDMA_WIDTH);
-    uint8_t *tcdm_in1 = (uint8_t *)tcdm_baseaddress;
-    uint8_t *tcdm_in2 = tcdm_in1 + tcdm_input_stride;
-    uint8_t *tcdm_out = tcdm_in2 + tcdm_input_stride;
+    uint8_t* tcdm_in1 = (uint8_t*)tcdm_baseaddress;
+    uint8_t* tcdm_in2 = tcdm_in1 + tcdm_input_stride;
+    uint8_t* tcdm_out = tcdm_in2 + tcdm_input_stride;
 
     if (snrt_is_dm_core()) {
         printf(
@@ -47,17 +48,18 @@ int main() {
         uint32_t ext_param[1] = {2};
         if (snax_xdma_enable_src_ext(READER_EXT_ELEMENTWISEADDBIT32,
                                      ext_param) != 0) {
-            printf("[ElementwiseAdd] Failed to enable reader elementwise add\n");
+            printf(
+                "[ElementwiseAdd] Failed to enable reader elementwise add\n");
             err++;
         }
 
         if (err == 0 &&
-            snax_xdma_memcpy_nd(
-                tcdm_in1, tcdm_out, spatial_stride_src, spatial_stride_dst,
-                temporal_dimension_src, temporal_strides_src,
-                temporal_bounds_src, temporal_dimension_dst,
-                temporal_strides_dst, temporal_bounds_dst, 0xFFFFFFFF,
-                0xFFFFFFFF, 0xFFFFFFFF) != 0) {
+            snax_xdma_memcpy_nd(tcdm_in1, tcdm_out, spatial_stride_src,
+                                spatial_stride_dst, temporal_dimension_src,
+                                temporal_strides_src, temporal_bounds_src,
+                                temporal_dimension_dst, temporal_strides_dst,
+                                temporal_bounds_dst, 0xFFFFFFFF, 0xFFFFFFFF,
+                                0xFFFFFFFF) != 0) {
             printf("[ElementwiseAdd] Failed to configure XDMA memcpy\n");
             err++;
         }
@@ -68,9 +70,9 @@ int main() {
             printf("[ElementwiseAdd] xdma task %d finished in %d cycles\n",
                    task_id, snax_xdma_last_task_cycle());
 
-            uint32_t *tcdm_result = (uint32_t *)tcdm_out;
-            const uint32_t *golden_result =
-                (const uint32_t *)golden_output_matrix;
+            uint32_t* tcdm_result = (uint32_t*)tcdm_out;
+            const uint32_t* golden_result =
+                (const uint32_t*)golden_output_matrix;
             uint32_t mismatch_count = 0;
 
             for (uint32_t i = 0; i < matrix_elements; i++) {

--- a/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
@@ -2,108 +2,101 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Jonas Crols <jonas.crols@student.kuleuven.be>
+// Yunhao Deng <yunhao.deng@kuleuven.be>
 
 #include "data.h"
 #include "snax-xdma-lib.h"
 #include "snrt.h"
 
+#ifndef READER_EXT_ELEMENTWISEADDBIT32
+#error "READER_EXT_ELEMENTWISEADDBIT32 is missing. Regenerate the XDMA CSR map with HasElementwiseAdd enabled."
+#endif
+
+static uint32_t align_up(uint32_t value, uint32_t alignment) {
+    return ((value + alignment - 1) / alignment) * alignment;
+}
+
 int main() {
-    // Set err value for checking
     int err = 0;
-    // Obtain the start address of the TCDM memory
-    uint32_t dma_load_input_start;
-    uint32_t dma_load_input_end;
     uint32_t tcdm_baseaddress = snrt_cluster_base_addrl();
-    // Put the first input at the starting of tcdm
-    void *tcdm_in1 = (void *)tcdm_baseaddress;
-    // Put the second input at the end of tcdm
-    void *tcdm_in2 =
-        (void *)(tcdm_baseaddress +
-                 (matrix1_size * sizeof(input_matrix1[0]) * 8 + 7) / 8);
-
-    // Put the output at the middle of tcdm
-    void *tcdm_out =
-        (void *)(tcdm_baseaddress +
-                 (matrix1_size * sizeof(input_matrix1[0]) * 8 + 7) / 8 +
-                 (matrix2_size * sizeof(input_matrix2[0]) * 8 + 7) / 8);
-
-    printf("tcdm_out: %p\n", tcdm_out);
+    uint32_t tcdm_input_stride = align_up(input_bytes, XDMA_WIDTH);
+    uint8_t *tcdm_in1 = (uint8_t *)tcdm_baseaddress;
+    uint8_t *tcdm_in2 = tcdm_in1 + tcdm_input_stride;
+    uint8_t *tcdm_out = tcdm_in2 + tcdm_input_stride;
 
     if (snrt_is_dm_core()) {
-        // First we need to transfer the input data from L3->TCDM
-        snrt_dma_start_1d(tcdm_in1, input_matrix1,
-                          matrix1_size * sizeof(input_matrix1[0]));
+        printf(
+            "[ElementwiseAdd] M=%u, N=%u, padded_N=%u, elements=%u, "
+            "tiles=%u\n",
+            matrix_m, matrix_n, matrix_padded_n, matrix_elements, tile_count);
+
+        if (tcdm_input_stride != input_bytes_aligned) {
+            printf(
+                "[ElementwiseAdd] Generated input stride %u does not match "
+                "runtime aligned stride %u\n",
+                input_bytes_aligned, tcdm_input_stride);
+            err++;
+        }
+
+        snrt_dma_start_1d(tcdm_in1, input_matrix1, input_bytes);
         snrt_dma_wait_all();
 
-        snrt_dma_start_1d(tcdm_in2, input_matrix2,
-                          matrix2_size * sizeof(input_matrix2[0]));
+        snrt_dma_start_1d(tcdm_in2, input_matrix2, input_bytes);
         snrt_dma_wait_all();
 
-        // --------------------- Configure the Ext --------------------- //
-        uint32_t xdma_csr_amount_of_tensors = 2;
-        uint32_t ext_param[1] = {xdma_csr_amount_of_tensors};
-        if (snax_xdma_disable_src_ext(0) != 0) {
-            printf("Error in disabling reader xdma extension 0\n");
+        uint32_t ext_param[1] = {2};
+        if (snax_xdma_enable_src_ext(READER_EXT_ELEMENTWISEADDBIT32,
+                                     ext_param) != 0) {
+            printf("[ElementwiseAdd] Failed to enable reader elementwise add\n");
             err++;
         }
 
-        if (snax_xdma_enable_src_ext(1, ext_param) != 0) {
-            printf("Error in enabling reader xdma extension 1\n");
+        if (err == 0 &&
+            snax_xdma_memcpy_nd(
+                tcdm_in1, tcdm_out, spatial_stride_src, spatial_stride_dst,
+                temporal_dimension_src, temporal_strides_src,
+                temporal_bounds_src, temporal_dimension_dst,
+                temporal_strides_dst, temporal_bounds_dst, 0xFFFFFFFF,
+                0xFFFFFFFF, 0xFFFFFFFF) != 0) {
+            printf("[ElementwiseAdd] Failed to configure XDMA memcpy\n");
             err++;
         }
 
-        if (snax_xdma_disable_src_ext(2) != 0) {
-            printf("Error in disabling reader xdma extension 2\n");
-            err++;
-        }
+        if (err == 0) {
+            int task_id = snax_xdma_start();
+            snax_xdma_local_wait(task_id);
+            printf("[ElementwiseAdd] xdma task %d finished in %d cycles\n",
+                   task_id, snax_xdma_last_task_cycle());
 
-        if (snax_xdma_disable_src_ext(3) != 0) {
-            printf("Error in disabling reader xdma extension 3\n");
-            err++;
-        }
+            uint32_t *tcdm_result = (uint32_t *)tcdm_out;
+            const uint32_t *golden_result =
+                (const uint32_t *)golden_output_matrix;
+            uint32_t mismatch_count = 0;
 
-        if (snax_xdma_disable_src_ext(4) != 0) {
-            printf("Error in disabling reader xdma extension 4\n");
-            err++;
-        }
+            for (uint32_t i = 0; i < matrix_elements; i++) {
+                if (tcdm_result[i] != golden_result[i]) {
+                    if (mismatch_count < 8) {
+                        printf(
+                            "[ElementwiseAdd] Mismatch at element %u "
+                            "(byte %u): got 0x%08x expected 0x%08x\n",
+                            i, i * (uint32_t)sizeof(uint32_t), tcdm_result[i],
+                            golden_result[i]);
+                    }
+                    mismatch_count++;
+                }
+            }
 
-        if (snax_xdma_disable_dst_ext(0) != 0) {
-            printf("Error in disabling writer xdma extension 0\n");
-            err++;
-        }
-
-        if (snax_xdma_disable_dst_ext(1) != 0) {
-            printf("Error in disabling writer xdma extension 1\n");
-            err++;
-        }
-
-        // --------------------- Configure the AGU --------------------- //
-        snax_xdma_memcpy_nd(
-            tcdm_in1, tcdm_out, spatial_stride_src, spatial_stride_dst,
-            temporal_dimension_src, temporal_strides_src, temporal_bounds_src,
-            temporal_dimension_dst, temporal_strides_dst, temporal_bounds_dst,
-            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF);
-        printf("snax_xdma_memcpy_nd done\n");
-        int task_id = snax_xdma_start();
-        printf("got out of snax_xdma_start, csr address: %d\n", task_id);
-        snax_xdma_local_wait(task_id);
-        printf("xdma task %d is done in %d cycles\n", task_id,
-               snax_xdma_last_task_cycle());
-
-        // --------------------- Checking the Results --------------------- //
-        uint16_t *golden_result = (uint16_t *)golden_output_matrix;
-        uint16_t *tcdm_result = (uint16_t *)tcdm_out;
-        uint16_t *tcdm_src1 = (uint16_t *)tcdm_in1;
-        uint16_t *tcdm_src2 = (uint16_t *)tcdm_in2;
-
-        for (int i = 0; i < matrix1_size * sizeof(input_matrix1[0]) / 2; i++) {
-            if (tcdm_result[i] != golden_result[i]) {
-                printf("The sum is incorrect at byte %d! \n", i << 2);
+            if (mismatch_count == 0) {
+                printf("[ElementwiseAdd] All values are correct\n");
+            } else {
+                printf("[ElementwiseAdd] Failed with %u mismatches\n",
+                       mismatch_count);
+                err++;
             }
         }
-        printf("Checking is done. All values are right\n");
+
+        snax_xdma_disable_src_ext(READER_EXT_ELEMENTWISEADDBIT32);
     }
 
-    return 0;
+    return err != 0;
 }

--- a/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
+++ b/target/snitch_cluster/sw/apps/snax-xdma-elementwise-add/src/snax-xdma-elementwise-add.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
+// Jonas Crols <jonas.crols@student.kuleuven.be>
 // Yunhao Deng <yunhao.deng@kuleuven.be>
 
 #include "data.h"

--- a/target/snitch_cluster/sw/snax-xdma-run.yaml
+++ b/target/snitch_cluster/sw/snax-xdma-run.yaml
@@ -9,3 +9,4 @@ runs:
   - elf: apps/snax-xdma-memset/build/snax-xdma-memset.elf
   - elf: apps/snax-xdma-reshape-comparison/build/snax-xdma-reshape-comparison.elf
   - elf: apps/snax-xdma-transpose/build/snax-xdma-transpose.elf
+  - elf: apps/snax-xdma-elementwise-add/build/snax-xdma-elementwise-add.elf

--- a/target/snitch_cluster/sw/snax/xdma/include/snax-xdma-addr.h
+++ b/target/snitch_cluster/sw/snax/xdma/include/snax-xdma-addr.h
@@ -26,11 +26,11 @@
 // The channel and strobe region of the reader of XDMA
 #define XDMA_SRC_ENABLED_CHAN_PTR XDMA_SRC_TEMP_STRIDE_PTR + XDMA_SRC_TEMP_DIM
 #define XDMA_SRC_ENABLE_PTR XDMA_SRC_ENABLED_CHAN_PTR + 1
-#define XDMA_SRC_EXT_NUM 1
+#define XDMA_SRC_EXT_NUM 2
 #define XDMA_SRC_EXT_CSR_PTR XDMA_SRC_ENABLE_PTR + 1
-#define XDMA_SRC_EXT_CSR_NUM 1
+#define XDMA_SRC_EXT_CSR_NUM 2
 #define XDMA_SRC_EXT_CUSTOM_CSR_NUM \
-    { 1 }
+    { 1, 1 }
 
 // The stride and bound region of the writer of XDMA
 #define XDMA_DST_TEMP_DIM 5
@@ -57,4 +57,5 @@
 
 // Extension Information
 #define READER_EXT_TRANSPOSERROW8_8COL8_8BIT8_16 0
+#define READER_EXT_ELEMENTWISEADDBIT32 1
 #define WRITER_EXT_VERILOGMEMSET 0


### PR DESCRIPTION
1. Rework ElementwiseAdder to at least store data once before sending to the next stage, which is better for the timing. 
2. Rework XDMA DatapathExtension Parser to make it being able to accept scalar params. 
3. Add this extension to KUL Cluster and versacore_to cluster
4. Reimplement the C tester so that the extension csr idx can be read from csr map header
5. Add C tester to CI