### PR TITLE
RTL fix: hold writer TCDM-request priority stable until grant

### DIFF
--- a/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/DataRequestor.scala
@@ -62,7 +62,18 @@ class DataRequestor(
   }
 
   if (dynamicPriority) {
-    io.out.tcdmReq.bits.priority := io.in.priority.get
+    // `io.in.priority` is the write-FIFO fill-level hint (queue.count > 2): it is combinational on the
+    // live count and can change while a TCDM request is already asserted and waiting for grant. The
+    // downstream TCDM `stream_xbar` enforces AXI payload stability
+    // (`valid && !ready |=> $stable(payload)`), and `priority` rides in the request `user` field, so a
+    // mid-request change trips `input_data_unstable`. Sample-and-hold the hint so the whole request
+    // payload is stable for the duration of each request.
+    val priorityHold = RegInit(false.B)
+    // Free to (re)load only when no request is in flight, or on the cycle the current one fires.
+    when(!io.out.tcdmReq.valid || io.out.tcdmReq.fire) {
+      priorityHold := io.in.priority.get
+    }
+    io.out.tcdmReq.bits.priority := priorityHold
   } else {
     io.out.tcdmReq.bits.priority := higherStaticPriority.B
   }

--- a/hw/chisel/src/main/scala/snax/readerWriter/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/Writer.scala
@@ -7,9 +7,7 @@ import snax.utils._
 
 class Writer(
   param:                ReaderWriterParam,
-  moduleNamePrefix:     String  = "unnamed_cluster",
-  dynamicPriority:      Boolean = true,
-  higherStaticPriority: Boolean = false
+  moduleNamePrefix:     String  = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
 
@@ -34,8 +32,8 @@ class Writer(
       numChannel           = param.tcdmParam.numChannel,
       isReader             = false,
       moduleNamePrefix     = s"${moduleNamePrefix}_Writer",
-      dynamicPriority      = dynamicPriority,
-      higherStaticPriority = higherStaticPriority
+      dynamicPriority      = param.dynamicPriority,
+      higherStaticPriority = param.higherStaticPriority
     )
   )
 

--- a/hw/chisel/src/main/scala/snax/readerWriter/Writer.scala
+++ b/hw/chisel/src/main/scala/snax/readerWriter/Writer.scala
@@ -6,8 +6,8 @@ import chisel3.util._
 import snax.utils._
 
 class Writer(
-  param:                ReaderWriterParam,
-  moduleNamePrefix:     String  = "unnamed_cluster"
+  param:            ReaderWriterParam,
+  moduleNamePrefix: String = "unnamed_cluster"
 ) extends Module
     with RequireAsyncReset {
 


### PR DESCRIPTION
The streamer's requestor forwarded the live write-FIFO fill-level hint (queue.count > threshold) combinationally onto the TCDM request priority bit when dynamicPriority is set to true. While a write request sits at a bank waiting for grant, the FIFO crosses the threshold and priority flips mid-request, violating the AXI (and other valid-ready handshake protocol) valid/ready payload-stability rule on the downstream stream_xbar (input_data_unstable).

This PR adds an additional priority hold register that only (re)loads when no request is in flight or on the cycle the current one fires, so the whole request payload stays stable across valid && !ready. Furthermore, this PR fixes a bug that writer streamer never pass the dynamic priority param to actual requestor / responser generator